### PR TITLE
Added deprecations, additions, removals and comp. info for 3.3

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -84,7 +84,7 @@ Replacement syntax for deprecated and removed features are also indicated.
 [options="header"]
 |===
 | Feature          | Type | Change | Details
-| `START`     | Clause | Removed | Replaced by the built-in procedures `db.nodeManualIndexSeek`, `db.nodeManualIndexSearch`, `db.relationshipManualIndexSeek`, and `db.relationshipManualIndexSearch`
+| `START`     | Clause | Removed | As in Cypher 3.2, any queries using the `START` clause will revert back to Cypher 3.1 `planner=rule`. However, there are now built-in procedures for accessing explicit indexes that will enable users to use the current version of Cypher and the cost planner together with these indexes. An example of this is `CALL db.index.explicit.searchNodes('my_index','email:me*')`.
 | `CYPHER runtime=slotted` (Faster interpreted runtime) | Functionality | Added | Neo4j Enterprise Edition only
 | <<functions-max, max()>>, <<functions-min, min()>> | Function  | Extended | Now also supports aggregation over a set containing lists of strings and numbers
 |===
@@ -100,17 +100,18 @@ There are two ways to select which version to use in queries.
 You can configure your database with the configuration parameter `cypher.default_language_version`, and enter which version you'd like to use (see <<cypher-versions>>).
 Every Cypher query will use this version, provided the query hasn't explicitly been configured as described in the next item below.
 
-. Setting a version on a query-by-query basis:
+. Setting a version on a query by query basis:
 The other method is to set the version for a particular query.
 Prepending a query with `CYPHER 2.3` will execute the query with the version of Cypher included in Neo4j 2.3.
 
-Below is an example using the `START` clause to access a legacy index:
+Below is an example using the `has()` function:
 
 [source, cypher]
 ----
 CYPHER 2.3
-START n=node:nodes(name = "A")
-RETURN n
+MATCH (n:Person)
+WHERE has(n.age)
+RETURN n.name, n.age
 ----
 
 

--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -85,6 +85,7 @@ Replacement syntax for deprecated and removed features are also indicated.
 |===
 | Feature          | Type | Change | Details
 | `START`     | Clause | Removed | Replaced by the built-in procedures `db.nodeManualIndexSeek`, `db.nodeManualIndexSearch`, `db.relationshipManualIndexSeek`, and `db.relationshipManualIndexSearch`
+| `CYPHER runtime=slotted` (Faster interpreted runtime) | Functionality | Added | Neo4j Enterprise Edition only
 | <<functions-max, max()>>, <<functions-min, min()>> | Function  | Extended | Now also supports aggregation over a set containing lists of strings and numbers
 |===
 

--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -11,6 +11,7 @@ New features get added to the language continuously, and occasionally, some feat
  ** <<cypher-deprecations-additions-removals-3.0, Version 3.0>>
  ** <<cypher-deprecations-additions-removals-3.1, Version 3.1>>
  ** <<cypher-deprecations-additions-removals-3.2, Version 3.2>>
+ ** <<cypher-deprecations-additions-removals-3.3, Version 3.3>>
 * <<cypher-compatibility, Compatibility>>
 * <<cypher-versions, Supported language versions>>
 
@@ -78,6 +79,16 @@ Replacement syntax for deprecated and removed features are also indicated.
 |===
 
 
+[[cypher-deprecations-additions-removals-3.3]]
+=== Version 3.3
+[options="header"]
+|===
+| Feature          | Type | Change | Details
+| `START`     | Clause | Removed | Replaced by the built-in procedures `db.nodeManualIndexSeek`, `db.nodeManualIndexSearch`, `db.relationshipManualIndexSeek`, and `db.relationshipManualIndexSearch`
+| <<functions-max, max()>>, <<functions-min, min()>> | Function  | Extended | Now also supports aggregation over a set containing lists of strings and numbers
+|===
+
+
 [[cypher-compatibility]]
 == Compatibility
 
@@ -105,8 +116,9 @@ RETURN n
 [[cypher-versions]]
 == Supported language versions
 
-Neo4j 3.2 supports the following versions of the Cypher language:
+Neo4j 3.3 supports the following versions of the Cypher language:
 
+* Neo4j Cypher 3.3
 * Neo4j Cypher 3.2
 * Neo4j Cypher 3.1
 * Neo4j Cypher 2.3


### PR DESCRIPTION
This must be forward-merged too.
This has a complex dependency chain.

The following PRs need to be merged (and fwd-merged) before this PR can be merged (and a lot of rebasing will ensue):

neo-technology/neo4j-manual-modeling#336

#129 (this deletes the old compat. files and adds the new file)

#127 (depends on the reverse function for lists)

https://github.com/neo4j/neo4j-documentation/pull/130 (this is the 3.2 version of this work, which also requires the above PRs to be in place)

Moreover, although this PR purportedly adds the "deprecations-additions....asciidoc" file, this ought already to be in existence thanks to PR 129. Therefore, what ought to happen here is that the contents of the "deprec..." file ought to be copied **in its entirety** to the version here.