### PR TITLE
3.3 - Added preparsing options details

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
@@ -202,9 +202,10 @@ This section comprises a glossary of all the keywords -- grouped by category and
 [options="header"]
 |===
 |Name           | Type | Description
-| <<cypher-version, CYPHER $version query>>  | Version | This will force `'query'` to use Neo4j Cypher `$version`. The default is `3.2`.
-| <<cypher-planner, CYPHER planner=rule query>> | Planner |  This will force `'query'` to use the rule planner. As the rule planner has been removed in 3.2, doing this will cause `'query'` to fall back to using Cypher 3.1.
+| <<cypher-version, CYPHER $version query>>  | Version | This will force `'query'` to use Neo4j Cypher `$version`. The default is `3.3`.
+| <<cypher-planner, CYPHER planner=rule query>> | Planner | This will force `'query'` to use the rule planner. As the rule planner was removed in 3.2, doing this will cause `'query'` to fall back to using Cypher 3.1.
 | <<cypher-planner, CYPHER planner=cost query>> | Planner | Neo4j {neo4j-version} uses the cost planner for all queries.
-| <<cypher-runtime, CYPHER runtime=interpreted query>> | Runtime | This will cause the query execution engine to disregard the compiled runtime, and therefore use the interpreted runtime. This is the only option in Neo4j Community Edition.
-| <<cypher-runtime, CYPHER runtime=compiled query>> | Runtime | This will cause the query execution engine to use the compiled runtime if it supports `'query'`, and fall back to using the interpreted runtime if it does not. This is only available in Neo4j Enterprise Edition.
+| <<cypher-runtime, CYPHER runtime=interpreted query>> | Runtime | This will force `'query'` to use the interpreted runtime. This is the only option in Neo4j Community Edition.
+| <<cypher-runtime, CYPHER runtime=slotted query>> | Runtime | This will force `'query'` to use the slotted runtime, if it is able to do so (otherwise `'query'` falls back to using the interpreted runtime). This is only available in Neo4j Enterprise Edition.
+| <<cypher-runtime, CYPHER runtime=compiled query>> | Runtime | This will force `'query'` to use the compiled runtime, if it is able to do so (otherwise `'query'` falls back to using the slotted or interpreted runtime). This is only available in Neo4j Enterprise Edition.
 |===

--- a/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
@@ -205,7 +205,7 @@ This section comprises a glossary of all the keywords -- grouped by category and
 | <<cypher-version, CYPHER $version query>>  | Version | This will force `'query'` to use Neo4j Cypher `$version`. The default is `3.3`.
 | <<cypher-planner, CYPHER planner=rule query>> | Planner | This will force `'query'` to use the rule planner. As the rule planner was removed in 3.2, doing this will cause `'query'` to fall back to using Cypher 3.1.
 | <<cypher-planner, CYPHER planner=cost query>> | Planner | Neo4j {neo4j-version} uses the cost planner for all queries.
-| <<cypher-runtime, CYPHER runtime=interpreted query>> | Runtime | This will force `'query'` to use the interpreted runtime. This is the only option in Neo4j Community Edition.
+| <<cypher-runtime, CYPHER runtime=interpreted query>> | Runtime | This will cause the query execution engine to disregard the compiled runtime, and therefore use the interpreted runtime. This is the only option in Neo4j Community Edition.
 | <<cypher-runtime, CYPHER runtime=slotted query>> | Runtime | This will force `'query'` to use the slotted runtime, if it is able to do so (otherwise `'query'` falls back to using the interpreted runtime). This is only available in Neo4j Enterprise Edition.
-| <<cypher-runtime, CYPHER runtime=compiled query>> | Runtime | This will force `'query'` to use the compiled runtime, if it is able to do so (otherwise `'query'` falls back to using the slotted or interpreted runtime). This is only available in Neo4j Enterprise Edition.
+| <<cypher-runtime, CYPHER runtime=compiled query>> | Runtime | This will cause the query execution engine to use the compiled runtime if it supports `'query'`, and fall back to using the interpreted runtime if it does not. This is only available in Neo4j Enterprise Edition.
 |===

--- a/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
@@ -205,7 +205,8 @@ This section comprises a glossary of all the keywords -- grouped by category and
 | <<cypher-version, CYPHER $version query>>  | Version | This will force `'query'` to use Neo4j Cypher `$version`. The default is `3.3`.
 | <<cypher-planner, CYPHER planner=rule query>> | Planner | This will force `'query'` to use the rule planner. As the rule planner was removed in 3.2, doing this will cause `'query'` to fall back to using Cypher 3.1.
 | <<cypher-planner, CYPHER planner=cost query>> | Planner | Neo4j {neo4j-version} uses the cost planner for all queries.
