### PR TITLE
Add Node Key constraint to Cypher Refcard

### DIFF
--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ConstraintTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ConstraintTest.scala
@@ -104,7 +104,7 @@ CREATE CONSTRAINT ON (p:Person)
        ASSERT exists(p.name)
 ###
 
-(†) Create a node property existence constraint on the label `Person` and property `name`.
+(★) Create a node property existence constraint on the label `Person` and property `name`.
 If a node with that label is created without a `name`, or if the `name` property is
 removed from an existing node with the `Person` label, the write operation will fail.
 
@@ -115,7 +115,7 @@ DROP CONSTRAINT ON (p:Person)
      ASSERT exists(p.name)
 ###
 
-(†) Drop the node property existence constraint on the label `Person` and property `name`.
+(★) Drop the node property existence constraint on the label `Person` and property `name`.
 
 ###assertion=create-relationship-property-existence-constraint
 //
@@ -124,7 +124,7 @@ CREATE CONSTRAINT ON ()-[l:LIKED]-()
        ASSERT exists(l.when)
 ###
 
-(†) Create a relationship property existence constraint on the type `LIKED` and property `when`.
+(★) Create a relationship property existence constraint on the type `LIKED` and property `when`.
 If a relationship with that type is created without a `when`, or if the `when` property is
 removed from an existing relationship with the `LIKED` type, the write operation will fail.
 
@@ -135,7 +135,7 @@ DROP CONSTRAINT ON ()-[l:LIKED]-()
      ASSERT exists(l.when)
 ###
 
-(†) Drop the relationship property existence constraint on the type `LIKED` and property `when`.
+(★) Drop the relationship property existence constraint on the type `LIKED` and property `when`.
 
 ###assertion=create-node-key-constraint
 //
@@ -144,7 +144,7 @@ CREATE CONSTRAINT ON (p:Person)
       ASSERT (p.firstname, p.surname) IS NODE KEY
 ###
 
-(†) Create a Node Key constraint on the label `Person` and properties `firstname` and `surname`.
+(★) Create a Node Key constraint on the label `Person` and properties `firstname` and `surname`.
 If a node with that label is created without both `firstname` and `surname`
 or if the combination of the two is not unique,
 or if the `firstname` and/or `surname` labels on an existing node with the `Person` label
@@ -158,7 +158,7 @@ DROP CONSTRAINT ON (p:Person)
 
 ###
 
