### PR TITLE
Overhaul of the "Syntax" landing page and operators

### DIFF
--- a/manual/cypher/cypher-docs/src/docs/dev/ql/delete/index.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/ql/delete/index.asciidoc
@@ -5,7 +5,7 @@
 The `DELETE` clause is used to delete graph elements -- nodes, relationships or paths.
 
 For removing properties and labels, see <<query-remove>>.
-Remember that you can not delete a node without also deleting relationships that start or end on said node.
+Remember that you cannot delete a node without also deleting relationships that start or end on said node.
 Either explicitly delete the relationships, or use `DETACH DELETE`.
 
 The examples start out with the following database:

--- a/manual/cypher/cypher-docs/src/docs/dev/ql/foreach/index.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/ql/foreach/index.asciidoc
@@ -8,10 +8,10 @@ Lists and paths are key concepts in Cypher.
 To use them for updating data, you can use the `FOREACH` construct.
 It allows you to do updating commands on elements in a path, or a list created by aggregation.
 
-The variable context inside of the foreach parenthesis is separate from the one outside it.
-This means that if you `CREATE` a node variable inside of a `FOREACH`, you will _not_ be able to use it outside of the foreach statement, unless you match to find it.
+The variable context within the foreach parenthesis is separate from the one outside it.
+This means that if you `CREATE` a node variable within a `FOREACH`, you will _not_ be able to use it outside of the foreach statement, unless you match to find it.
 
-Inside of the `FOREACH` parentheses, you can do any of the updating commands -- `CREATE`, `CREATE UNIQUE`, `MERGE`, `DELETE`, and `FOREACH`.
+Within the `FOREACH` parentheses, you can do any of the updating commands -- `CREATE`, `CREATE UNIQUE`, `MERGE`, `DELETE`, and `FOREACH`.
 
 If you want to execute an additional `MATCH` for each element in a list then `UNWIND` (see <<query-unwind>>) would be a more appropriate command.
 

--- a/manual/cypher/cypher-docs/src/docs/dev/ql/functions/index.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/ql/functions/index.asciidoc
@@ -86,6 +86,7 @@ Further details and examples of lists may be found in <<syntax-lists>>.
 
 These functions all operate on numerical expressions only, and will return an error if used on any other values.
 
+[[header-query-functions-numeric]]
 **<<query-functions-numeric, Numeric functions>>**
 
 [options="header"]

--- a/manual/cypher/cypher-docs/src/docs/dev/ql/functions/index.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/ql/functions/index.asciidoc
@@ -65,6 +65,7 @@ These functions return a single value.
 **<<query-functions-list, List functions>>**
 
 These functions return lists of other values.
+Further details and examples of lists may be found in <<syntax-lists>>.
 
 [options="header"]
 |===
@@ -245,7 +246,7 @@ ifndef::asciidoctor[:leveloffset: 1]
 
 List functions return lists of things -- nodes in a path, and so on.
 
-See also <<query-operators-list>>.
+Further details and examples of lists may be found in <<syntax-lists>> and <<query-operators-list>>.
 
 .Graph
 include::includes/cypher-functions-graph.asciidoc[]

--- a/manual/cypher/cypher-docs/src/docs/dev/ql/order-by/index.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/ql/order-by/index.asciidoc
@@ -4,7 +4,7 @@
 [abstract]
 `ORDER BY` is a sub-clause following `RETURN` or `WITH`, and it specifies that the output should be sorted and how.
 
-Note that you can not sort on nodes or relationships, just on properties on these.
+Note that you cannot sort on nodes or relationships, just on properties on these.
 `ORDER BY` relies on comparisons to sort the output, see <<cypher-ordering>>.
 
 In terms of scope of variables, `ORDER BY` follows special rules, depending on if the projecting `RETURN` or `WITH` clause is either aggregating or `DISTINCT`.

--- a/manual/cypher/cypher-docs/src/docs/dev/ql/syntax/index.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/ql/syntax/index.asciidoc
@@ -1,5 +1,5 @@
 [[query-syntax-case]]
-= Case Expressions
+= CASE Expressions
 
 Cypher supports `CASE` expressions, which is a generic conditional expression, similar to if/else statements in other languages.
 Two variants of `CASE` exist -- the simple form and the generic form.

--- a/manual/cypher/cypher-docs/src/docs/dev/ql/syntax/operators.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/ql/syntax/operators.asciidoc
@@ -4,15 +4,19 @@
 The mathematical operators comprise:
 
 * addition: `+`
-* subtraction: `-`
+* subtraction or unary minus: `-`
 * multiplication: `*`
 * division: `/`
-* modulo: `%`
+* modulo division: `%`
 * exponentiation: `^`
 
 ifndef::asciidoctor[:leveloffset: 1]
 
 include::using-the-exponentiation-operator.asciidoc[]
+
+ifndef::asciidoctor[:leveloffset: 1]
+
+include::using-the-unary-minus-operator.asciidoc[]
 
 [[query-operators-comparison]]
 = Comparison operators =

