### PR TITLE
3.2 Fixes: removal of RULE planner, START and CREATE UNIQUE workarounds; Preparser options

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/clause.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/clause.asciidoc
@@ -107,7 +107,6 @@ These comprise clauses that both read data from and write data to the database.
 |--- <<query-merge-on-create-on-match,ON CREATE>>   | Used in conjunction with `MERGE`, this write sub-clause specifies the actions to take if the pattern needs to be created.
 |--- <<query-merge-on-create-on-match,ON MATCH>>    | Used in conjunction with `MERGE`, this write sub-clause specifies the actions to take if the pattern already exists.
 |<<query-call,CALL [...YIELD]>>         | Invoke a procedure deployed in the database and return any results.
-|<<query-create-unique,CREATE UNIQUE>>      |   A mixture of `MATCH` and `CREATE`, matching what it can, and creating what is missing.
 |===
 
 

--- a/cypher/cypher-docs/src/docs/dev/clause.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/clause.asciidoc
@@ -30,7 +30,6 @@ This set is refined and augmented by subsequent parts of the query.
 |Clause                                     |   Description
 |<<query-match,MATCH>>                      |   Specify the patterns to search for in the database.
 |<<query-optional-match,OPTIONAL MATCH>>    |   Specify the patterns to search for in the database while using `nulls` for missing parts of the pattern.
-|<<query-start,START>>                      |   Find starting points through legacy indexes.
 |===
 
 

--- a/cypher/cypher-docs/src/docs/dev/clause.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/clause.asciidoc
@@ -150,8 +150,6 @@ include::ql/query-match.adoc[leveloffset=+1]
 
 include::ql/query-optional-match.adoc[leveloffset=+1]
 
-include::ql/start/index.asciidoc[leveloffset=+1]
-
 //Projecting
 include::ql/query-return.adoc[leveloffset=+1]
 
@@ -183,8 +181,6 @@ include::ql/foreach/index.asciidoc[leveloffset=+1]
 include::ql/merge/index.asciidoc[leveloffset=+1]
 
 include::ql/call/index.asciidoc[leveloffset=+1]
-
-include::ql/create-unique/index.asciidoc[leveloffset=+1]
 
 //Set
 include::ql/query-union.adoc[leveloffset=+1]

--- a/cypher/cypher-docs/src/docs/dev/execution-plan-groups/update.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/execution-plan-groups/update.asciidoc
@@ -6,15 +6,13 @@ These operators are used in queries that update the graph.
 
 Operators:
 
+* <<query-plan-create-node, CreateNode>>
 * <<query-plan-constraint-operation, Constraint operation>>
 * <<query-plan-empty-result, EmptyResult>>
-* <<query-plan-update-graph, UpdateGraph>>
-* <<query-plan-merge-into, Merge(Into)>>
+
+include::../ql/query-plan/create-node.asciidoc[]
 
 include::../ql/query-plan/constraint-operation.asciidoc[]
 
 include::../ql/query-plan/empty-result.asciidoc[]
 
-include::../ql/query-plan/update-graph.asciidoc[]
-
-include::../ql/query-plan/merge-into.asciidoc[]

--- a/cypher/cypher-docs/src/docs/dev/execution-plans.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/execution-plans.asciidoc
@@ -57,6 +57,7 @@ This table comprises all the execution plan operators ordered lexicographically.
 | <<query-plan-assert-same-node, AssertSameNode>>                            | Combining | This operator is used to ensure that no uniqueness constraints are violated.
 | <<query-plan-conditional-apply, ConditionalApply>>                         | Combining | Checks whether a variable is not `null`, and if so the right-hand side will be executed.
 | <<query-plan-constraint-operation, Constraint operation>>                  | Update | Creates a constraint on a (label,property) pair.
+| <<query-plan-create-node, CreateNode>>                                   | Update | Creates a node.
 | <<query-plan-directed-relationship-by-id-seek, DirectedRelationshipByIdSeek>>  | Starting point | Reads one or more relationships by id from the relationship store.
 | <<query-plan-distinct, Distinct>>                                          | Row | Removes duplicate rows from the incoming stream of rows.
 | <<query-plan-eager, Eager>>                                                | Row | For isolation purposes, `Eager` ensures that operations affecting subsequent operations are executed fully for the whole dataset before continuing execution.
@@ -68,7 +69,6 @@ This table comprises all the execution plan operators ordered lexicographically.
 | <<query-plan-let-anti-semi-apply, LetAntiSemiApply>>                       | Combining | Tests for the absence of a pattern predicate in queries containing multiple pattern predicates.
 | <<query-plan-let-semi-apply, LetSemiApply>>                                | Combining | Tests for the existence of a pattern predicate in queries containing multiple pattern predicates.
 | <<query-plan-limit, Limit>>                                                | Row | Returns the first 'n' rows from the incoming input.
