### PR TITLE
Add tag around settings reference summary table

### DIFF
--- a/config-docs/pom.xml
+++ b/config-docs/pom.xml
@@ -178,7 +178,6 @@
                       classpathref="maven.compile.classpath" failonerror="true">
                   <arg value="--id=reference-dynamic-settings-reference" />
                   <arg value="--title=Dynamic settings reference" />
-                  <arg value="--id-prefix=dynamic-setting_" />
                   <arg value="--dynamic-only=true" />
                   <arg file="${project.build.directory}/docs/ops/dynamic-settings.adoc" />
                 </java>

--- a/doctools/src/main/java/org/neo4j/doc/AsciiDocListGenerator.java
+++ b/doctools/src/main/java/org/neo4j/doc/AsciiDocListGenerator.java
@@ -42,6 +42,7 @@ public class AsciiDocListGenerator
     {
         StringBuilder sb = new StringBuilder( 200 * items.size() );
         StringBuilder print = new StringBuilder( 100 * items.size() );
+        sb.append(String.format("// tag::%s[]%n", listId));
         if ( listId != null )
         {
             sb.append( "[[" ).append( listId ).append( String.format( "]]%n" ) );
@@ -90,6 +91,7 @@ public class AsciiDocListGenerator
         print.append( SettingsDocumenter.ENDIF )
             .append( System.lineSeparator() );
         sb.append( print.toString() );
+        sb.append(String.format("// end::%s[]%n%n", listId));
         return sb.toString();
     }
 

--- a/doctools/src/test/java/org/neo4j/doc/SettingsDocumenterTest.java
+++ b/doctools/src/test/java/org/neo4j/doc/SettingsDocumenterTest.java
@@ -59,6 +59,7 @@ public class SettingsDocumenterTest
         // in which case you should trust your best judgement, and change the assertion
         // below accordingly.
         assertThat( result, equalTo( String.format(
+            "// tag::config-org.neo4j.doc.SettingsDocumenterTest-SimpleSettings[]%n" +
             "[[config-org.neo4j.doc.SettingsDocumenterTest-SimpleSettings]]%n" +
             ".List of configuration settings%n" +
             "ifndef::nonhtmloutput[]%n" +
@@ -76,6 +77,8 @@ public class SettingsDocumenterTest
             "endif::nonhtmloutput[]%n" +
             "%n" +
             "%n" +
+            "// end::config-org.neo4j.doc.SettingsDocumenterTest-SimpleSettings[]%n%n" +
+            "// tag::config-org.neo4j.doc.SettingsDocumenterTest-SimpleSettings-deprecated[]%n" +
             "[[config-org.neo4j.doc.SettingsDocumenterTest-SimpleSettings-deprecated]]%n" +
             ".Deprecated settings%n" +
             "ifndef::nonhtmloutput[]%n" +
@@ -91,6 +94,7 @@ public class SettingsDocumenterTest
             "endif::nonhtmloutput[]%n" +
             "%n" +
             "%n" +
+            "// end::config-org.neo4j.doc.SettingsDocumenterTest-SimpleSettings-deprecated[]%n%n" +
             "ifndef::nonhtmloutput[]%n" +
             "[[config_public.default]]%n" +
             ".public.default%n" +
@@ -155,7 +159,8 @@ public class SettingsDocumenterTest
             "|Description a|Public nodefault.%n" +
             "|Valid values a|public.nodefault is a string%n" +
             "|===%n" +
-            "endif::nonhtmloutput[]%n%n" ) ));
+            "endif::nonhtmloutput[]%n%n"
+        ) ));
     }
 
     @Test
@@ -166,6 +171,7 @@ public class SettingsDocumenterTest
 
         // then
         assertThat( result, equalTo( String.format(
+                "// tag::config-org.neo4j.doc.SettingsDocumenterTest-Giraffe[]%n" +
                 "[[config-org.neo4j.doc.SettingsDocumenterTest-Giraffe]]%n" +
                 ".Use this group to configure giraffes%n" +
                 "ifndef::nonhtmloutput[]%n" +
@@ -185,6 +191,7 @@ public class SettingsDocumenterTest
                 "endif::nonhtmloutput[]%n" +
                 "%n" +
                 "%n" +
+                "// end::config-org.neo4j.doc.SettingsDocumenterTest-Giraffe[]%n%n" +
                 "ifndef::nonhtmloutput[]%n" +
                 "[[config_group.key.spot_count]]%n" +
                 ".group.(key).spot_count%n" +


### PR DESCRIPTION
This allows the summary table to be included separately, and have it's
reference point to the detail tables in the global settings reference.