--- a/manual/cypher/cypher-docs/src/docs/dev/ql/syntax/operators.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/ql/syntax/operators.asciidoc
@@ -1,0 +1,93 @@
+[[query-operators-mathematical]]
+= Mathematical operators =
+
+The mathematical operators comprise:
+
+* addition: `+`
+* subtraction: `-`
+* multiplication: `*`
+* division: `/`
+* modulo: `%`
+* exponentiation: `^`
+
+ifndef::asciidoctor[:leveloffset: 1]
+
+include::using-the-exponentiation-operator.asciidoc[]
+
+[[query-operators-comparison]]
+= Comparison operators =
+
+The comparison operators comprise:
+
+* equality: `=`
+* inequality: `<>`
+* less than: `<`
+* greater than: `>`
+* less than or equal to: `\<=`
+* greater than or equal to: `>=`
+* `IS NULL`
+* `IS NOT NULL`
+
+[[query-operator-comparison-string-specific]]
+String-specific comparison operators comprise:
+
+* `STARTS WITH`: perform case-sensitive prefix searching on strings
+* `ENDS WITH`: perform case-sensitive suffix searching on strings
+* `CONTAINS`: perform case-sensitive inclusion searching in strings
+
+ifndef::asciidoctor[:leveloffset: 1]
+
+include::comparing-two-numbers.asciidoc[]
+
+See <<cypher-comparison>> for more details on the behavior of comparison operators, and <<query-where-ranges>> for more examples showing how these may be used.
+
+ifndef::asciidoctor[:leveloffset: 1]
+
+include::using-starts-with-to-filter-names.asciidoc[]
+
+<<query-where-string>> contains more information regarding the string-specific comparison operators as well as additional examples illustrating the usage thereof.
+
+[[query-operators-boolean]]
+= Boolean operators =
+
+The boolean operators -- also known as logical operators -- comprise:
+
+* conjunction: `AND`
+* disjunction: `OR`,
+* exclusive disjunction: `XOR`
+* negation: `NOT`
+
+include::../../syntax/boolean-operator-table.asciidoc[]
+
+ifndef::asciidoctor[:leveloffset: 1]
+
+include::using-boolean-operators-to-filter-numbers.asciidoc[]
+
+[[query-operators-string]]
+= String operators =
+
+String operators comprise:
+
+* concatenating strings: `+`
+* matching a regular expression: `=~`
+
+ifndef::asciidoctor[:leveloffset: 1]
+
+include::using-a-regular-expression-to-filter-words.asciidoc[]
+
+Further information and examples regarding the use of regular expressions in filtering can be found in <<query-where-regex>>.
+In addition, refer to <<query-operator-comparison-string-specific>> for details on string-specific comparison operators.
+
+[[query-operators-list]]
+= List operators =
+
+List operators comprise:
+
+* concatenating lists: `+`
+* checking if an element exists in a list: `IN`
+
+ifndef::asciidoctor[:leveloffset: 1]
+
+include::using-in-to-check-if-a-number-is-in-a-list.asciidoc[]
+
+ifndef::asciidoctor[:leveloffset: 1]

--- a/manual/cypher/cypher-docs/src/docs/dev/ql/where/index.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/ql/where/index.asciidoc
@@ -110,6 +110,7 @@ include::filter-on-null.asciidoc[leveloffset=+1]
 
 ifndef::asciidoctor[:leveloffset: 2]
 
+[[query-where-ranges]]
 == Using ranges ==
 
 ifndef::asciidoctor[:leveloffset: 3]

--- a/manual/cypher/cypher-docs/src/docs/dev/syntax/boolean-operator-table.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/syntax/boolean-operator-table.asciidoc
@@ -1,0 +1,15 @@
+Here is the truth table for `AND`, `OR`, `XOR` and `NOT`.
+
+[options="header", cols="^,^,^,^,^,^", width="85%"]
+|====
+|a | b | a `AND` b | a `OR` b | a `XOR` b | `NOT` a
+|`false` | `false` | `false` | `false` | `false` | `true`
+|`false` | `null` | `false` | `null` | `null` | `true`
+|`false` | `true` | `false` | `true` | `true` | `true`
+|`true` | `false` | `false` | `true` | `true` | `false`
+|`true` | `null` | `null` | `true` | `null` | `false`
+|`true` | `true` | `true` | `true` | `false` | `false`
+|`null` | `false` | `false` | `null` | `null` | `null`
+|`null` | `null` | `null` | `null` | `null` | `null`
+|`null` | `true` | `null` | `true` | `null` | `null`
+|====

--- a/manual/cypher/cypher-docs/src/docs/dev/syntax/comparison.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/syntax/comparison.asciidoc
@@ -1,5 +1,5 @@
 [[cypher-comparison]]
-== Equality and Comparison of Values ==
+== Equality and comparison of values ==
 
 === Equality ===
 
@@ -22,7 +22,7 @@ Especially, nodes, relationships, and literal maps are incomparable with each ot
 It is an error to compare values that cannot be compared.
 
 [[cypher-ordering]]
-== Ordering and Comparison of Values ==
+== Ordering and comparison of values ==
 
 The comparison operators `\<=`, `<` (for ascending) and `>=`, `>` (for descending) are used to compare values for ordering.
 The following points give some details on how the comparison is performed.
@@ -34,12 +34,13 @@ The following points give some details on how the comparison is performed.
 * Comparing for ordering when one argument is `null` (e.g. `null < 3` is `null`).
 * It is an error to compare other types of values with each other for ordering.
 
-== Chaining Comparison Operations ==
+[[cypher-operations-chaining]]
+== Chaining comparison operations ==
 Comparisons can be chained arbitrarily, e.g., `x < y \<= z` is equivalent to `x < y AND y \<= z`.
 
 Formally, if `a, b, c, \..., y, z` are expressions and `op1, op2, \..., opN` are comparison operators, then `a op1 b op2 c \... y opN z` is equivalent to `a op1 b and b op2 c and \... y opN z`.
 
