### PR TITLE
Remove pin count metric configuration note

### DIFF
--- a/manual/ha-docs/src/docs/ops/jmx.asciidoc
+++ b/manual/ha-docs/src/docs/ops/jmx.asciidoc
@@ -22,11 +22,6 @@ include::jmx-memory-mapping.asciidoc[]
 
 include::jmx-page-cache.asciidoc[]
 
-[NOTE]
-The page pin count metric is disabled by default for performance reasons, in which case the pin count value will always be zero.
-The page pin count metric can be enabled by adding this line to the `neo4j.conf` file:
-`dbms.jvm.additional=-Dorg.neo4j.io.pagecache.tracing.tracePinUnpin=true`
-
 include::jmx-primitive-count.asciidoc[]
 
 include::jmx-store-file-sizes.asciidoc[]


### PR DESCRIPTION
Remove additional configuration for page cache pin tracing since
now we always count page cache pins.