### PR TITLE
Amended deprecated legacy pattern syntax to replacement syntax

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MatchTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MatchTest.scala
@@ -213,8 +213,8 @@ class MatchTest extends DocumentingTest {
         }
       }
       section("Relationship variable in variable length relationships", "rel-variable-in-varlength-rels") {
-        p("When the connection between two nodes is of variable length, a relationship variable becomes a list of relationships.")
-        query("MATCH (actor {name: 'Charlie Sheen'})-[r:ACTED_IN*2]-(co_actor) RETURN r", assertActedInRelationshipsAreReturned) {
+        p("When the connection between two nodes is of variable length, the list of relationships comprising the connection can be returned using the following syntax:")
+        query("MATCH p = (actor {name: 'Charlie Sheen'})-[:ACTED_IN*2]-(co_actor) RETURN relationships(p)", assertActedInRelationshipsAreReturned) {
           p("Returns a list of relationships.")
           resultTable()
         }

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/PatternTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/PatternTest.scala
@@ -186,9 +186,9 @@ class PatternTest extends DocumentingTest {
     section("Variable-length pattern matching", "cypher-pattern-varlength") {
       caution {
         p("""Variable length pattern matching in versions 2.1.x and earlier does not enforce relationship uniqueness for patterns described within a single `MATCH` clause.
-            |This means that a query such as the following: `MATCH (a)-[r]\->(b), (a)-[rs*]\->(c) RETURN *` may include `r` as part of the `rs` set.
+            |This means that a query such as the following: `MATCH (a)-[r]\->(b), p = (a)-[*]\->(c) RETURN *, relationships(p) AS rs` may include `r` as part of the `rs` set.
             |This behavior has changed in versions 2.2.0 and later, in such a way that `r` will be excluded from the result set, as this better adheres to the rules of relationship uniqueness as documented here <<cypherdoc-uniqueness>>.
-            |If you have a query pattern that needs to retrace relationships rather than ignoring them as the relationship uniqueness rules normally dictate, you can accomplish this using multiple match clauses, as follows: `MATCH (a)-[r]\->(b) MATCH (a)-[rs*]\->(c) RETURN *`.
+            |If you have a query pattern that needs to retrace relationships rather than ignoring them as the relationship uniqueness rules normally dictate, you can accomplish this using multiple match clauses, as follows: `MATCH (a)-[r]\->(b) MATCH p = (a)-[*]\->(c) RETURN *, relationships(p)`.
             |This will work in all versions of Neo4j that support the `MATCH` clause, namely 2.0.0 and later.""")
       }
       p("""Rather than describing a long path using a sequence of many node and relationship descriptions in a pattern, many relationships (and the intermediate nodes) can be described by specifying a length in the relationship description of a pattern.

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ShortestPathPlanningTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ShortestPathPlanningTest.scala
@@ -77,8 +77,8 @@ class ShortestPathPlanningTest extends DocumentingTest {
       query(
         """MATCH (ms:Person {name: 'Martin Sheen'} ),
           |      (cs:Person {name: 'Charlie Sheen'}),
-          |      p = shortestPath((ms)-[rels:ACTED_IN*]-(cs))
-          |WHERE all(r IN rels WHERE exists(r.role))
+          |      p = shortestPath((ms)-[:ACTED_IN*]-(cs))
+          |WHERE all(r IN relationships(p) WHERE exists(r.role))
           |RETURN p""", assertShortestPathLength) {
         p(
           """This query can be evaluated with the fast algorithm -- there are no predicates that need to see the whole

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ListsTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ListsTest.scala
@@ -94,12 +94,12 @@ range($firstNum, $lastNum, $step) AS list
 ###assertion=returns-one
 //
 
-MATCH (a)-[r:KNOWS*]->()
-RETURN r AS rels
+MATCH p = (a)-[:KNOWS*]->()
+RETURN relationships(p) AS r
 
 ###
 
-Relationship variables of a variable length path contain a list of relationships.
+The list of relationships comprising a variable length path can be returned using named paths and `relationships()`.
 
 ###assertion=returns-two
 MATCH (matchedNode)


### PR DESCRIPTION
According to https://github.com/neo4j/neo4j/pull/9160, the legacy pattern syntax has been updated to use the recommended syntax instead.