-Note that `a op1 b op2 c` does not imply any kind of comparison between `a` and `c`, so that, e.g., `x < y > z` is perfectly legal (though perhaps not pretty).
+Note that `a op1 b op2 c` does not imply any kind of comparison between `a` and `c`, so that, e.g., `x < y > z` is perfectly legal (although perhaps not elegant).
 
 The example:
 

--- a/manual/cypher/cypher-docs/src/docs/dev/syntax/expressions.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/syntax/expressions.asciidoc
@@ -2,6 +2,7 @@
 Expressions
 ===========
 
+[[cypher-expressions-general]]
 == Expressions in general ==
 
 An expression in Cypher can be:
@@ -26,8 +27,9 @@ An expression in Cypher can be:
 * A case-sensitive string matching expression: `a.surname STARTS WITH 'Sven'`, `a.surname ENDS WITH 'son'` or `a.surname CONTAINS 'son'`
 * A `CASE` expression.
 
+[[cypher-expressions-string-literals]]
 == Note on string literals ==
-String literals can contain these escape sequences.
+String literals can contain the following escape sequences:
 
 [options="header", cols=">1,<2", width="50%"]
 |===================

--- a/manual/cypher/cypher-docs/src/docs/dev/syntax/index.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/syntax/index.asciidoc
@@ -14,7 +14,7 @@ This section describes the syntax of the Cypher query language.
 * <<cypher-variables,Variables>>
 * <<cypher-parameters,Parameters>>
 * <<query-operators,Operators>>
- ** <<query-operators,Operator summary>>
+ ** <<query-operators,Operators at a glance>>
  ** <<query-operators-mathematical,Mathematical operators>>
  ** <<query-operators-comparison,Comparison operators>>
  ** <<query-operators-boolean,Boolean operators>>

--- a/manual/cypher/cypher-docs/src/docs/dev/syntax/index.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/syntax/index.asciidoc
@@ -8,13 +8,39 @@ This section describes the syntax of the Cypher query language.
 
 * <<cypher-values,Values>>
 * <<cypher-expressions,Expressions>>
+ ** <<cypher-expressions-general,Expressions in general>>
+ ** <<cypher-expressions-string-literals,Note on string literals>>
+ ** <<query-syntax-case,CASE Expressions>>
 * <<cypher-variables,Variables>>
 * <<cypher-parameters,Parameters>>
 * <<query-operators,Operators>>
+ ** <<query-operators,Operator summary>>
+ ** <<query-operators-mathematical,Mathematical operators>>
+ ** <<query-operators-comparison,Comparison operators>>
+ ** <<query-operators-boolean,Boolean operators>>
+ ** <<query-operators-string,String operators>>
+ ** <<query-operators-list,List operators>>
+ ** <<query-operators-property,Property operators>>
+ ** <<cypher-comparison,Equality and comparison of values>>
+ ** <<cypher-ordering,Ordering and comparison of values>>
+ ** <<cypher-operations-chaining,Chaining comparison operations>>
 * <<cypher-comments,Comments>>
 * <<introduction-pattern,Patterns>>
+ ** <<cypher-pattern-node,Patterns for nodes>>
+ ** <<cypher-pattern-related-nodes,Patterns for related nodes>>
+ ** <<cypher-pattern-label,Patterns for labels>>
+ ** <<cypher-pattern-properties,Specifying properties>>
+ ** <<cypher-pattern-relationship,Patterns for relationships>>
+ ** <<cypher-pattern-path-variables,Assigning to path variables>>
 * <<syntax-lists,Lists>>
+ ** <<cypher-lists-general,Lists in general>>
+ ** <<cypher-list-comprehension,List comprehension>>
+ ** <<cypher-literal-maps,Literal maps>>
 * <<cypher-working-with-null,Working with null>>
+ ** <<cypher-null-intro,Introduction to 'null' in Cypher>>
+ ** <<cypher-null-logical-operators,Logical operations with null>>
+ ** <<cypher-null-in-operator,The IN operator and null>>
+ ** <<cypher-expressions-and-null,Expressions that return null>>
 
 ifndef::asciidoctor[:leveloffset: 2]
 

--- a/manual/cypher/cypher-docs/src/docs/dev/syntax/operators.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/syntax/operators.asciidoc
@@ -2,10 +2,22 @@
 Operators
 =========
 
+[[query-operators-summary]]
+== Operators at a glance ==
+
+|===
+| <<query-operators-mathematical,Mathematical operators>> | `+`, `-`, `*`, `/`, `%`, `^`
+| <<query-operators-comparison,Comparison operators>>     | `=`, `<>`, `<`, `>`, `<=`, `>=`, `IS NULL`, `IS NOT NULL`
+| <<query-operators-comparison,String-specific comparison operators>> | `STARTS WITH`, `ENDS WITH`, `CONTAINS`
+| <<query-operators-boolean,Boolean operators>> | `AND`, `OR`, `XOR`, `NOT`
+| <<query-operators-string,String operators>>   | `+` for concatenation, `=~` for regex matching
+| <<query-operators-list,List operators>>       | `+` for concatenation, `IN` to check existence of an element in a list
+|===
+
 [[query-operators-mathematical]]
 == Mathematical operators ==
 