-| <<cypher-runtime, CYPHER runtime=interpreted query>> | Runtime | This will cause the query execution engine to disregard the compiled runtime, and therefore use the interpreted runtime. This is the only option in Neo4j Community Edition.
-| <<cypher-runtime, CYPHER runtime=slotted query>> | Runtime | This will force `'query'` to use the slotted runtime, if it is able to do so (otherwise `'query'` falls back to using the interpreted runtime). This is only available in Neo4j Enterprise Edition.
-| <<cypher-runtime, CYPHER runtime=compiled query>> | Runtime | This will cause the query execution engine to use the compiled runtime if it supports `'query'`, and fall back to using the interpreted runtime if it does not. This is only available in Neo4j Enterprise Edition.
+| <<cypher-runtime, CYPHER runtime=interpreted query>> | Runtime | This will force the query execution engine to use the interpreted runtime. This is the only option in Neo4j Community Edition.
+| <<cypher-runtime, CYPHER runtime=slotted query>> | Runtime | This will cause the query execution engine to use the slotted runtime if it supports `'query'`. This is only available in Neo4j Enterprise Edition.
+| <<cypher-runtime, CYPHER runtime=compiled query>> | Runtime | This will cause the query execution engine to use the compiled runtime if it supports `'query'`. This is only available in Neo4j Enterprise Edition.
 |===
+

--- a/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
@@ -103,6 +103,7 @@ Slotted::
 This is very similar to the interpreted runtime, except that there are additional optimizations regarding the way in which the records are streamed through the iterators.
 This results in improvements to both the performance and memory usage of the query.
 In effect, this can be thought of as a the 'faster interpreted' runtime.
+This is still under development and does not support all possible operators or queries.
 
 [NOTE]
 The slotted runtime is only available in Neo4j Enterprise Edition.