-| <<query-plan-merge-into, Merge(Into)>>                                     | Update | When both the start and end node have already been found, `Merge(Into)` is used to find all connecting relationships or creating a new relationship between the two nodes.
 | <<query-plan-node-by-id-seek, NodeByIdSeek>>                               | Starting point | Reads one or more nodes by id from the node store.
 | <<query-plan-node-by-label-scan, NodeByLabelScan>>                         | Starting point | Using the label index, fetches all nodes with a specific label on them from the node label index.
 | <<query-plan-node-count-from-count-store, NodeCountFromCountStore>>        | Row | Uses the count store to answer questions about node counts.
@@ -92,7 +92,6 @@ This table comprises all the execution plan operators ordered lexicographically.
 | <<query-plan-undirected-relationship-by-id-seek, UndirectedRelationshipByIdSeek>> | Starting point | Reads one or more relationships by id from the relationship store.
 | <<query-plan-union, Union>>                                                | Row | Concatenates the results from the right plan after the results of the left plan.
 | <<query-plan-unwind, Unwind>>                                              | Row | Takes a list of values and returns one row per item in the list.
-| <<query-plan-update-graph, UpdateGraph>>                                   | Update | Applies updates to the graph.
 |===
 
 

--- a/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
@@ -205,6 +205,6 @@ This section comprises a glossary of all the keywords -- grouped by category and
 | <<cypher-version, CYPHER $version query>>  | Version | This will force `'query'` to use Neo4j Cypher `$version`. The default is `3.2`.
 | <<cypher-planner, CYPHER planner=rule query>> | Planner |  This will force `'query'` to use the rule planner. As the rule planner has been removed in 3.2, doing this will cause `'query'` to fall back to using Cypher 3.1.
 | <<cypher-planner, CYPHER planner=cost query>> | Planner | Neo4j {neo4j-version} uses the cost planner for all queries.
-| <<cypher-runtime, CYPHER runtime=interpreted query>> | Runtime | This will force `'query'` to use the interpreted runtime. This is the only option in Neo4j Community Edition.
-| <<cypher-runtime, CYPHER runtime=compiled query>> | Runtime | This will force `'query'` to use the compiled runtime, if it is able to do so (otherwise `'query'` falls back to using the interpreted runtime). This is only available in Neo4j Enterprise Edition.
+| <<cypher-runtime, CYPHER runtime=interpreted query>> | Runtime | This will cause the query execution engine to disregard the compiled runtime, and therefore use the interpreted runtime. This is the only option in Neo4j Community Edition.
+| <<cypher-runtime, CYPHER runtime=compiled query>> | Runtime | This will cause the query execution engine to use the compiled runtime if it supports `'query'`, and fall back to using the interpreted runtime if it does not. This is only available in Neo4j Enterprise Edition.
 |===

--- a/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
@@ -49,7 +49,6 @@ This section comprises a glossary of all the keywords -- grouped by category and
 |<<query-return, RETURN ... [AS]>>                    | Projecting   |  Defines what to include in the query result set.
 |<<query-set, SET>>                          | Writing     |  Update labels on nodes and properties on nodes and relationships.
 |<<query-skip, SKIP>>                            | Reading/Writing | A sub-clause defining from which row to start including the rows in the output.
-|<<query-start, START>>                      | Reading      |  Find starting points through legacy indexes.
 |<<query-union, UNION>>                      | Set operations   |  Combines the result of multiple queries. Duplicates are removed.
 |<<query-union, UNION ALL>>                      | Set operations   |  Combines the result of multiple queries. Duplicates are retained.
 |<<query-unwind, UNWIND ... [AS]>>                    | Projecting   |  Expands a list into a sequence of rows.

--- a/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
@@ -203,10 +203,10 @@ This section comprises a glossary of all the keywords -- grouped by category and
 
 [options="header"]
 |===
-|Name           | Description
-| <<cypher-version, CYPHER $version query>>  | This will force `'query'` to use Neo4j Cypher `$version`. The default is `3.2`.
-| <<cypher-planner, CYPHER planner=rule query>> | This will force `'query'` to use the rule planner. As the rule planner has been removed in 3.2, doing this will cause `'query'` to fall back to using Cypher 3.1.
-| <<cypher-planner, CYPHER planner=cost query>> | Neo4j {neo4j-version} uses the cost planner for all queries.
-| <<cypher-runtime, CYPHER runtime=interpreted query>> | This will force `'query'` to use the interpreted runtime. This is the only option in Neo4j Community Edition.
-| <<cypher-runtime, CYPHER runtime=compiled query>> | This will force `'query'` to use the compiled runtime, if it is able to do so (otherwise `'query'` falls back to using the interpreted runtime). This is only available in Neo4j Enterprise Edition.
+|Name           | Type | Description
+| <<cypher-version, CYPHER $version query>>  | Version | This will force `'query'` to use Neo4j Cypher `$version`. The default is `3.2`.
+| <<cypher-planner, CYPHER planner=rule query>> | Planner |  This will force `'query'` to use the rule planner. As the rule planner has been removed in 3.2, doing this will cause `'query'` to fall back to using Cypher 3.1.
+| <<cypher-planner, CYPHER planner=cost query>> | Planner | Neo4j {neo4j-version} uses the cost planner for all queries.
+| <<cypher-runtime, CYPHER runtime=interpreted query>> | Runtime | This will force `'query'` to use the interpreted runtime. This is the only option in Neo4j Community Edition.
+| <<cypher-runtime, CYPHER runtime=compiled query>> | Runtime | This will force `'query'` to use the compiled runtime, if it is able to do so (otherwise `'query'` falls back to using the interpreted runtime). This is only available in Neo4j Enterprise Edition.
 |===

