### PR TITLE
Cypher CALL docs should link to docs for building procs and to built-in proc reference

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/ql/call/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/call/index.asciidoc
@@ -46,11 +46,11 @@ Calling a `VOID` procedure in the middle of a larger query will simply pass on e
 
 [NOTE]
 ====
-User-defined procedures can be developed and deployed to the database.
-See <<procedures>> for details.
+Neo4j comes with a number of built-in procedures.
+For a list of these, see <<operations-manual#ref-procedures, Operations Manual -> Built-in procedures>>.
 
-Neo4j also has a number of procedures built in.
-For a list of built-in procedures, see <<operations-manual#ref-procedures, Operations Manual -> Built-in procedures>>.
+Users can also develop custom procedures and deploy to the database.
+See <<procedures>> for details.
 ====
 
 The following examples show how to pass arguments to and yield result fields from a procedure call.

--- a/cypher/cypher-docs/src/docs/dev/ql/call/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/call/index.asciidoc
@@ -64,9 +64,6 @@ classifier=sources
 tag=indexingProcedure
 ----
 
-[NOTE]
-This clause cannot be combined with other clauses.
-
 include::call-a-procedure-using-call.asciidoc[]
 
 include::call-a-procedure-using-a-quoted-namespace-and-name.asciidoc[]

--- a/cypher/cypher-docs/src/docs/dev/ql/call/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/call/index.asciidoc
@@ -44,6 +44,15 @@ A `VOID` procedure is a procedure that does not declare any result fields and re
 Calling a `VOID` procedure may only have a side effect and thus does neither allow nor require the use of `YIELD`.
 Calling a `VOID` procedure in the middle of a larger query will simply pass on each input record (i.e. it acts like `WITH *` in terms of the record stream).
 
+[NOTE]
+====
+User-defined procedures can be developed and deployed to the database.
+See <<procedures>> for details.
+
+Neo4j also has a number of procedures built in.
+For a list of built-in procedures, see <<operations-manual#ref-procedures, Operations Manual -> Built-in procedures>>.
+====
+
 The following examples show how to pass arguments to and yield result fields from a procedure call.
 All examples use the following procedure:
 


### PR DESCRIPTION
![call-link-admon-preview](https://user-images.githubusercontent.com/6028968/37994253-439a5fcc-3211-11e8-9ae1-0ee4fc31a999.png)
