### PR TITLE
Add enterprise-kernel module to published javadocs

### DIFF
--- a/javadocs/pom.xml
+++ b/javadocs/pom.xml
@@ -71,6 +71,13 @@
     </dependency>
     <dependency>
       <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-enterprise-kernel</artifactId>
+      <version>${project.version}</version>
+      <classifier>sources</classifier>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
       <artifactId>neo4j-ha</artifactId>
       <version>${project.version}</version>
       <classifier>sources</classifier>


### PR DESCRIPTION
This way we can start adding proper documentation to e.g. `EnterpriseGraphDatabaseFactory`