### PR TITLE
Generate correct links when creating the refcard

### DIFF
--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/RefcardTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/RefcardTest.scala
@@ -151,7 +151,7 @@ abstract class RefcardTest extends Assertions with DocumentationHelper with Grap
     writer.println("[options=\"header\"]")
     writer.println("|====")
     if (linkId != null) {
-      writer.println("| link:../" + linkId + ".html[" + title + "]")
+      writer.println("| link:{developer-manual-base-uri}/cypher/#" + linkId + "[" + title + "]")
     } else {
       writer.println("|" + title)
     }

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CollectionsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CollectionsTest.scala
@@ -27,7 +27,7 @@ class CollectionsTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("A KNOWS B")
   val title = "Lists"
   val css = "general c2-2 c3-2 c4-3 c5-2 c6-6"
-  override val linkId = "syntax-collections"
+  override val linkId = "syntax-lists"
 
   override def assert(name: String, result: InternalExecutionResult) {
     name match {

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MapsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MapsTest.scala
@@ -27,7 +27,7 @@ class MapsTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("A KNOWS B")
   val title = "Maps"
   val css = "general c2-2 c3-3 c4-4 c5-2 c6-4"
-  override val linkId = "syntax-collections"
+  override val linkId = "syntax-lists"
 
   override def assert(name: String, result: InternalExecutionResult) {
     name match {

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PathFunctionsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PathFunctionsTest.scala
@@ -27,7 +27,7 @@ class PathFunctionsTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT KNOWS A", "A:Person KNOWS B:Person", "B KNOWS C:Person", "C KNOWS ROOT")
   val title = "Path Functions"
   val css = "general c3-3 c4-2 c5-5 c6-5"
-  override val linkId = "query-functions-collection"
+  override val linkId = "query-functions-list"
 
   override def assert(name: String, result: InternalExecutionResult) {
     name match {

--- a/manual/refcard/pom.xml
+++ b/manual/refcard/pom.xml
@@ -23,7 +23,7 @@
     <docs.sources>${project.build.directory}/docs</docs.sources>
     <docs-plugin.skip>true</docs-plugin.skip>
     <doctools.version>13</doctools.version>
-    <refcard.version>${project.version}</refcard.version>
+    <refcard.version>3.0</refcard.version>
   </properties>
 
   <dependencies>

--- a/manual/refcard/src/cypher-refcard.asciidoc
+++ b/manual/refcard/src/cypher-refcard.asciidoc
@@ -1,6 +1,7 @@
 = Neo4j Cypher Refcard {neo4j-version}
 :sources: ../docs/neo4j-cypher-refcard-tests-docs-jar/dev/ql/refcard
-:docs-home: http://neo4j.com/docs
+:docs-home: https://neo4j.com/docs
+:developer-manual-base-uri: {docs-home}/developer-manual/{neo4j-version}
 
 *Cypher is the declarative query language for Neo4j, the world’s leading graph database.*
 


### PR DESCRIPTION
so we don't have to fix them downstream.

When forward merging to 3.1 and 3.2 there are some additional work to get the links right since we chunk Cypher much more there, and the URL paths are mapped differently to the IDs.