--- a/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
@@ -203,10 +203,10 @@ This section comprises a glossary of all the keywords -- grouped by category and
 
 [options="header"]
 |===
-|Name           | Type | Description
-| <<cypher-version, CYPHER $version query>>  | Version | This will force `'query'` to use Neo4j Cypher `$version`. The default is `3.1`.
-| <<cypher-planner, CYPHER planner=rule query>> | Planner | This will force `'query'` to use the rule planner.
-| <<cypher-planner, CYPHER planner=cost query>> | Planner | This will force `'query'` to use the cost planner. This is the default planner.
+|Name           | Description
+| <<cypher-version, CYPHER $version query>>  | This will force `'query'` to use Neo4j Cypher `$version`. The default is `3.2`.
+| <<cypher-planner, CYPHER planner=rule query>> | This will force `'query'` to use the rule planner. As the rule planner has been removed in 3.2, doing this will cause `'query'` to fall back to using Cypher 3.1.
+| <<cypher-planner, CYPHER planner=cost query>> | Neo4j {neo4j-version} uses the cost planner for all queries.
+| <<cypher-runtime, CYPHER runtime=interpreted query>> | This will force `'query'` to use the interpreted runtime. This is the only option in Neo4j Community Edition.
+| <<cypher-runtime, CYPHER runtime=compiled query>> | This will force `'query'` to use the compiled runtime, if it is able to do so (otherwise `'query'` falls back to using the interpreted runtime). This is only available in Neo4j Enterprise Edition.
 |===
-
-

--- a/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
@@ -27,7 +27,6 @@ This section comprises a glossary of all the keywords -- grouped by category and
 |<<constraints-create-uniqueness-constraint, CREATE CONSTRAINT ON (n:Label) ASSERT n.property IS UNIQUE>>  |  Schema | Create a constraint ensuring the uniqueness of the combination of node label and property value for a particular property key across all nodes.
 |<<schema-index-create-a-single-property-index, CREATE INDEX ON :Label(property)>>  | Schema  | Create an index on all nodes with a particular label and a single property; i.e. create a single-property index.
 |<<create-a-composite-index, CREATE INDEX ON :Label(prop1, ..., propN)>>  | Schema  | Create an index on all nodes with a particular label and multiple properties; i.e. create a composite index.
-|<<query-create-unique, CREATE UNIQUE>>      | Reading/Writing     |  A mixture of `MATCH` and `CREATE`, matching what it can, and creating what is missing.
 |<<query-delete, DELETE>>                    | Writing     |  Delete graph elements — nodes, relationships or paths. Any node to be deleted must also have all associated relationships explicitly deleted.
 |<<query-delete, DETACH DELETE>>             | Writing     |  Delete a node or set of nodes. All associated relationships will automatically be deleted.
 |<<constraints-drop-node-property-existence-constraint, DROP CONSTRAINT ON (n:Label) ASSERT exists(n.property)>>      | Schema   | Drop a constraint ensuring that all nodes with a particular label have a certain property.

--- a/cypher/cypher-docs/src/docs/dev/ql/create-unique/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/create-unique/index.asciidoc
@@ -4,6 +4,12 @@
 [abstract]
 The `CREATE UNIQUE` clause is a mix of `MATCH` and `CREATE` -- it will match what it can, and create what is missing.
 
+[IMPORTANT]
+The `CREATE UNIQUE` clause was removed in Cypher 3.2.
+Using the `CREATE UNIQUE` clause will cause the query to fall back to using Cypher 3.1.
+Use `<<query-merge, MERGE>>` instead of `CREATE UNIQUE`; refer to the <<query-create-unique-introduction, Introduction>> for an example of how to achieve the same level of node and relationship uniqueness.
+
+
 * <<query-create-unique-introduction, Introduction>>
 * <<query-create-unique-nodes, Create unique nodes>>
  ** <<create-unique-create-node-if-missing, Create node if missing>>
@@ -18,21 +24,53 @@ The `CREATE UNIQUE` clause is a mix of `MATCH` and `CREATE` -- it will match wha
 [[query-create-unique-introduction]]
 == Introduction
 
-[TIP]
-`<<query-merge, MERGE>>` might be what you want to use instead of `CREATE UNIQUE`.
-Note however, that `MERGE` doesn't give as strong guarantees for relationships being unique.
-
 `CREATE UNIQUE` is in the middle of `MATCH` and `CREATE` -- it will match what it can, and create what is missing.
-`CREATE UNIQUE` will always make the least change possible to the graph -- if it can use parts of the existing graph, it will.
 
