### PR TITLE
Fix typo in replace function description

### DIFF
--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/StringFunctionsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/StringFunctionsTest.scala
@@ -78,7 +78,7 @@ replace($original, $search, $replacement)
 ###
 
 Replace all occurrences of `search` with `replacement`.
-All arguments are be expressions.
+All arguments are expressions.
 
 ###assertion=returns-one parameters=sub
 RETURN


### PR DESCRIPTION
There was a typo in the description for the String function "replace" - it looks like the word "be" was unnecessarily inserted at some point.

Let me know if this was supposed to say "must be" instead of "are" - I wasn't sure which wording was intended, so I went with the simpler option.