-The mathematical operators include `+`, `-`, `*`, `/` and `%`, `^`.
+The mathematical operators include `+`, `-`, `*`, `/`, `%`, and `^`.
 
 [[query-operators-comparison]]
 == Comparison operators ==
@@ -17,7 +29,7 @@ The operators `STARTS WITH`, `ENDS WITH` and `CONTAINS` can be used to search fo
 
 [[query-operators-boolean]]
 == Boolean operators ==
-The boolean operators are `AND`, `OR`, `XOR`, `NOT`.
+The boolean operators are `AND`, `OR`, `XOR`, and `NOT`.
 
 [[query-operators-string]]
 == String operators ==

--- a/manual/cypher/cypher-docs/src/docs/dev/syntax/operators.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/syntax/operators.asciidoc
@@ -14,34 +14,7 @@ Operators
 | <<query-operators-list,List operators>>       | `+` for concatenation, `IN` to check existence of an element in a list
 |===
 
-[[query-operators-mathematical]]
-== Mathematical operators ==
-
-The mathematical operators include `+`, `-`, `*`, `/`, `%`, and `^`.
-
-[[query-operators-comparison]]
-== Comparison operators ==
-
-The comparison operators include `=`, `<>`, `<`, `>`, `\<=`, `>=`, `IS NULL`, and `IS NOT NULL`.
-See <<cypher-comparison>> on their behavior.
-
-The operators `STARTS WITH`, `ENDS WITH` and `CONTAINS` can be used to search for a string value by its content.
-
-[[query-operators-boolean]]
-== Boolean operators ==
-The boolean operators are `AND`, `OR`, `XOR`, and `NOT`.
-
-[[query-operators-string]]
-== String operators ==
-
-Strings can be concatenated using the `+` operator.
-For regular expression matching the `=~` operator is used.
-
-[[query-operators-list]]
-== List operators ==
-
-Lists can be concatenated using the `+` operator.
-The `IN` operator can be used to check if an element exists in a list.
+include::../ql/syntax/operators.asciidoc[leveloffset=+1]
 
 [[query-operators-property]]
 == Property operators ==

--- a/manual/cypher/cypher-docs/src/docs/dev/syntax/operators.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/syntax/operators.asciidoc
@@ -5,13 +5,13 @@ Operators
 [[query-operators-mathematical]]
 == Mathematical operators ==
 
-The mathematical operators are `+`, `-`, `*`, `/` and `%`, `^`.
+The mathematical operators include `+`, `-`, `*`, `/` and `%`, `^`.
 
 [[query-operators-comparison]]
 == Comparison operators ==
 
-The comparison operators are `=`, `<>`, `<`, `>`, `\<=`, `>=`, `IS NULL`, and `IS NOT NULL`.
-See <<cypher-comparison>> on how they behave.
+The comparison operators include `=`, `<>`, `<`, `>`, `\<=`, `>=`, `IS NULL`, and `IS NOT NULL`.
+See <<cypher-comparison>> on their behavior.
 
 The operators `STARTS WITH`, `ENDS WITH` and `CONTAINS` can be used to search for a string value by its content.
 
@@ -29,15 +29,15 @@ For regular expression matching the `=~` operator is used.
 == List operators ==
 
 Lists can be concatenated using the `+` operator.
-To check if an element exists in a list, you can use the `IN` operator.
+The `IN` operator can be used to check if an element exists in a list.
 
 [[query-operators-property]]
 == Property operators ==
 
 [NOTE]
-Since version 2.0, the previously existing property operators `?` and `!` have been removed.
+Since version 2.0, the previously supported property operators `?` and `!` have been removed.
 This syntax is no longer supported.
 Missing properties are now returned as `null`.
 Please use `(NOT(has(<ident>.prop)) OR <ident>.prop=<value>)` if you really need the old behavior of the `?` operator.
--- Also, the use of `?` for optional relationships has been removed in favor of the newly introduced `OPTIONAL MATCH` clause.
+-- Also, the use of `?` for optional relationships has been removed in favor of the newly-introduced `OPTIONAL MATCH` clause.
 

--- a/manual/cypher/cypher-docs/src/docs/dev/syntax/working-with-null.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/syntax/working-with-null.asciidoc
@@ -2,6 +2,7 @@
 Working with null
 =================
 
+[[cypher-null-intro]]
 == Introduction to 'null' in Cypher ==
 
 In Cypher, `null` is used to represent missing or undefined values.
@@ -15,6 +16,7 @@ In this case, anything that is not `true` is interpreted as being false.
 Not knowing two values does not imply that they are the same value.
 So the expression `null` = `null` yields `null` and not `true`.
 
+[[cypher-null-logical-operators]]
 == Logical operations with null ==
 
 The logical operators (`AND`, `OR`, `XOR`, `IN`, `NOT`) treat `null` as the 'unknown' value of three-valued logic.
@@ -34,6 +36,7 @@ Here is the truth table for `AND`, `OR` and `XOR`.
 |`null` | `true` | `null` | `true` | `null`
 |====
 
+[[cypher-null-in-operator]]
 == The IN operator and null ==
 
 The `IN` operator follows similar logic.
@@ -59,6 +62,7 @@ Using `all`, `any`, `none`, and `single` follows a similar rule.
 If the result can be calculated definitely, `true` or `false` is returned.
 Otherwise `null` is produced.
 
+[[cypher-expressions-and-null]]
 == Expressions that return null ==
 
 * Getting a missing element from a list: `[][0]`, `head([])`

