### PR TITLE
Disable all license checking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,17 +95,20 @@
         <plugin>
           <groupId>org.neo4j.build.plugins</groupId>
           <artifactId>licensing-maven-plugin</artifactId>
-          <configuration>
-            <failIfDisliked>true</failIfDisliked>
-            <failIfMissing>true</failIfMissing>
-            <plainTextReport>true</plainTextReport>
-            <prependText>${licensing.prepend.text}</prependText>
-            <excludedGroups>
-              ^((org.neo4j){1}|(org.neo4j.app){1}|(org.neo4j.doc){1}|(org.neo4j.server.plugin){1}|(org.neo4j.assembly){1}|(org.neo4j.bolt){1}|(org.neo4j.build){1}|(org.neo4j.examples){1}|(org.neo4j.test){1})$
-            </excludedGroups>
-            <excludedArtifacts>^((neo4j-browser))$</excludedArtifacts>
-            <includedScopes>compile</includedScopes>
-          </configuration>
+          <executions>
+            <execution>
+              <id>enforce-licensing-oss</id>
+              <phase/>
+            </execution>
+            <execution>
+              <id>enforce-licensing-com</id>
+              <phase/>
+            </execution>
+            <execution>
+              <id>list-all-licenses</id>
+              <phase/>
+            </execution>
+          </executions>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
These maven modules are never published anywhere, and do not require
adherence to OSS license terms.