### PR TITLE
Add back START and CREATE UNIQUE

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/clause.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/clause.asciidoc
@@ -30,7 +30,7 @@ This set is refined and augmented by subsequent parts of the query.
 |Clause                                     |   Description
 |<<query-match,MATCH>>                      |   Specify the patterns to search for in the database.
 |<<query-optional-match,OPTIONAL MATCH>>    |   Specify the patterns to search for in the database while using `nulls` for missing parts of the pattern.
-|<<query-start,START>>                      |   Use the deprecated function `STARTind starting points through legacy indexes.
+|<<query-start,START>>                      |   [deprecated]#Find starting points through legacy indexes.#
 |===
 
 
@@ -108,7 +108,7 @@ These comprise clauses that both read data from and write data to the database.
 |--- <<query-merge-on-create-on-match,ON CREATE>>   | Used in conjunction with `MERGE`, this write sub-clause specifies the actions to take if the pattern needs to be created.
 |--- <<query-merge-on-create-on-match,ON MATCH>>    | Used in conjunction with `MERGE`, this write sub-clause specifies the actions to take if the pattern already exists.
 |<<query-call,CALL [...YIELD]>>         | Invoke a procedure deployed in the database and return any results.
-|<<query-create-unique,CREATE UNIQUE>>      |   A mixture of `MATCH` and `CREATE`, matching what it can, and creating what is missing.
+|<<query-create-unique,CREATE UNIQUE>>      |   [deprecated]#A mixture of `MATCH` and `CREATE`, matching what it can, and creating what is missing.#
 |===
 
 

--- a/cypher/cypher-docs/src/docs/dev/clause.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/clause.asciidoc
@@ -30,6 +30,7 @@ This set is refined and augmented by subsequent parts of the query.
 |Clause                                     |   Description
 |<<query-match,MATCH>>                      |   Specify the patterns to search for in the database.
 |<<query-optional-match,OPTIONAL MATCH>>    |   Specify the patterns to search for in the database while using `nulls` for missing parts of the pattern.
+|<<query-start,START>>                      |   Use the deprecated function `STARTind starting points through legacy indexes.
 |===
 
 
@@ -107,6 +108,7 @@ These comprise clauses that both read data from and write data to the database.
 |--- <<query-merge-on-create-on-match,ON CREATE>>   | Used in conjunction with `MERGE`, this write sub-clause specifies the actions to take if the pattern needs to be created.
 |--- <<query-merge-on-create-on-match,ON MATCH>>    | Used in conjunction with `MERGE`, this write sub-clause specifies the actions to take if the pattern already exists.
 |<<query-call,CALL [...YIELD]>>         | Invoke a procedure deployed in the database and return any results.
+|<<query-create-unique,CREATE UNIQUE>>      |   A mixture of `MATCH` and `CREATE`, matching what it can, and creating what is missing.
 |===
 
 
@@ -150,6 +152,8 @@ include::ql/query-match.adoc[leveloffset=+1]
 
 include::ql/query-optional-match.adoc[leveloffset=+1]
 
+include::ql/start/index.asciidoc[leveloffset=+1]
+
 //Projecting
 include::ql/query-return.adoc[leveloffset=+1]
 
@@ -181,6 +185,8 @@ include::ql/foreach/index.asciidoc[leveloffset=+1]
 include::ql/merge/index.asciidoc[leveloffset=+1]
 
 include::ql/call/index.asciidoc[leveloffset=+1]
+
+include::ql/create-unique/index.asciidoc[leveloffset=+1]
 
 //Set
 include::ql/query-union.adoc[leveloffset=+1]

--- a/cypher/cypher-docs/src/docs/dev/ql/create-unique/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/create-unique/index.asciidoc
@@ -1,3 +1,4 @@
+[role=deprecated]
 [[query-create-unique]]
 = CREATE UNIQUE
 

--- a/cypher/cypher-docs/src/docs/dev/ql/start/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/start/index.asciidoc
@@ -1,3 +1,4 @@
+[role=deprecated]
 [[query-start]]
 = START
 


### PR DESCRIPTION
From Neo4j perspective these clauses are still there in 3.2, even if they are not in Cypher 3.2. Removing them is problematic, especially since the 3.2 docs have already been published for some time. Instead of removing them, we are working on a scheme for visually signaling deprecations.

For 3.3 we add a link to the explicit index procedures from the `START` page.