--- a/manual/cypher/cypher-docs/src/docs/dev/syntax/working-with-null.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/syntax/working-with-null.asciidoc
@@ -19,22 +19,9 @@ So the expression `null` = `null` yields `null` and not `true`.
 [[cypher-null-logical-operators]]
 == Logical operations with null ==
 
-The logical operators (`AND`, `OR`, `XOR`, `IN`, `NOT`) treat `null` as the 'unknown' value of three-valued logic.
-Here is the truth table for `AND`, `OR` and `XOR`.
+The logical operators (`AND`, `OR`, `XOR`, `NOT`) treat `null` as the 'unknown' value of three-valued logic.
 
-[options="header", cols="^,^,^,^,^", width="80%"]
-|====
-|a | b | a `AND` b | a `OR` b | a `XOR` b
-|`false` | `false` | `false` | `false` | `false`
-|`false` | `null` | `false` | `null` | `null`
-|`false` | `true` | `false` | `true` | `true`
-|`true` | `false` | `false` | `true` | `true`
-|`true` | `null` | `null` | `true` | `null`
-|`true` | `true` | `true` | `true` | `false`
-|`null` | `false` | `false` | `null` | `null`
-|`null` | `null` | `null` | `null` | `null`
-|`null` | `true` | `null` | `true` | `null`
-|====
+include::boolean-operator-table.asciidoc[]
 
 [[cypher-null-in-operator]]
 == The IN operator and null ==

--- a/manual/cypher/cypher-docs/src/docs/graphgists/intro/loading-data.adoc
+++ b/manual/cypher/cypher-docs/src/docs/graphgists/intro/loading-data.adoc
@@ -5,7 +5,7 @@
 //file:persons.csv
 //file:movie_actor_roles.csv
 
-As you've seen you can not only query data expressively but also create data with Cypher statements.
+As you've seen, you are able not only to query data expressively, but can also create data with Cypher statements.
 
 Naturally in most cases you wouldn't want to write or generate huge statements to generate your data but instead use an existing data source that you pass into your statement and which is used to drive the graph generation process.
 
@@ -18,7 +18,7 @@ In general we recommend passing in varying literal values from the outside as na
 This allows Cypher to reuse existing execution plans for the statements.
 
 Of course you can also pass in parameters for data to be imported.
