### PR TITLE
Clarify custom id names for :ID fields in the import tool

### DIFF
--- a/import-tool/src/docs/ops/import-tool.asciidoc
+++ b/import-tool/src/docs/ops/import-tool.asciidoc
@@ -34,8 +34,8 @@ The header row of each data source specifies how the fields should be interprete
 The same delimiter is used for the header row as for the rest of the data.
 
 The header contains information for each field, with the format: `<name>:<field_type>`.
-The `<name>` is used as the property key for values, and ignored in other cases.
-The following `<field_type>` settings can be used for both nodes and relationships:
+The `<name>` is used as the property key for values and optionally for node identifiers (`<name>:ID`), and ignored in other cases.
+The following `<field_type>` settings can be used for both node and relationship properties:
 
 Property value:: Use one of `int`, `long`, `float`, `double`, `boolean`, `byte`, `short`, `char`, `string` to designate the data type.
   If no data type is given, this defaults to `string`.
@@ -56,6 +56,7 @@ ID::
   Each node must have a unique id which is used during the import.
   The ids are used to find the correct nodes when creating relationships.
   Note that the id has to be unique across all nodes in the import, even nodes with different labels.
+  Note that this field type can optionally define a name in the form of `<name>:ID`, in which case the ID will be persisted in a property called `<name>`.
 LABEL::
   Read one or more labels from this field.
   Like array values, multiple labels are separated by `;`, or by the character specified with `--array-delimiter`.
@@ -71,6 +72,9 @@ START_ID::
   The id of the start node of the relationship to create.
 END_ID::
   The id of the end node of the relationship to create.
+
+Note that neither the `START_ID` nor the `END_ID` fields take a name, i.e. the `<name>` in `<name>:START_ID` and `<name>:END_ID` is ignored.
+Even if the start and/or the end nodes have an **ID** with a specific name, it does not need to be specified at the relationships. The import tool will take care of finding the appropriate nodes.
 
 [[import-tool-id-spaces]]
 === ID spaces


### PR DESCRIPTION
I added some clarification to discuss custom node id fields (`:ID`) and the fact that users do *not* have to specify them for relationships (`:START_ID`, `:END_ID`).

Interestingly, the AsciiDoc source file has a similar note in the ["Import tool examples" section](https://github.com/neo4j/neo4j-documentation/blob/45cb5a75b8bebcadaad7c8f3a229b0fbd8f37189/import-tool/src/docs/ops/import-tool.asciidoc#import-tool-examples), but it is not deployed in the operations manual (even Google cannot find it, apart from an old operations manual PDF). Meanwhile, I cannot find source for the [set of examples](https://neo4j.com/docs/operations-manual/3.2/tutorial/import-tool/) in the 3.2 docs.

Note: I came across custom IDs while working on https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/489.

(cc-ing @petraselmer as I discussed submitting a PR with her previously)