### PR TITLE
Editorial changes, mentioned new param syntax in a lightweight manner

### DIFF
--- a/manual/cypher/cypher-docs/src/docs/dev/syntax/parameters.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/syntax/parameters.asciidoc
@@ -3,19 +3,31 @@
 
 Cypher supports querying with parameters.
 This means developers don't have to resort to string building to create a query.
-In addition to that, it also makes caching of execution plans much easier for Cypher.
+Additionally, parameters make caching of execution plans much easier for Cypher, thus leading to faster query execution times.
 
-Parameters can be used for literals and expressions in the `WHERE` clause, for the index value in the `START` clause, index queries, and finally for node/relationship ids.
-Parameters can not be used as for property names, relationship types and labels, since these patterns are part of the query structure that is compiled into a query plan.
+Parameters can be used for:
 
-Accepted names for parameters are letters and numbers, and any combination of these.
+* literals and expressions
+* node and relationship ids
+* for legacy indexes only: index values and queries
+
+Parameters cannot be used for the following constructs, as these form part of the query structure that is compiled into a query plan:
+
+* property keys; so, `MATCH (n) WHERE n.{param} = 'something'` is invalid
+* relationship types
+* labels
+
+Parameters may consist of letters and numbers, and any combination of these, but cannot start with a number or a currency symbol.
 
 For details on using parameters via the Neo4j REST API, see <<rest-api-transactional>>.
-// For details on parameters when using the Neo4j embedded Java API, see <<tutorials-cypher-parameters-java>>.
 
-Below follows a comprehensive set of examples of parameter usage.
-The parameters are given as JSON here.
-Exactly how to submit them depends on the driver in use.
+We provide below a comprehensive list of examples of parameter usage.
+In these examples, parameters are given in JSON; the exact manner in which they are to be submitted depends upon the driver being used.
+
+[NOTE]
+====
+We introduce in this release the new parameter syntax `$param`, and note that the current syntax `{param}` will be deprecated in a later release.
+====
 
 == String literal ==
 
@@ -43,7 +55,7 @@ include::includes/create_node_from_map.asciidoc[]
 
 include::includes/create_multiple_nodes_from_map.asciidoc[]
 
-== Setting all properties on node ==
+== Setting all properties on a node ==
 
 Note that this will replace all the current properties.
 
@@ -68,5 +80,3 @@ include::includes/exampleWithParameterForIndexValue.asciidoc[]
 == Index query (legacy indexes) ==
 
 include::includes/exampleWithParametersForQuery.asciidoc[]
-
-


### PR DESCRIPTION
This must be **null** fwd-merged to 3.1 and 3.2, as those versions have already been addressed, and differ from the message conveyed in this PR