-Those can be scalar values, maps, lists or even lists of maps.
+These can be scalar values, maps, lists or even lists of maps.
 
 In your Cypher statement you can then iterate over those values (e.g. with `UNWIND`) to create your graph structures.
 

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CollectionsAndMapsTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CollectionsAndMapsTest.scala
@@ -33,8 +33,9 @@ class CollectionsAndMapsTest extends ArticleTest {
 Lists
 =====
 
-Cypher has good support for lists.
+Cypher has comprehensive support for lists.
 
+[[cypher-lists-general]]
 == Lists in general ==
 
 A literal list is created by using brackets and separating the elements in the list with commas.
@@ -42,7 +43,7 @@ A literal list is created by using brackets and separating the elements in the l
 ###
 RETURN [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] as list###
 
-In our examples, we'll use the range function.
+In our examples, we'll use the <<functions-range,range>> function.
 It gives you a list containing all numbers between given start and end numbers.
 Range is inclusive in both ends.
 
@@ -76,11 +77,12 @@ RETURN range(0, 10)[15]###
 ###
 RETURN range(0, 10)[5..15]###
 
-You can get the size of a list like this:
+You can get the <<functions-size,size>> of a list as follows:
 
 ###
 RETURN size(range(0, 10)[0..3])###
 
+[[cypher-list-comprehension]]
 == List comprehension ==
 
 List comprehension is a syntactic construct available in Cypher for creating a list based on existing lists.
@@ -97,7 +99,7 @@ RETURN [x IN range(0,10) WHERE x % 2 = 0 ] AS result###
 ###
 RETURN [x IN range(0,10) | x^3 ] AS result###
 
-
+[[cypher-literal-maps]]
 == Literal maps ==
 
 From Cypher, you can also construct maps. Through REST you will get JSON objects; in Java they will be `java.util.Map<String,Object>`.

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MatchTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MatchTest.scala
@@ -244,7 +244,7 @@ class MatchTest extends DocumentingTest {
             |RETURN p""", assertShortestPathLength) {
           p(
             """This means: find a single shortest path between two nodes, as long as the path is max 15 relationships long.
-              |Inside of the parentheses you define a single link of a path -- the starting node, the connecting relationship
+              |Within the parentheses you define a single link of a path -- the starting node, the connecting relationship
               |and the end node. Characteristics describing the relationship like relationship type, max hops and direction
               |are all used when finding the shortest path. If there is a `WHERE` clause following the match of a
               |`shortestPath`, relevant predicates will be included in the `shortestPath`.

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/PatternTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/PatternTest.scala
@@ -51,7 +51,7 @@ Using patterns, you describe the shape of the data you're looking for. For examp
 The pattern describes the data using a form that is very similar to how one typically draws the shape of property graph data on a whiteboard: usually as circles (representing nodes) and arrows between them to represent relationships.
 
 Patterns appear in multiple places in Cypher: in `MATCH`, `CREATE` and `MERGE` clauses, and in pattern expressions. Each of these
-is described in more details in:
+is described in more detail in:
 
 * <<query-match>>
 * <<query-optional-match>>
@@ -59,6 +59,7 @@ is described in more details in:
 * <<query-merge>>
 * <<query-where-patterns>>
 
+[[cypher-pattern-node]]
 == Patterns for nodes ==
 
 The very simplest 'shape' that can be described in a pattern is a node. A node is described using a pair of parentheses, and is typically given a name.
@@ -71,9 +72,10 @@ For example:
 
 This simple pattern describes a single node, and names that node using the variable `a`.
 
+[[cypher-pattern-related-nodes]]
 == Patterns for related nodes ==
 
-More interesting is patterns that describe multiple nodes and relationships between them.
+A more powerful construct is a pattern that describes multiple nodes and relationships between them.
 Cypher patterns describe relationships by employing an arrow between two nodes.
 For example:
 
@@ -85,7 +87,7 @@ For example:
 This pattern describes a very simple data shape: two nodes, and a single relationship from one to the other.
 In this example, the two nodes are both named as `a` and `b` respectively, and the relationship is 'directed': it goes from `a` to `b`.
 
-This way of describing nodes and relationships can be extended to cover an arbitrary number of nodes and the relationships between them, for example:
+This manner of describing nodes and relationships can be extended to cover an arbitrary number of nodes and the relationships between them, for example:
 
 [source,cypher]
 ----
@@ -95,14 +97,15 @@ This way of describing nodes and relationships can be extended to cover an arbit
 Such a series of connected nodes and relationships is called a "path".
 
 Note that the naming of the nodes in these patterns is only necessary should one need to refer to the same node again, either later in the pattern or elsewhere in the Cypher query.
-If this is not necessary then the name may be omitted, like so:
+If this is not necessary, then the name may be omitted, as follows:
 
 [source,cypher]
 ----
 (a)-->()<--(c)
 ----
 
-== Labels ==
+[[cypher-pattern-label]]
+== Patterns for labels ==
 
 In addition to simply describing the shape of a node in the pattern, one can also describe attributes.
 The most simple attribute that can be described in the pattern is a label that the node must have.
@@ -120,6 +123,7 @@ One can also describe a node that has multiple labels:
 (a:User:Admin)-->(b)
 ----
 
+[[cypher-pattern-properties]]
 == Specifying properties ==
 
 Nodes and relationships are the fundamental structures in a graph. Neo4j uses properties on both of these to allow for far richer models.
@@ -132,7 +136,7 @@ E.g. a node with two properties on it would look like:
 (a { name: 'Andres', sport: 'Brazilian Ju-Jitsu'})
 ----
 
-A relationship with expectations on it would could look like:
+A relationship with expectations on it is given by:
 
 [source,cypher]
 ----
@@ -140,18 +144,19 @@ A relationship with expectations on it would could look like:
 ----
 
 When properties appear in patterns, they add an additional constraint to the shape of the data.
-In the case of a `CREATE` clause, the properties will be set in the newly created nodes and relationships.
+In the case of a `CREATE` clause, the properties will be set in the newly-created nodes and relationships.
 In the case of a `MERGE` clause, the properties will be used as additional constraints on the shape any existing data must have (the specified properties must exactly match any existing data in the graph).
 If no matching data is found, then `MERGE` behaves like `CREATE` and the properties will be set in the newly created nodes and relationships.
 
 Note that patterns supplied to `CREATE` may use a single parameter to specify properties, e.g: `CREATE (node {paramName})`.
 This is not possible with patterns used in other clauses, as Cypher needs to know the property names at the time the query is compiled, so that matching can be done effectively.
 
-== Describing relationships ==
+[[cypher-pattern-relationship]]
+== Patterns for relationships ==
 
 The simplest way to describe a relationship is by using the arrow between two nodes, as in the previous examples.
 Using this technique, you can describe that the relationship should exist and the directionality of it.
-If you don't care about the direction of the relationship, the arrow head can be omitted, like so:
+If you don't care about the direction of the relationship, the arrow head can be omitted, as exemplified by:
 
 [source,cypher]
 ----
@@ -168,7 +173,7 @@ For example:
 ----
 
 Much like labels on nodes, relationships can have types.
-To describe a relationship with a specific type, you can specify this like so:
+To describe a relationship with a specific type, you can specify this as follows:
 
 [source,cypher]
 ----
@@ -186,7 +191,7 @@ But if we'd like to describe some data such that the relationship could have any
 Note that this form of pattern can only be used to describe existing data (ie. when using a pattern with `MATCH` or as an expression).
 It will not work with `CREATE` or `MERGE`, since it's not possible to create a relationship with multiple types.
 
-As with nodes, the name of the relationship can always be omitted, in this case like so:
+As with nodes, the name of the relationship can always be omitted, as exemplified by:
 
 [source,cypher]
 ----
@@ -260,12 +265,13 @@ RETURN remote_friend.name###
 This query finds data in the graph which a shape that fits the pattern: specifically a node (with the name property *'Filipa'*) and then the `KNOWS` related nodes, one or two steps out.
 This is a typical example of finding first and second degree friends.
 
-Note that variable length relationships can not be used with `CREATE` and `MERGE`.
+Note that variable length relationships cannot be used with `CREATE` and `MERGE`.
 
+[[cypher-pattern-path-variables]]
 == Assigning to path variables ==
 
 As described above, a series of connected nodes and relationships is called a "path". Cypher allows paths to be named
-using an identifer, like so:
+using an identifer, as exemplified by:
 
 [source,cypher]
 ----

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/PatternTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/PatternTest.scala
@@ -201,7 +201,7 @@ As with nodes, the name of the relationship can always be omitted, as exemplifie
 === Variable length ===
 
 [CAUTION]
-Variable length pattern matching in versions 2.1.x and earlier does not enforce relationship uniqueness for patterns described inside of a single `MATCH` clause.
+Variable length pattern matching in versions 2.1.x and earlier does not enforce relationship uniqueness for patterns described within a single `MATCH` clause.
 This means that a query such as the following: `MATCH (a)-[r]\->(b), (a)-[rs*]\->(c) RETURN *` may include `r` as part of the `rs` set.
 This behavior has changed in versions 2.2.0 and later, in such a way that `r` will be excluded from the result set, as this better adheres to the rules of relationship uniqueness as documented here <<cypherdoc-uniqueness>>.
 If you have a query pattern that needs to retrace relationships rather than ignoring them as the relationship uniqueness rules normally dictate, you can accomplish this using multiple match clauses, as follows: `MATCH (a)-[r]\->(b) MATCH (a)-[rs*]\->(c) RETURN *`.

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SyntaxTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SyntaxTest.scala
@@ -113,7 +113,21 @@ END AS result""",
         """WITH 2 AS number, 3 AS exponent
            RETURN number ^ exponent AS result""",
       returns = "",
-      assertions = (p) => assert(Set(Map("result" -> 8)) === p.toSet)
+      assertions = (p) => assert(Set(Map("result" -> 8L)) === p.toSet)
+    )
+  }
+
+  @Test def mathematical_operator_unary_minus() {
+    testThis(
+      title = "Using the unary minus operator",
+      syntax = "",
+      arguments = List.empty,
+      text = "",
+      queryText =
+        """WITH -3 AS a, 4 AS b
+          |return b - a AS result""".stripMargin,
+      returns = "",
+      assertions = (p) => assert(Set(Map("result" -> 7L)) === p.toSet)
     )
   }
 

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SyntaxTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SyntaxTest.scala
@@ -103,26 +103,112 @@ END AS result""",
     )
   }
 