-Another difference to `MATCH` is that `CREATE UNIQUE` assumes the pattern to be unique.
-If multiple matching subgraphs are found an error will be generated.
+We show in the following example how to express using `MERGE` the same level of uniqueness guaranteed by `CREATE UNIQUE` for nodes and relationships.
 
-[TIP]
-In the `CREATE UNIQUE` clause, patterns are used a lot.
-Read <<cypher-patterns>> for an introduction.
+Assume the original set of queries is given by:
 
-The examples use the following graph:
+[source, cypher]
+----
+MERGE (p:Person {name: 'Joe'})
+RETURN p
+
+MATCH (a:Person {name: 'Joe'})
+CREATE UNIQUE (a)-[r:LIKES]->(b:Person {name: 'Jill'})-[r1:EATS]->(f:Food {name: 'Margarita Pizza'})
+RETURN a
+
+MATCH (a:Person {name: 'Joe'})
+CREATE UNIQUE (a)-[r:LIKES]->(b:Person {name: 'Jill'})-[r1:EATS]->(f:Food {name: 'Banana'})
+RETURN a
+----
+
+This will create two `:Person` nodes, a `:LIKES` relationship between them, and two `:EATS` relationships from one of the `:Person` nodes to two `:Food` nodes.
+No node or relationship is duplicated.
+
+The following set of queries -- using `MERGE` -- will achieve the same result:
+
+[source, cypher]
+----
+MERGE (p:Person {name: 'Joe'})
+RETURN p
+
+MATCH (a:Person {name: 'Joe'})
+MERGE (b:Person {name: 'Jill'})
+MERGE (a)-[r:LIKES]->(b)
+MERGE (b)-[r1:EATS]->(f:Food {name: 'Margarita Pizza'})
+RETURN a
+
+MATCH (a:Person {name: 'Joe'})
+MERGE (b:Person {name: 'Jill'})
+MERGE (a)-[r:LIKES]->(b)
+MERGE (b)-[r1:EATS]->(f:Food {name: 'Banana'})
+RETURN a
+
+----
+
+We note that all these queries can also be combined into a single, larger query.
+
+The `CREATE UNIQUE` examples below use the following graph:
 
 include::includes/cypher-createunique-graph.asciidoc[]
 

--- a/cypher/cypher-docs/src/docs/dev/ql/foreach/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/foreach/index.asciidoc
@@ -18,7 +18,7 @@ It allows you to do updating commands on elements in a path, or a list created b
 The variable context within the foreach parenthesis is separate from the one outside it.
 This means that if you `CREATE` a node variable within a `FOREACH`, you will _not_ be able to use it outside of the foreach statement, unless you match to find it.
 
-Within the `FOREACH` parentheses, you can do any of the updating commands -- `CREATE`, `CREATE UNIQUE`, `MERGE`, `DELETE`, and `FOREACH`.
+Within the `FOREACH` parentheses, you can do any of the updating commands -- `CREATE`, `MERGE`, `DELETE`, and `FOREACH`.
 
 If you want to execute an additional `MATCH` for each element in a list then `UNWIND` (see <<query-unwind>>) would be a more appropriate command.
 

--- a/cypher/cypher-docs/src/docs/dev/ql/merge/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/merge/index.asciidoc
@@ -50,10 +50,6 @@ If there are multiple matches, they will all be passed on to later stages of the
 The last part of `MERGE` is the `ON CREATE` and `ON MATCH`.
 These allow a query to express additional changes to the properties of a node or relationship, depending on if the element was `MATCH` -ed in the database or if it was `CREATE` -ed.
 
-The rule planner (see <<how-are-queries-executed>>) expands a `MERGE` pattern from the end point that has the variable with the lowest lexicographical order.
-This means that it might choose a suboptimal expansion path, expanding from a node with a higher degree.
-The pattern `MERGE (a:A)-[:R]->(b:B)` will always expand from `a` to `b`, so if it is known that `b` nodes are a better choice for start point, renaming variables could improve performance.
-
 The following graph is used for the examples below:
 
 .Graph

--- a/cypher/cypher-docs/src/docs/dev/ql/start/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/start/index.asciidoc
@@ -5,7 +5,9 @@
 Find starting points through legacy indexes.
 
 [IMPORTANT]
-The `START` clause should only be used when accessing legacy indexes.
+The `START` clause was removed in Cypher 3.2.
+Using the `START` clause will cause the query to fall back to using Cypher 3.1.
+`START` should only be used when accessing legacy indexes.
 In all other cases, use `MATCH` instead (see <<query-match>>).
 
 * <<start-node-by-index-seek, Node by index seek>>

--- a/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
@@ -53,40 +53,12 @@ Here we detail the available versions:
 |===
 | Query option | Description | Default?
 | `2.3` | This will force the query to use Neo4j Cypher 2.3.  |