@@ -114,12 +115,15 @@ While this should lead to superior performance in most cases (over both the inte
 [NOTE]
 The compiled runtime is only available in Neo4j Enterprise Edition.
 
+[NOTE]
+In Enterprise Edition, the query execution engine's fallback mechanism is to try the compiled runtime first, and if it does not support the query, to then try the slotted runtime, and if that also does not support the query, to finally fall back to the interpreted runtime, which supports all queries.
+
 [options="header"]
 |===
 | Option | Description | Default?
 | `runtime=interpreted` | This will force the query execution engine to use the interpreted runtime. | This is the default option for some queries in Enterprise Edition, and the only option for all queries in Community Edition (so it is not necessary to use this option in Community Edition).
-| `runtime=slotted` | This will force the query to use the slotted runtime. | This is the default option for some queries in Enterprise Edition only. Setting this option for a query that does not support the slotted runtime will cause the query to fall back to using the interpreted runtime.
-| `runtime=compiled` | This will cause the query execution engine to use the compiled runtime if it supports the query, and fall back to using the interpreted runtime if it does not. | This is the default option for some queries in Enterprise Edition only.
+| `runtime=slotted` | This will cause the query execution engine to use the slotted runtime if it supports the query, and fall back to using the interpreted runtime if it does not. | This is the default option for some queries in Enterprise Edition only.
+| `runtime=compiled` | This will cause the query execution engine to use the compiled runtime if it supports the query. If the compiled runtime does not support the query, the engine will fall back to the slotted runtime, and, failing that, to the interpreted runtime. | This is the default option for some queries in Enterprise Edition only.
 |===
 
 

--- a/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
@@ -40,8 +40,9 @@ To read more about the execution plan operators mentioned in this chapter, see <
 This section describes the query options available in Cypher.
 --
 
-Queries are able to be fine-tuned through the use of query options.
-If there is a requirement to use one or more of these options, the query must be prepended with `CYPHER`, followed by the query option(s), as exemplified thus: `CYPHER query-option [further-query-options] query`.
+Query execution can to be fine-tuned through the use of query options.
+In order to use one or more of these options, the query must be prepended with `CYPHER`, followed by the query option(s), as exemplified thus: `CYPHER query-option [further-query-options] query`.
+
 
 [[cypher-version]]
 === Cypher version

--- a/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
@@ -63,6 +63,7 @@ Here we detail the available versions:
 [[cypher-planner]]
 === Cypher planner
 
+x
 Each query is turned into an execution plan by something called the _execution planner_.
 The execution plan tells Neo4j which operations to perform when executing the query.
 

--- a/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
@@ -63,7 +63,6 @@ Here we detail the available versions:
 [[cypher-planner]]
 === Cypher planner
 
-x
 Each query is turned into an execution plan by something called the _execution planner_.
 The execution plan tells Neo4j which operations to perform when executing the query.
 

--- a/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
@@ -54,8 +54,8 @@ Here we detail the available versions:
 |===
 | Query option | Description | Default?
 | `2.3` | This will force the query to use Neo4j Cypher 2.3.  |
-| `3.2` | This will force the query to use Neo4j Cypher 3.2. |
 | `3.1` | This will force the query to use Neo4j Cypher 3.1. |
+| `3.2` | This will force the query to use Neo4j Cypher 3.2. |
 | `3.3` | This will force the query to use Neo4j Cypher 3.3. As this is the default version, it is not necessary to use this option explicitly. | X
 |===
 
@@ -70,7 +70,7 @@ Neo4j uses a _cost_-based execution planning strategy (known as the 'cost' plann
 
 All versions of Neo4j prior to Neo4j 3.2 also included a rule-based planner, which used rules to produce execution plans.
 This planner considered available indexes, but did not use statistical information to guide the query compilation.
-The rule planner was removed in Neo4j 3.2 owing to inferior query performance when compared with the cost planner.
+The rule planner was removed in Neo4j 3.2 owing to inferior query execution performance when compared with the cost planner.
 
 
 [options="header"]
@@ -108,7 +108,7 @@ In effect, this can be thought of as a the 'faster interpreted' runtime.
 The slotted runtime is only available in Neo4j Enterprise Edition.
 
 Compiled::
-Algorithms are employed to group intelligently the operators in the execution plan in order to generate new combinations and orders of execution which are optimised for performance and memory usage.
+Algorithms are employed to intelligently group the operators in the execution plan in order to generate new combinations and orders of execution which are optimised for performance and memory usage.
 While this should lead to superior performance in most cases (over both the interpreted and slotted runtimes), it is still under development and does not support all possible operators or queries (the slotted runtime has a higher coverage of operators and queries).
 
 [NOTE]
@@ -117,9 +117,9 @@ The compiled runtime is only available in Neo4j Enterprise Edition.
 [options="header"]
 |===
 | Option | Description | Default?
-| `runtime=interpreted` | This will force the query to use the interpreted runtime.  | This is the default option for some queries in Enterprise Edition, and the only option for all queries in Community Edition (so it is not necessary to use this option in Community Edition).
+| `runtime=interpreted` | This will force the query execution engine to use the interpreted runtime. | This is the default option for some queries in Enterprise Edition, and the only option for all queries in Community Edition (so it is not necessary to use this option in Community Edition).
 | `runtime=slotted` | This will force the query to use the slotted runtime. | This is the default option for some queries in Enterprise Edition only. Setting this option for a query that does not support the slotted runtime will cause the query to fall back to using the interpreted runtime.
-| `runtime=compiled` | This will force the query to use the compiled runtime. | This is the default option for some queries in Enterprise Edition only. Setting this option for a query that does not support the compiled runtime will cause the query to fall back to using the slotted or interpreted runtime.
+| `runtime=compiled` | This will cause the query execution engine to use the compiled runtime if it supports the query, and fall back to using the interpreted runtime if it does not. | This is the default option for some queries in Enterprise Edition only.
 |===
 
 

--- a/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
@@ -54,6 +54,7 @@ Here we detail the available versions:
 | Query option | Description | Default?
 | `2.3` | This will force the query to use Neo4j Cypher 2.3.  |
 | `3.2` | This will force the query to use Neo4j Cypher 3.2. |
+| `3.1` | This will force the query to use Neo4j Cypher 3.1. |
 | `3.3` | This will force the query to use Neo4j Cypher 3.3. As this is the default version, it is not necessary to use this option explicitly. | X
 |===
 

--- a/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
@@ -40,8 +40,8 @@ To read more about the execution plan operators mentioned in this chapter, see <
 This section describes the query options available in Cypher.
 --
 
-Query execution can be fine-tuned through the use of query options.
-In order to use one or more of these options, the query must be prepended with `CYPHER`, followed by the query option(s), as exemplified thus: `CYPHER query-option [further-query-options] query`.
+Queries are able to be fine-tuned through the use of query options.
+If there is a requirement to use one or more of these options, the query must be prepended with `CYPHER`, followed by the query option(s), as exemplified thus: `CYPHER query-option [further-query-options] query`.
 
 [[cypher-version]]
 === Cypher version
@@ -53,8 +53,8 @@ Here we detail the available versions:
 |===
 | Query option | Description | Default?
 | `2.3` | This will force the query to use Neo4j Cypher 2.3.  |
-| `3.1` | This will force the query to use Neo4j Cypher 3.1. |
-| `3.2` | This will force the query to use Neo4j Cypher 3.2. As this is the default version, it is not necessary to use this option explicitly. | X
+| `3.2` | This will force the query to use Neo4j Cypher 3.2. |
+| `3.3` | This will force the query to use Neo4j Cypher 3.3. As this is the default version, it is not necessary to use this option explicitly. | X
 |===
 
 
@@ -66,9 +66,10 @@ The execution plan tells Neo4j which operations to perform when executing the qu
 
 Neo4j uses a _cost_-based execution planning strategy (known as the 'cost' planner): the statistics service in Neo4j is used to assign a cost to alternative plans and picks the cheapest one.
 
-All previous versions of Neo4j also included a rule-based planner, which used rules to produce execution plans.
+All versions of Neo4j prior to Neo4j 3.2 also included a rule-based planner, which used rules to produce execution plans.
 This planner considered available indexes, but did not use statistical information to guide the query compilation.
-The rule planner was removed in Neo4j 3.2 owing to inferior query execution performance when compared with the cost planner.
+The rule planner was removed in Neo4j 3.2 owing to inferior query performance when compared with the cost planner.
+
 
 [options="header"]
 |===
@@ -90,15 +91,23 @@ These index decisions are only valid until the schema changes, so adding or remo
 === Cypher runtime
 
 Using the execution plan, the query is executed -- and records returned -- by the query engine, or _runtime_.
-Depending on whether Neo4j Enterprise Edition or Neo4j Community Edition is used, there are two different runtimes available:
+Depending on whether Neo4j Enterprise Edition or Neo4j Community Edition is used, there are three different runtimes available:
 
 Interpreted::
 In this runtime, the operators in the execution plan are chained together in a tree, where each non-leaf operator feeds from one or two child operators.
 The tree thus comprises nested iterators, and the records are streamed in a pipelined manner from the top iterator, which pulls from the next iterator and so on.
 
+Slotted::
+This is very similar to the interpreted runtime, except that there are additional optimizations regarding the way in which the records are streamed through the iterators.
+This results in improvements to both the performance and memory usage of the query.
+In effect, this can be thought of as a the 'faster interpreted' runtime.
+
+[NOTE]
+The slotted runtime is only available in Neo4j Enterprise Edition.
+
 Compiled::
-Algorithms are employed to intelligently group the operators in the execution plan in order to generate new combinations and orders of execution which are optimised for performance and memory usage.
-While this should lead to superior performance in most cases, it is still under development and does not support all possible operators or queries.
+Algorithms are employed to group intelligently the operators in the execution plan in order to generate new combinations and orders of execution which are optimised for performance and memory usage.
+While this should lead to superior performance in most cases (over both the interpreted and slotted runtimes), it is still under development and does not support all possible operators or queries (the slotted runtime has a higher coverage of operators and queries).
 
 [NOTE]
 The compiled runtime is only available in Neo4j Enterprise Edition.
@@ -106,9 +115,11 @@ The compiled runtime is only available in Neo4j Enterprise Edition.
 [options="header"]
 |===
 | Option | Description | Default?
-| `runtime=interpreted` | This will cause the query execution engine to disregard the compiled runtime, and therefore use the interpreted runtime. | This is the default option for some queries in Enterprise Edition, and the only option for all queries in Community Edition (so it is not necessary to use this option in Community Edition).
-| `runtime=compiled` | This will cause the query execution engine to use the compiled runtime if it supports the query, and fall back to using the interpreted runtime if it does not. | This is the default option for some queries in Enterprise Edition only.
+| `runtime=interpreted` | This will force the query to use the interpreted runtime.  | This is the default option for some queries in Enterprise Edition, and the only option for all queries in Community Edition (so it is not necessary to use this option in Community Edition).
+| `runtime=slotted` | This will force the query to use the slotted runtime. | This is the default option for some queries in Enterprise Edition only. Setting this option for a query that does not support the slotted runtime will cause the query to fall back to using the interpreted runtime.
+| `runtime=compiled` | This will force the query to use the compiled runtime. | This is the default option for some queries in Enterprise Edition only. Setting this option for a query that does not support the compiled runtime will cause the query to fall back to using the slotted or interpreted runtime.
 |===
+
 
 [[how-do-i-profile-a-query]]
 == Profiling a query


### PR DESCRIPTION
@craigtaverner the preparser options information is ready for your review. There are quite a few differences from 3.1 and 3.2. In particular, there is still the issue of supported versions vs compatibility vs 3.1 fallbacks (due to removal of the RULE planner in 3.2)

@mariascharin This can only be merged once reviewed by Craig. However, this PR needs to be merged before this one: https://github.com/neo4j/neo4j-documentation/pull/133

Moreover - Docs Team as a whole - a new term needs to be invented/selected/decided upon for "Preparser options", just as for the 3.2 and 3.1 version. You'll notice I have peppered "TODOs" liberally in the PR.