+  @Test def mathematical_operator_exponentiation() {
+    testThis(
+      title = "Using the exponentiation operator",
+      syntax = "",
+      arguments = List.empty,
+      text = "",
+      queryText =
+        """WITH 2 AS number, 3 AS exponent
+           RETURN number ^ exponent AS result""",
+      returns = "",
+      assertions = (p) => assert(Set(Map("result" -> 8)) === p.toSet)
+    )
+  }
+
+  @Test def comparison_operator() {
+    testThis(
+      title = "Comparing two numbers",
+      syntax = "",
+      arguments = List.empty,
+      text = "",
+      queryText =
+        """WITH 4 AS one, 3 AS two
+           RETURN one > two AS result""",
+      returns = "",
+      assertions = (p) => assert(Set(Map("result" -> true)) === p.toSet)
+    )
+  }
+
+  @Test def starts_with_comparison_operator() {
+    testThis(
+      title = "Using STARTS WITH to filter names",
+      syntax = "",
+      arguments = List.empty,
+      text = "",
+      queryText =
+        """WITH ['John', 'Mark', 'Jonathan', 'Bill'] AS somenames
+          |UNWIND somenames AS names
+          |WITH names AS candidate
+          |WHERE candidate STARTS WITH 'Jo'
+          |RETURN candidate""".stripMargin,
+      returns = "",
+      assertions = (p) => assert(Set(Map("candidate" -> "John"), Map("candidate" -> "Jonathan")) === p.toSet)
+    )
+  }
+
+  @Test def boolean_operator() {
+    testThis(
+      title = "Using boolean operators to filter numbers",
+      syntax = "",
+      arguments = List.empty,
+      text = "",
+      queryText =
+        """WITH [2, 4, 7, 9, 12] AS numberlist
+          |UNWIND numberlist AS number
+          |WITH number
+          |WHERE number = 4 OR (number > 6 AND number < 10)
+          |RETURN number""".stripMargin,
+      returns = "",
+      assertions = (p) => assert(Set(Map("number" -> 4L), Map("number" -> 7L), Map("number" -> 9L)) === p.toSet)
+    )
+  }
+
+  @Test def regex_string_operator() {
+    testThis(
+      title = "Using a regular expression to filter words",
+      syntax = "",
+      arguments = List.empty,
+      text = "",
+      queryText =
+        """WITH ['mouse', 'chair', 'door', 'house'] AS wordlist
+          |UNWIND wordlist AS word
+          |WITH word
+          |WHERE word =~ '.*ous.*'
+          |RETURN word""".stripMargin,
+      returns = "",
+      assertions = (p) => assert(Set(Map("word" -> "mouse"), Map("word" -> "house")) === p.toSet)
+    )
+  }
+
+  @Test def in_list_operator() {
+    testThis(
+      title = "Using `IN` to check if a number is in a list",
+      syntax = "",
+      arguments = List.empty,
+      text = "",
+      queryText =
+        """WITH [2, 3, 4, 5] AS numberlist
+          |UNWIND numberlist AS number
+          |WITH number
+          |WHERE number IN [2, 3, 8]
+          |RETURN number""".stripMargin,
+      returns = "",
+      assertions = (p) => assert(Set(Map("number" -> 2L), Map("number" -> 3L)) === p.toSet)
+    )
+  }
+
   private def testThis(title: String, syntax: String, arguments: List[(String, String)], text: String, queryText: String, returns: String, assertions: InternalExecutionResult => Unit) {
-    val argsText = arguments.map(x => "* _" + x._1 + ":_ " + x._2).mkString("\r\n\r\n")
+    val formattedSyntax = if (!syntax.isEmpty) Array("*Syntax:*", "[source,cypher]", syntax).mkString("\n", "\n", "") else ""
 
-
-    val formattedArguments = arguments.map(x => "| `" + x._1 + "` | " + x._2).mkString("", "\n", "")
+    val args = arguments.map(x => "| `" + x._1 + "` | " + x._2).mkString("", "\n", "")
+    val formattedArguments = if (!arguments.isEmpty) Array("*Arguments:*", "[options=\"header\"]", "|===", "| Name | Description", args, "|===").mkString("\n", "\n", "") else ""
     val fullText = String.format(
       """%s
-         |
-         |*Syntax:*
-         |[source,cypher]
          |%s
-         |
-         |*Arguments:*
-         |[options="header"]
-         ||===
-         || Name | Description
          |%s
-         ||===
-
-      """.stripMargin, text, syntax, formattedArguments)
+      """.stripMargin, text, formattedSyntax, formattedArguments)
 
     testQuery(title, fullText, queryText, returns, assertions = assertions)
   }

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
@@ -217,10 +217,10 @@ class WhereTest extends DocumentingTestBase {
 expressions are also predicates -- an empty list represents `false`, and a non-empty represents `true`.
 
 So, patterns are not only expressions, they are also predicates. The only limitation to your pattern is that you must be
-able to express it in a single path. You can not use commas between multiple paths like you do in `MATCH`. You can achieve
+able to express it in a single path. You cannot use commas between multiple paths like you do in `MATCH`. You can achieve
 the same effect by combining multiple patterns with `AND`.
 
-Note that you can not introduce new variables here. Although it might look very similar to the `MATCH` patterns, the
+Note that you cannot introduce new variables here. Although it might look very similar to the `MATCH` patterns, the
 `WHERE` clause is all about eliminating matched subgraphs. `MATCH (a)-[*]->(b)` is very different from `WHERE (a)-[*]->(b)`; the
 first will produce a subgraph for every path it can find between `a` and `b`, and the latter will eliminate any matched
 subgraphs where `a` and `b` do not have a directed relationship chain between them.

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
@@ -85,7 +85,7 @@ class WhereTest extends DocumentingTestBase {
   @Test def boolean_operations() {
     testQuery(
       title = "Boolean operations",
-      text = "You can use the expected boolean operators `AND` and `OR`, and also the boolean function `NOT`. " +
+      text = "You can use the boolean operators `AND`, `OR`, `XOR` and `NOT`. " +
         "See <<cypher-working-with-null>> for more information on how this works with `null`.",
       queryText = """MATCH (n) WHERE n.name = 'Peter' XOR (n.age < 30 AND n.name = 'Tobias') OR NOT (n.name = 'Tobias' OR n.name = 'Peter') RETURN n""",
       assertions = (p) => assertEquals(nodes("Andres", "Tobias", "Peter").toSet, p.columnAs[Node]("n").toSet))
@@ -103,7 +103,7 @@ class WhereTest extends DocumentingTestBase {
   @Test def regular_expressions_escaped() {
     testQuery(
       title = "Escaping in regular expressions",
-      text = "If you need a forward slash inside of your regular expression, escape it. Remember that back slash needs " +
+      text = "If you need a forward slash within your regular expression, escape it. Remember that back slash needs " +
              "to be escaped in string literals.",
       queryText = """MATCH (n) WHERE n.address =~ 'Sweden\\/Malmo' RETURN n""",
       optionalResultExplanation = """*'Tobias'* is returned because his address is in *'Sweden/Malmo'*.""",
@@ -260,7 +260,7 @@ subgraphs where `a` and `b` do not have a directed relationship chain between th
   @Test def simple_range() {
     testQuery(
       title = "Simple range",
-      text = "To check for an element being inside a specific range, use the inequality operators `<`, `<=`, `>=`, `>`.",
+      text = "To check for an element being inside a specific range, use the inequality operators `<`, `\\<=`, `>=`, `>`.",
       queryText = """MATCH (a) WHERE a.name >= 'Peter' RETURN a""",
       optionalResultExplanation = "Nodes having a name property lexicographically greater than or equal to *'Peter'* are returned.",
       assertions = (p) => assertEquals(List(node("Tobias"),node("Peter")), p.columnAs[Node]("a").toList))

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/tests/ContentAndResultMergerTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/tests/ContentAndResultMergerTest.scala
@@ -75,7 +75,7 @@ class ContentAndResultMergerTest extends CypherFunSuite {
       Document("title", "myId", initQueries = Seq.empty, GRAPHVIZ_RESULT ~ TABLE_RESULT))
   }
 
-  test("doc with GraphVizBefore and Result Table inside of Query") {
+  test("doc with GraphVizBefore and Result Table within Query") {
     // given
     val queryObj = Query(QUERY, NoAssertions, Seq.empty, TABLE_PLACEHOLDER ~ GRAPHVIZ_PLACEHOLDER)
     val doc = Document("title", "myId", initQueries = Seq.empty, queryObj)


### PR DESCRIPTION
- Added a proper landing page to the Syntax section so that readers may easily see what is contained therein
- Language improvements

This must be forward-merged 