-| `3.0` | This will force the query to use Neo4j Cypher 3.0. |
-| `3.1` | This will force the query to use Neo4j Cypher 3.1. As this is the default version, it is not necessary to use this option explicitly. | X
-|===
-
-[[cypher-planner]]
-=== Cypher planner
-
-_***XXTODO by Docs Team - change this heading to something like 'Preparser options' (this is what they are called internally), or something more reader-friendly (if a term other than 'preparser' is decided upon, please also change accordingly in the text). This section no longer deals with 'how queries are executed' per se. More of that content will be added by me later on. END TODO***_
-
-[abstract]
---
-This section describes the preparser options available in Cypher.
---
-
-Query execution can be fine-tuned through the use of _preparser options_.
-In order to use one or more of these options, the query must be prepended with `CYPHER`, followed by the preparser option(s), as exemplified thus: `CYPHER preparser-option1 [further preparser options] query`.
-
-
-[[cypher-preparser-version]]
-=== Cypher version
-
-Occasionally, there is a requirement to use a previous version of the Cypher compiler when running a query.
-Here we detail the available versions:
-
-[options="header"]
-|===
-| Preparser option | Description | Default?
-| `2.3` | This will force the query to use Neo4j Cypher 2.3.  |
 | `3.1` | This will force the query to use Neo4j Cypher 3.1. |
 | `3.2` | This will force the query to use Neo4j Cypher 3.2. As this is the default version, it is not necessary to use this option explicitly. | X
 |===
 
 
-[[cypher-preparser-planner]]
+[[cypher-planner]]
 === Cypher planner
 
 Each query is turned into an execution plan by something called the _execution planner_.
@@ -100,7 +72,7 @@ The rule planner was removed in Neo4j 3.2 owing to inferior query execution perf
 
 [options="header"]
 |===
-| Preparser option | Description | Default?
+| Option         | Description | Default?
 | `planner=rule` | This will force the query to use the rule planner, and will therefore cause the query to fall back to using Cypher 3.1.  |
 | `planner=cost` | Neo4j {neo4j-version} uses the cost planner for _all_ queries, and therefore it is not necessary to use this option explicitly. | X
 |===
@@ -114,7 +86,7 @@ When Cypher is building execution plans, it looks at the schema to see if it can
 These index decisions are only valid until the schema changes, so adding or removing indexes leads to the execution plan cache being flushed.
 
 
-[[cypher-preparser-runtime]]
+[[cypher-runtime]]
 === Cypher runtime
 
 Using the execution plan, the query is executed -- and records returned -- by the query engine, or _runtime_.
@@ -133,7 +105,7 @@ The compiled runtime is only available in Neo4j Enterprise Edition.
 
 [options="header"]
 |===
-| Preparser option | Description | Default?
+| Option | Description | Default?
 | `runtime=interpreted` | This will cause the query execution engine to disregard the compiled runtime, and therefore use the interpreted runtime. | This is the default option for some queries in Enterprise Edition, and the only option for all queries in Community Edition (so it is not necessary to use this option in Community Edition).
 | `runtime=compiled` | This will cause the query execution engine to use the compiled runtime if it supports the query, and fall back to using the interpreted runtime if it does not. | This is the default option for some queries in Enterprise Edition only.
 |===

--- a/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
@@ -62,26 +62,17 @@ Here we detail the available versions:
 
 Each query is turned into an execution plan by something called the _execution planner_.
 The execution plan tells Neo4j which operations to perform when executing the query.
-Two different execution planning strategies are included in Neo4j:
 
-Rule::
-This planner has rules that are used to produce execution plans.
-The planner considers available indexes, but does not use statistical information to guide the query compilation.
+Neo4j uses a _cost_-based execution planning strategy (known as the 'cost' planner): the statistics service in Neo4j is used to assign a cost to alternative plans and picks the cheapest one.
 
-Cost::
-This planner uses the statistics service in Neo4j to assign cost to alternative plans and picks the cheapest one.
-Compared with the rule planner, the cost planner results in superior query execution performance.
+All previous versions of Neo4j also included a rule-based planner, which used rules to produce execution plans.
+This planner considered available indexes, but did not use statistical information to guide the query compilation.
+The rule planner was removed in Neo4j 3.2 owing to inferior query performance when compared with the cost planner.
 
