### PR TITLE
Remove confusing link (Labels card)

### DIFF
--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/LabelsTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/LabelsTest.scala
@@ -26,7 +26,6 @@ import org.neo4j.cypher.internal.compiler.v3_0.executionplan.InternalExecutionRe
 class LabelsTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("A:Person KNOWS ROOT")
   val title = "Labels"
-  override val linkId = "../get-started/cypher/labels-constraints-and-indexes"
 
   override def assert(name: String, result: InternalExecutionResult) {
     name match {


### PR DESCRIPTION
The refcard section on Labels is about how to
use them, syntax etc. and the link goes to a page describing labels in
connection to indexes and constraints. This is confusing.
Conferred with PS and decided to remove card.