-(†) Drop the Node Key constraint on the label `Person` and properties `firstname` and `surname`.
+(★) Drop the Node Key constraint on the label `Person` and properties `firstname` and `surname`.
 
 """
 }

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ConstraintTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ConstraintTest.scala
@@ -104,7 +104,7 @@ CREATE CONSTRAINT ON (p:Person)
        ASSERT exists(p.name)
 ###
 
-Create a node property existence constraint on the label `Person` and property `name`.
+(†) Create a node property existence constraint on the label `Person` and property `name`.
 If a node with that label is created without a `name`, or if the `name` property is
 removed from an existing node with the `Person` label, the write operation will fail.
 
@@ -115,7 +115,7 @@ DROP CONSTRAINT ON (p:Person)
      ASSERT exists(p.name)
 ###
 
-Drop the node property existence constraint on the label `Person` and property `name`.
+(†) Drop the node property existence constraint on the label `Person` and property `name`.
 
 ###assertion=create-relationship-property-existence-constraint
 //
@@ -124,7 +124,7 @@ CREATE CONSTRAINT ON ()-[l:LIKED]-()
        ASSERT exists(l.when)
 ###
 
-Create a relationship property existence constraint on the type `LIKED` and property `when`.
+(†) Create a relationship property existence constraint on the type `LIKED` and property `when`.
 If a relationship with that type is created without a `when`, or if the `when` property is
 removed from an existing relationship with the `LIKED` type, the write operation will fail.
 
@@ -135,7 +135,7 @@ DROP CONSTRAINT ON ()-[l:LIKED]-()
      ASSERT exists(l.when)
 ###
 
-Drop the relationship property existence constraint on the type `LIKED` and property `when`.
+(†) Drop the relationship property existence constraint on the type `LIKED` and property `when`.
 
 ###assertion=create-node-key-constraint
 //
@@ -144,7 +144,7 @@ CREATE CONSTRAINT ON (p:Person)
       ASSERT (p.firstname, p.surname) IS NODE KEY
 ###
 
-Create a Node Key constraint on the label `Person` and properties `firstname` and `surname`.
+(†) Create a Node Key constraint on the label `Person` and properties `firstname` and `surname`.
 If a node with that label is created without both `firstname` and `surname`
 or if the combination of the two is not unique,
 or if the `firstname` and/or `surname` labels on an existing node with the `Person` label
@@ -158,7 +158,7 @@ DROP CONSTRAINT ON (p:Person)
 
 ###
 
-Drop the Node Key constraint on the label `Person` and properties `firstname` and `surname`.
+(†) Drop the Node Key constraint on the label `Person` and properties `firstname` and `surname`.
 
 """
 }

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ConstraintTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ConstraintTest.scala
@@ -52,10 +52,10 @@ class ConstraintTest extends RefcardTest with QueryStatisticsTestSupport {
         assertStats(result, constraintsRemoved = 1)
         assert(result.toList.size === 0)
       case "create-node-key-constraint" =>
-        assertStats(result, constraintsAdded = 0)
+        assertStats(result, constraintsAdded = 1)
         assert(result.toList.size === 0)
       case "drop-node-key-constraint" =>
-        assertStats(result, constraintsRemoved = 0)
+        assertStats(result, constraintsRemoved = 1)
         assert(result.toList.size === 0)
       case "match" =>
         assertStats(result, nodesCreated = 0)

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ConstraintTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ConstraintTest.scala
@@ -51,6 +51,12 @@ class ConstraintTest extends RefcardTest with QueryStatisticsTestSupport {
       case "drop-relationship-property-existence-constraint" =>
         assertStats(result, constraintsRemoved = 1)
         assert(result.toList.size === 0)
+      case "create-node-key-constraint" =>
+        assertStats(result, constraintsAdded = 0)
+        assert(result.toList.size === 0)
+      case "drop-node-key-constraint" =>
+        assertStats(result, constraintsRemoved = 0)
+        assert(result.toList.size === 0)
       case "match" =>
         assertStats(result, nodesCreated = 0)
         assert(result.toList.size === 1)
@@ -58,8 +64,8 @@ class ConstraintTest extends RefcardTest with QueryStatisticsTestSupport {
   }
 
   override val properties: Map[String, Map[String, Any]] = Map(
-    "A" -> Map("name" -> "Alice"),
-    "B" -> Map("name" -> "Bobo"))
+    "A" -> Map("name" -> "Alice", "firstname" -> "Alice", "surname" -> "Johnson"),
+    "B" -> Map("name" -> "Bobo", "firstname" -> "Bobo", "surname" -> "Baumann"))
 
   override def parameters(name: String): Map[String, Any] =
     name match {
@@ -130,5 +136,29 @@ DROP CONSTRAINT ON ()-[l:LIKED]-()
 ###
 
 Drop the relationship property existence constraint on the type `LIKED` and property `when`.
+
+###assertion=create-node-key-constraint
+//
+
+CREATE CONSTRAINT ON (p:Person)
+      ASSERT (p.firstname, p.surname) IS NODE KEY
+###
+
+Create a Node Key constraint on the label `Person` and properties `firstname` and `surname`.
+If a node with that label is created without both `firstname` and `surname`
+or if the combination of the two is not unique,
+or if the `firstname` and/or `surname` labels on an existing node with the `Person` label
+is modified to violate these constraints, the write operation will fail.
+
+###assertion=drop-node-key-constraint
+//
+
+DROP CONSTRAINT ON (p:Person)
+      ASSERT (p.firstname, p.surname) IS NODE KEY
+
+###
+
+Drop the Node Key constraint on the label `Person` and properties `firstname` and `surname`.
+
 """
 }


### PR DESCRIPTION
A couple of changes must go through before this PR is ready to be merged:

1. Bug on message when node key constraint has been added/deleted be fixed (Cypher team)
2. Assert statements be corrected to match the bugfix