-While this should lead to superior execution plans in most cases, it is still under development.
-
-[options="header"]
-|===
-| Query option | Description | Default?
-| `planner=rule` | This will force the query to use the rule planner.  |
-| `planner=cost` | This will force the query to use the cost planner. As this is the default planner, it is not necessary to use this option explicitly. | X
-|===
-
-It is also possible to change the default planner by using the `cypher.planner` configuration setting (see <<operations-manual#config_cypher.planner, Operations Manual -> Configuration Settings>>).
+[NOTE]
+Neo4j {neo4j-version} uses the cost planner for _all_ queries.
+If required, you can force it to use the rule planner by using the `cypher.planner` configuration setting (see <<operations-manual#config_cypher.planner, Operations Manual -> Configuration Settings>>), or by prepending your query with `CYPHER planner=rule`.
+However, doing this will cause the query to fall back to using Cypher 3.1.
 
 You can see which planner was used by looking at the execution plan.
 

--- a/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
@@ -96,7 +96,7 @@ Neo4j uses a _cost_-based execution planning strategy (known as the 'cost' plann
 
 All previous versions of Neo4j also included a rule-based planner, which used rules to produce execution plans.
 This planner considered available indexes, but did not use statistical information to guide the query compilation.
-The rule planner was removed in Neo4j 3.2 owing to inferior query performance when compared with the cost planner.
+The rule planner was removed in Neo4j 3.2 owing to inferior query execution performance when compared with the cost planner.
 
 [options="header"]
 |===
@@ -105,7 +105,7 @@ The rule planner was removed in Neo4j 3.2 owing to inferior query performance wh
 | `planner=cost` | Neo4j {neo4j-version} uses the cost planner for _all_ queries, and therefore it is not necessary to use this option explicitly. | X
 |===
 
-It is also possible to set the default planner by using the `cypher.planner` configuration setting (see <<operations-manual#config_cypher.planner, Operations Manual -> Configuration Settings>>).
+It is also possible to change the default planner by using the `cypher.planner` configuration setting (see <<operations-manual#config_cypher.planner, Operations Manual -> Configuration Settings>>).
 
 You can see which planner was used by looking at the execution plan.
 
@@ -125,8 +125,8 @@ In this runtime, the operators in the execution plan are chained together in a t
 The tree thus comprises nested iterators, and the records are streamed in a pipelined manner from the top iterator, which pulls from the next iterator and so on.
 
 Compiled::
-Algorithms are employed to group intelligently the operators in the execution plan in order to generate new combinations and orders of execution which are optimised for performance and memory usage.
-While this should lead to superior performance in most cases, it is still under development.
+Algorithms are employed to intelligently group the operators in the execution plan in order to generate new combinations and orders of execution which are optimised for performance and memory usage.
+While this should lead to superior performance in most cases, it is still under development and does not support all possible operators or queries.
 
 [NOTE]
 The compiled runtime is only available in Neo4j Enterprise Edition.
@@ -134,8 +134,8 @@ The compiled runtime is only available in Neo4j Enterprise Edition.
 [options="header"]
 |===
 | Preparser option | Description | Default?
-| `runtime=interpreted` | This will force the query to use the interpreted runtime.  | This is the default option for some queries in Enterprise Edition, and the only option for all queries in Community Edition (so it is not necessary to use this option in Community Edition).
-| `runtime=compiled` | This will force the query to use the compiled runtime. | This is the default option for some queries in Enterprise Edition only. Setting this option for a query that does not support the compiled runtime will cause the query to fall back to using the interpreted runtime.
+| `runtime=interpreted` | This will cause the query execution engine to disregard the compiled runtime, and therefore use the interpreted runtime. | This is the default option for some queries in Enterprise Edition, and the only option for all queries in Community Edition (so it is not necessary to use this option in Community Edition).
+| `runtime=compiled` | This will cause the query execution engine to use the compiled runtime if it supports the query, and fall back to using the interpreted runtime if it does not. | This is the default option for some queries in Enterprise Edition only.
 |===
 
 [[how-do-i-profile-a-query]]

--- a/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
@@ -67,8 +67,8 @@ _***XXTODO by Docs Team - change this heading to something like 'Preparser optio
 This section describes the preparser options available in Cypher.
 --
 
-Queries are able to be fine-tuned through the use of _preparser options_.
-If there is a requirement to use one or more of these options, the query must be prepended with `CYPHER`, followed by the preparser option(s), as exemplified thus: `CYPHER preparser-option1 [further preparser options] query`.
+Query execution can be fine-tuned through the use of _preparser options_.
+In order to use one or more of these options, the query must be prepended with `CYPHER`, followed by the preparser option(s), as exemplified thus: `CYPHER preparser-option1 [further preparser options] query`.
 
 
 [[cypher-preparser-version]]
@@ -105,7 +105,7 @@ The rule planner was removed in Neo4j 3.2 owing to inferior query performance wh
 | `planner=cost` | Neo4j {neo4j-version} uses the cost planner for _all_ queries, and therefore it is not necessary to use this option explicitly. | X
 |===
 
-It is also possible to force queries to use a specific planner by using the `cypher.planner` configuration setting (see <<operations-manual#config_cypher.planner, Operations Manual -> Configuration Settings>>).
+It is also possible to set the default planner by using the `cypher.planner` configuration setting (see <<operations-manual#config_cypher.planner, Operations Manual -> Configuration Settings>>).
 
 You can see which planner was used by looking at the execution plan.
 

--- a/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
@@ -60,6 +60,35 @@ Here we detail the available versions:
 [[cypher-planner]]
 === Cypher planner
 
+_***XXTODO by Docs Team - change this heading to something like 'Preparser options' (this is what they are called internally), or something more reader-friendly (if a term other than 'preparser' is decided upon, please also change accordingly in the text). This section no longer deals with 'how queries are executed' per se. More of that content will be added by me later on. END TODO***_
+
+[abstract]
+--
+This section describes the preparser options available in Cypher.
+--
+
+Queries are able to be fine-tuned through the use of _preparser options_.
+If there is a requirement to use one or more of these options, the query must be prepended with `CYPHER`, followed by the preparser option(s), as exemplified thus: `CYPHER preparser-option1 [further preparser options] query`.
+
+
+[[cypher-preparser-version]]
+=== Cypher version
+
+Occasionally, there is a requirement to use a previous version of the Cypher compiler when running a query.
+Here we detail the available versions:
+
+[options="header"]
+|===
+| Preparser option | Description | Default?
+| `2.3` | This will force the query to use Neo4j Cypher 2.3.  |
+| `3.1` | This will force the query to use Neo4j Cypher 3.1. |
+| `3.2` | This will force the query to use Neo4j Cypher 3.2. As this is the default version, it is not necessary to use this option explicitly. | X
+|===
+
+
+[[cypher-preparser-planner]]
+=== Cypher planner
+
 Each query is turned into an execution plan by something called the _execution planner_.
 The execution plan tells Neo4j which operations to perform when executing the query.
 
@@ -69,10 +98,14 @@ All previous versions of Neo4j also included a rule-based planner, which used ru
 This planner considered available indexes, but did not use statistical information to guide the query compilation.
 The rule planner was removed in Neo4j 3.2 owing to inferior query performance when compared with the cost planner.
 
-[NOTE]
-Neo4j {neo4j-version} uses the cost planner for _all_ queries.
-If required, you can force it to use the rule planner by using the `cypher.planner` configuration setting (see <<operations-manual#config_cypher.planner, Operations Manual -> Configuration Settings>>), or by prepending your query with `CYPHER planner=rule`.
-However, doing this will cause the query to fall back to using Cypher 3.1.
+[options="header"]
+|===
+| Preparser option | Description | Default?
+| `planner=rule` | This will force the query to use the rule planner, and will therefore cause the query to fall back to using Cypher 3.1.  |
+| `planner=cost` | Neo4j {neo4j-version} uses the cost planner for _all_ queries, and therefore it is not necessary to use this option explicitly. | X
+|===
+
+It is also possible to force queries to use a specific planner by using the `cypher.planner` configuration setting (see <<operations-manual#config_cypher.planner, Operations Manual -> Configuration Settings>>).
 
 You can see which planner was used by looking at the execution plan.
 
@@ -80,6 +113,30 @@ You can see which planner was used by looking at the execution plan.
 When Cypher is building execution plans, it looks at the schema to see if it can find indexes it can use.
 These index decisions are only valid until the schema changes, so adding or removing indexes leads to the execution plan cache being flushed.
 
+
+[[cypher-preparser-runtime]]
+=== Cypher runtime
+
+Using the execution plan, the query is executed -- and records returned -- by the query engine, or _runtime_.
+Depending on whether Neo4j Enterprise Edition or Neo4j Community Edition is used, there are two different runtimes available:
+
+Interpreted::
+In this runtime, the operators in the execution plan are chained together in a tree, where each non-leaf operator feeds from one or two child operators.
+The tree thus comprises nested iterators, and the records are streamed in a pipelined manner from the top iterator, which pulls from the next iterator and so on.
+
+Compiled::
+Algorithms are employed to group intelligently the operators in the execution plan in order to generate new combinations and orders of execution which are optimised for performance and memory usage.
+While this should lead to superior performance in most cases, it is still under development.
+
+[NOTE]
+The compiled runtime is only available in Neo4j Enterprise Edition.
+
+[options="header"]
+|===
+| Preparser option | Description | Default?
+| `runtime=interpreted` | This will force the query to use the interpreted runtime.  | This is the default option for some queries in Enterprise Edition, and the only option for all queries in Community Edition (so it is not necessary to use this option in Community Edition).
+| `runtime=compiled` | This will force the query to use the compiled runtime. | This is the default option for some queries in Enterprise Edition only. Setting this option for a query that does not support the compiled runtime will cause the query to fall back to using the interpreted runtime.
+|===
 
 [[how-do-i-profile-a-query]]
 == Profiling a query

--- a/cypher/cypher-docs/src/docs/dev/tutorials/gists/cypher/create-nodes-and-rels.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/tutorials/gists/cypher/create-nodes-and-rels.asciidoc
@@ -55,7 +55,6 @@ This is how our graph looks now:
 // graph:created-first-movie
 
 We can do more of the work in a single clause.
-`CREATE UNIQUE` will make sure we don't create duplicate patterns.
 Using this: `[r:ACTED_IN]` lets us return the relationship.
 
 [source, cypher]

--- a/cypher/cypher-docs/src/docs/dev/tutorials/gists/modeling/linked-list.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/tutorials/gists/modeling/linked-list.asciidoc
@@ -30,7 +30,6 @@ Properties set: 1
 Adding values is done by finding the relationship where the new value should be placed in, and replacing it with
 a new node, and two relationships to it.
 We also have to handle the fact that the *'before'* and *'after'* nodes could be the same as the *'root'* node.
-The case where *'before'*, *'after'* and the *'root'* node are all the same, makes it necessary to use `CREATE UNIQUE` to not create two new value nodes by mistake.
 
 [source, cypher]
 ----

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentingTestBase.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentingTestBase.scala
@@ -327,7 +327,7 @@ abstract class DocumentingTestBase extends JUnitSuite with DocumentationHelper w
                                               providedPlanners: Seq[String],
                                               prepareFunction: => Unit) = {
     // COST planner is default. Can't specify it without getting exception thrown if it's unavailable.
-    val planners = if (providedPlanners.isEmpty) Seq("", "CYPHER PLANNER=rule ") else providedPlanners
+    val planners = if (providedPlanners.isEmpty) Seq("") else providedPlanners
 
     val results = planners.flatMap {
       case planner if expectedException.isEmpty =>

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
@@ -175,26 +175,15 @@ class QueryPlanTest extends DocumentingTestBase with SoftReset {
     )
   }
 
-  @Test def updateGraph() {
+  @Test def createNode() {
     profileQuery(
-      title = "Update Graph",
+      title = "Create Node",
       text =
         """Creates a node in the graph.""".stripMargin,
-      queryText = """CYPHER planner=rule CREATE (:Person {name: 'Alistair'})""",
+      queryText = """CREATE (:Person {name: 'Alistair'})""",
       assertions = (p) => {
         assertThat(p.executionPlanDescription().toString, containsString("CreateNode"))
-        assertThat(p.executionPlanDescription().toString, containsString("UpdateGraph"))
       }
-    )
-  }
-
-  @Test def mergeInto() {
-    profileQuery(
-      title = "Merge Into",
-      text =
-        """When both the start and end node have already been found, `Merge Into` is used to find all connecting relationships or creating a new relationship between the two nodes.""".stripMargin,
-      queryText = """CYPHER planner=rule MATCH (p:Person {name: 'me'}), (f:Person {name: 'Andres'}) MERGE (p)-[:FRIENDS_WITH]->(f)""",
-      assertions = (p) => assertThat(p.executionPlanDescription().toString, containsString("Merge(Into)"))
     )
   }
 

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SchemaIndexTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SchemaIndexTest.scala
@@ -93,7 +93,7 @@ class SchemaIndexTest extends DocumentingTestBase with QueryStatisticsTestSuppor
         (p) =>
           assertEquals(1, p.size)
 
-          checkPlanDescription(p)("SchemaIndex", "NodeIndexSeek")
+          checkPlanDescription(p)("NodeIndexSeek")
       }
     )
   }
@@ -108,7 +108,7 @@ class SchemaIndexTest extends DocumentingTestBase with QueryStatisticsTestSuppor
         (p) =>
           assertEquals(1, p.size)
 
-          checkPlanDescription(p)("SchemaIndex", "NodeIndexSeek")
+          checkPlanDescription(p)("NodeIndexSeek")
       }
     )
   }
@@ -128,7 +128,7 @@ class SchemaIndexTest extends DocumentingTestBase with QueryStatisticsTestSuppor
         (p) =>
           assertEquals(1, p.size)
 
-          checkPlanDescription(p)("SchemaIndex", "NodeIndexSeek")
+          checkPlanDescription(p)("NodeIndexSeek")
       }
     )
   }
@@ -154,7 +154,7 @@ class SchemaIndexTest extends DocumentingTestBase with QueryStatisticsTestSuppor
         (p) =>
           assertEquals(2, p.size)
 
-          checkPlanDescription(p)("SchemaIndex", "NodeIndexSeek")
+          checkPlanDescription(p)("NodeIndexSeek")
       }
     )
   }
