### PR TITLE
Added Additions, Deprecations and Removals for 3.2

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -62,7 +62,7 @@ Replacement syntax for deprecated and removed features are also indicated.
 [options="header"]
 |===
 | Feature          | Type | Change | Details
-| Rule planner     | Functionality | Removed | All queries now use the cost planner
+| `CYPHER planner=rule` (Rule planner)    | Functionality | Removed | All queries now use the cost planner
 | `CREATE UNIQUE`     | Clause | Removed | Running such queries will fall back to using Cypher 3.1 (and use the rule planner)
 | `START`     | Clause | Removed | Running such queries will fall back to using Cypher 3.1 (and use the rule planner)
 | `MATCH (n)-[rs*]-() RETURN rs`     | Syntax | Deprecated | Replaced by `MATCH p=(n)-[*]-() RETURN relationships(p) AS rs`
@@ -72,6 +72,7 @@ Replacement syntax for deprecated and removed features are also indicated.
 | <<user-defined-aggregation-functions, User-defined aggregation functions>> | Functionality | Added |
 | <<query-schema-index-introduction, Composite indexes>> | Index | Added |
 | <<query-constraint-node-key, Node Key>> | Index | Added | Neo4j Enterprise Edition only
+| `CYPHER runtime=compiled` (Compiled runtime) | Functionality | Added | Neo4j Enterprise Edition only
 | <<functions-reverse-list,reverse()>> | Function  | Extended | Now also allows a list as input
 | <<functions-max, max()>>, <<functions-min, min()>> | Function  | Extended | Now also supports aggregation over a set containing both strings and numbers
 |===

--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -62,7 +62,7 @@ Replacement syntax for deprecated and removed features are also indicated.
 [options="header"]
 |===
 | Feature          | Type | Change | Details
-| `CYPHER planner=rule` (Rule planner)    | Functionality | Removed | All queries now use the cost planner
+| `CYPHER planner=rule` (Rule planner)    | Functionality | Removed | All queries now use the cost planner. Any query prepended thus will fall back to using Cypher 3.1.
 | `CREATE UNIQUE`     | Clause | Removed | Running such queries will fall back to using Cypher 3.1 (and use the rule planner)
 | `START`     | Clause | Removed | Running such queries will fall back to using Cypher 3.1 (and use the rule planner)
 | `MATCH (n)-[rs*]-() RETURN rs`     | Syntax | Deprecated | Replaced by `MATCH p=(n)-[*]-() RETURN relationships(p) AS rs`

--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -10,6 +10,7 @@ New features get added to the language continuously, and occasionally, some feat
 * <<cypher-deprecations-additions-removals, Removals, deprecations, additions and extensions>>
  ** <<cypher-deprecations-additions-removals-3.0, Version 3.0>>
  ** <<cypher-deprecations-additions-removals-3.1, Version 3.1>>
+ ** <<cypher-deprecations-additions-removals-3.2, Version 3.2>>
 * <<cypher-compatibility, Compatibility>>
 * <<cypher-versions, Supported language versions>>
 
@@ -19,6 +20,7 @@ New features get added to the language continuously, and occasionally, some feat
 
 The following tables lists all the features which have been removed, deprecated, added or extended in Cypher.
 Replacement syntax for deprecated and removed features are also indicated.
+
 
 [[cypher-deprecations-additions-removals-3.0]]
 === Version 3.0
@@ -37,6 +39,7 @@ Replacement syntax for deprecated and removed features are also indicated.
 |  <<functions-tostring, toString()>>   | Function  | Extended | Now also allows Boolean values as input
 |===
 
+
 [[cypher-deprecations-additions-removals-3.1]]
 === Version 3.1
 [options="header"]
@@ -52,6 +55,27 @@ Replacement syntax for deprecated and removed features are also indicated.
 | <<user-defined-functions, User-defined functions>> | Functionality | Added |
 | <<query-call, CALL\...YIELD\...WHERE>>   | Clause  | Extended  | Records returned by `YIELD` may be filtered further using `WHERE`
 |===
+
+
+[[cypher-deprecations-additions-removals-3.2]]
+=== Version 3.2
+[options="header"]
+|===
+| Feature          | Type | Change | Details
+| Rule planner     | Functionality | Removed | All queries now use the cost planner
+| `CREATE UNIQUE`     | Clause | Removed | Running such queries will fall back to using Cypher 3.1 (and use the rule planner)
+| `START`     | Clause | Removed | Running such queries will fall back to using Cypher 3.1 (and use the rule planner)
+| `MATCH (n)-[rs*]-() RETURN rs`     | Syntax | Deprecated | Replaced by `MATCH p=(n)-[*]-() RETURN relationships(p) AS rs`
+| `MATCH (n)-[:A\|:B\|:C {foo: 'bar'}]-() RETURN n`     | Syntax | Deprecated | Replaced by `MATCH (n)-[:A\|B\|C {foo: 'bar'}]-() RETURN n`
+| `MATCH (n)-[x:A\|:B\|:C]-() RETURN n`     | Syntax | Deprecated | Replaced by `MATCH (n)-[x:A\|B\|C]-() RETURN n`
+| `MATCH (n)-[x:A\|:B\|:C*]-() RETURN n`     | Syntax | Deprecated | Replaced by `MATCH (n)-[x:A\|B\|C*]-() RETURN n`
+| <<user-defined-aggregation-functions, User-defined aggregation functions>> | Functionality | Added |
+| <<query-schema-index-introduction, Composite indexes>> | Index | Added |
+| <<query-constraint-node-key, Node Key>> | Index | Added | Neo4j Enterprise Edition only
+| <<functions-reverse-list,reverse()>> | Function  | Extended | Now also allows a list as input
+| <<functions-max, max()>>, <<functions-min, min()>> | Function  | Extended | Now also supports aggregation over a set containing both strings and numbers
+|===
+
 
 [[cypher-compatibility]]
 == Compatibility
@@ -80,10 +104,10 @@ RETURN n
 [[cypher-versions]]
 == Supported language versions
 
-Neo4j 3.1 supports the following versions of the Cypher language:
+Neo4j 3.2 supports the following versions of the Cypher language:
 
+* Neo4j Cypher 3.2
 * Neo4j Cypher 3.1
-* Neo4j Cypher 3.0
 * Neo4j Cypher 2.3
 
 [TIP]


### PR DESCRIPTION
This must be forward-merged too.
This has a complex dependency chain.

The following PRs need to be merged (and fwd-merged) before this PR can be merged (and a lot of rebasing will ensue):

- https://github.com/neo-technology/neo4j-manual-modeling/pull/336

- https://github.com/neo4j/neo4j-documentation/pull/129 (this deletes the old compat. files and adds the new file)

- https://github.com/neo4j/neo4j-documentation/pull/127 (depends on the reverse function for lists)

Moreover, although this PR purportedly _adds_ the "deprecations-additions....asciidoc" file, this ought already to be in existence thanks to PR 129. Therefore, what ought to happen here is that the contents of the "deprec..." file ought to be copied **in its entirety** to the version here. 