@@ -205,7 +205,7 @@ class SchemaIndexTest extends DocumentingTestBase with QueryStatisticsTestSuppor
     assert(expectedIndexes === db.indexPropsForLabel(label))
   }
 
-  private def checkPlanDescription(result: InternalExecutionResult)(ruleString: String, costString: String): Unit = {
+  private def checkPlanDescription(result: InternalExecutionResult)(costString: String): Unit = {
     val planDescription = result.executionPlanDescription()
     val plannerArgument = planDescription.arguments.find(a => a.name == "planner")
 


### PR DESCRIPTION
@craigtaverner the preparser options information is ready for your review. There are quite a few differences from 3.1.


@mariascharin This can only be merged once reviewed by Craig. However, this PR must be  merged first: https://github.com/neo4j/neo4j-documentation/pull/134

Moreover, please note that there is a lot of old compatibility content which was removed in another PR. Thus, when merging this, take as truth the main codebase when it comes to any compatibility-related errors.

Moreover - Docs Team as a whole - a new term needs to be invented/selected/decided upon for "Preparser options", just as for the 3.1 version. You'll notice I have peppered "TODOs" liberally in the PR. Additionally, sub-pages need to be created under the new "Deprecations" section (not merged at the time of raising this PR, hence not done in conjunction with this PR) for `START` and `CREATE UNIQUE`