### PR TITLE
3.4 temporal refcard

### DIFF
--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DurationFunctionsTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DurationFunctionsTest.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.docgen.refcard
+
+import java.time._
+
+import org.neo4j.cypher.QueryStatisticsTestSupport
+import org.neo4j.cypher.docgen.RefcardTest
+import org.neo4j.cypher.internal.runtime.InternalExecutionResult
+import org.neo4j.values.storable.DurationValue
+
+class DurationFunctionsTest extends RefcardTest with QueryStatisticsTestSupport {
+  val graphDescription = List("ROOT KNOWS A")
+  val title = "Duration Functions"
+  override val linkId = "functions/duration"
+
+  override def assert(name: String, result: InternalExecutionResult) {
+    name match {
+      case "returns-one" =>
+        assertStats(result, nodesCreated = 0)
+        assert(result.toList.size === 1)
+      case "returns-duration-5min" =>
+        assertStats(result, nodesCreated = 0)
+        val results = result.toList
+        assert(results.size === 1)
+        assert(results.head === Map("duration(\"PT30S\") * 10" -> DurationValue.parse("PT5M")))
+    }
+  }
+
+  override def parameters(name: String): Map[String, Any] = {
+    val date1 = LocalDate.parse("2015-02-02")
+    val date2 = LocalDate.parse("2018-04-05")
+    name match {
+      case "parameters=between" =>
+        Map("date1" -> date1, "date2" -> date2)
+      case "" =>
+        Map()
+    }
+  }
+
+  def text = """
+###assertion=returns-one
+RETURN
+
+duration("P1Y2M10DT12H45M30.25S")
+###
+
+Returns a duration of 1 year, 2 months, 10 days, 12 hours, 45 minutes and 30.25 seconds.
+
+###assertion=returns-one parameters=between
+RETURN
+
+duration.between($date1,$date2)
+###
+
+Returns a duration between two temporal instances.
+
+###assertion=returns-one
+
+
+WITH duration("P1Y2M10DT12H45M") AS d
+RETURN d.years, d.months, d.days, d.hours, d.minutes
+###
+
+Returns 1 year, 14 months, 10 days, 12 hours and 765 minutes.
+
+###assertion=returns-one
+
+
+WITH duration("P1Y2M10DT12H45M") AS d
+RETURN d.years, d.monthsOfYear, d.days, d.hours, d.minutesOfHour
+###
+
+Returns 1 year, 2 months, 10 days, 12 hours and 45 minutes.
+
+###assertion=returns-one
+RETURN
+
+date("2015-01-01") + duration("P1Y1M1D")
+###
+
+Returns a date of `2016-02-02`. It is also possible to subtract durations from temporal instances.
+
+###assertion=returns-duration-5min
+RETURN
+
+duration("PT30S") * 10
+###
+
+Returns a duration of 5 minutes. It is also possible to divide a duration by a number.
+"""
+}

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DurationFunctionsTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DurationFunctionsTest.scala
@@ -40,7 +40,23 @@ class DurationFunctionsTest extends RefcardTest with QueryStatisticsTestSupport 
         assertStats(result, nodesCreated = 0)
         val results = result.toList
         assert(results.size === 1)
-        assert(results.head === Map("duration(\"PT30S\") * 10" -> DurationValue.parse("PT5M")))
+        assert(results.head.values.head === DurationValue.parse("PT5M"))
+      case "returns-date" =>
+        assertStats(result, nodesCreated = 0)
+        val results = result.toList
+        assert(results.size === 1)
+        assert(results.head.values.head === LocalDate.parse("2016-02-02"))
+      case "returns-duration-accessors1" =>
+        assertStats(result, nodesCreated = 0)
+        val results = result.toList
+        assert(results.size === 1)
+        assert(results.head === Map("d.years" -> 1, "d.months" -> 14, "d.days" -> 10, "d.hours" -> 12, "d.minutes" -> 765))
+      case "returns-duration-accessors2" =>
+        assertStats(result, nodesCreated = 0)
+        val results = result.toList
+        assert(results.size === 1)
+        assert(results.head === Map("d.years" -> 1, "d.monthsOfYear" -> 2, "d.days" -> 10, "d.hours" -> 12, "d.minutesOfHour" -> 45))
+
     }
   }
 
@@ -72,7 +88,7 @@ duration.between($date1,$date2)
 
 Returns a duration between two temporal instances.
 
-###assertion=returns-one
+###assertion=returns-duration-accessors1
 
 
 WITH duration("P1Y2M10DT12H45M") AS d
@@ -81,7 +97,7 @@ RETURN d.years, d.months, d.days, d.hours, d.minutes
 
 Returns 1 year, 14 months, 10 days, 12 hours and 765 minutes.
 
-###assertion=returns-one
+###assertion=returns-duration-accessors2
 
 
 WITH duration("P1Y2M10DT12H45M") AS d
@@ -90,7 +106,7 @@ RETURN d.years, d.monthsOfYear, d.days, d.hours, d.minutesOfHour
 
 Returns 1 year, 2 months, 10 days, 12 hours and 45 minutes.
 
-###assertion=returns-one
+###assertion=returns-date
 RETURN
 
 date("2015-01-01") + duration("P1Y1M1D")

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SpatialFunctionsTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SpatialFunctionsTest.scala
@@ -59,7 +59,7 @@ RETURN
 
 point({latitude: $y, longitude: $x})
 ###
-Returns a point in a 2D geographic coordinate system.
+Returns a point in a 2D geographic coordinate system, with coordinates specified in decimal degrees.
 
 ###assertion=returns-one parameters=point
 RETURN
@@ -73,7 +73,16 @@ RETURN
 
 point({latitude: $y, longitude: $x, height: $z})
 ###
-Returns a point in a 3D geographic coordinate system.
+Returns a point in a 3D geographic coordinate system, with latitude and longitude in decimal degrees, and height in meters.
+
+###assertion=returns-one parameters=distance
+RETURN
+
+distance(point({x: $x1, y: $y1}), point({x: $x2, y: $2}))
+###
+
+Returns a floating point number representing the linear distance between two points.
+The units will be the same as those of the points, and it will work for both 2D and 3D cartesian points.
 
 ###assertion=returns-one parameters=distance
 RETURN
@@ -81,6 +90,6 @@ RETURN
 distance(point({latitude: $y1, longitude: $x1}), point({latitude: $y2, longitude: $x2}))
 ###
 
-Returns a floating point number representing the geodesic distance between two points.
+Returns the geodesic distance between two points in meters. It can be used for 3D geographic points as well.
 """
 }

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SpatialFunctionsTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SpatialFunctionsTest.scala
@@ -50,35 +50,35 @@ class SpatialFunctionsTest extends RefcardTest with QueryStatisticsTestSupport {
 ###assertion=returns-one parameters=point
 RETURN
 
-point({x: {x}, y: {y}})
+point({x: $x, y: $y})
 ###
 Returns a point in a 2D cartesian coordinate system.
 
 ###assertion=returns-one parameters=point
 RETURN
 
-point({latitude: {y}, longitude: {x}})
+point({latitude: $y, longitude: $x})
 ###
 Returns a point in a 2D geographic coordinate system.
 
 ###assertion=returns-one parameters=point
 RETURN
 
-point({x: {x}, y: {y}, z: {z}})
+point({x: $x, y: $y, z: $z})
 ###
 Returns a point in a 3D cartesian coordinate system.
 
 ###assertion=returns-one parameters=point
 RETURN
 
-point({latitude: {y}, longitude: {x}, height: {z}})
+point({latitude: $y, longitude: $x, height: $z})
 ###
 Returns a point in a 3D geographic coordinate system.
 
 ###assertion=returns-one parameters=distance
 RETURN
 
-distance(point({latitude: {y1}, longitude: {x1}}), point({latitude: {y2}, longitude: {x2}}))
+distance(point({latitude: $y1, longitude: $x1}), point({latitude: $y2, longitude: $x2}))
 ###
 
 Returns a floating point number representing the geodesic distance between two points.

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SpatialFunctionsTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SpatialFunctionsTest.scala
@@ -39,7 +39,7 @@ class SpatialFunctionsTest extends RefcardTest with QueryStatisticsTestSupport {
   override def parameters(name: String): Map[String, Any] =
     name match {
       case "parameters=point" =>
-        Map("x" -> 2.3, "y" -> 4.5)
+        Map("x" -> 2.3, "y" -> 4.5, "z" -> 6.7)
       case "parameters=distance" =>
         Map("x1" -> 2.3, "y1" -> 4.5, "x2" -> 1.3, "y2" -> 3.5)
       case "" =>
@@ -52,12 +52,33 @@ RETURN
 
 point({x: {x}, y: {y}})
 ###
-Returns a point in a 2D coordinate system.
+Returns a point in a 2D cartesian coordinate system.
+
+###assertion=returns-one parameters=point
+RETURN
+
+point({latitude: {y}, longitude: {x}})
+###
+Returns a point in a 2D geographic coordinate system.
+
+###assertion=returns-one parameters=point
+RETURN
+
+point({x: {x}, y: {y}, z: {z}})
+###
+Returns a point in a 3D cartesian coordinate system.
+
+###assertion=returns-one parameters=point
+RETURN
+
+point({latitude: {y}, longitude: {x}, height: {z}})
+###
+Returns a point in a 3D geographic coordinate system.
 
 ###assertion=returns-one parameters=distance
 RETURN
 
-distance(point({x: {x1}, y: {y1}}), point({x: {x2}, y: {y2}}))
+distance(point({latitude: {y1}, longitude: {x1}}), point({latitude: {y2}, longitude: {x2}}))
 ###
 
 Returns a floating point number representing the geodesic distance between two points.

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SpatialFunctionsTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SpatialFunctionsTest.scala
@@ -78,11 +78,11 @@ Returns a point in a 3D geographic coordinate system, with latitude and longitud
 ###assertion=returns-one parameters=distance
 RETURN
 
-distance(point({x: $x1, y: $y1}), point({x: $x2, y: $2}))
+distance(point({x: $x1, y: $y1}), point({x: $x2, y: $y2}))
 ###
 
 Returns a floating point number representing the linear distance between two points.
-The units will be the same as those of the points, and it will work for both 2D and 3D cartesian points.
+The returned units will be the same as those of the point coordinates, and it will work for both 2D and 3D cartesian points.
 
 ###assertion=returns-one parameters=distance
 RETURN

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/TemporalFunctionsTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/TemporalFunctionsTest.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.docgen.refcard
+
+import java.time._
+
+import org.neo4j.cypher.QueryStatisticsTestSupport
+import org.neo4j.cypher.docgen.RefcardTest
+import org.neo4j.cypher.internal.runtime.InternalExecutionResult
+
+class TemporalFunctionsTest extends RefcardTest with QueryStatisticsTestSupport {
+  val graphDescription = List("ROOT KNOWS A")
+  val title = "Temporal Functions"
+  override val linkId = "functions/temporal"
+
+  override def assert(name: String, result: InternalExecutionResult) {
+    name match {
+      case "returns-one" =>
+        assertStats(result, nodesCreated = 0)
+        assert(result.toList.size === 1)
+    }
+  }
+
+  override def parameters(name: String): Map[String, Any] = {
+    val date = LocalDate.parse("2018-04-05")
+    val time = OffsetTime.of(12, 45, 30, 250000000, ZoneOffset.ofHours(1))
+    val localtime = LocalTime.of(12, 45, 30, 250000000)
+    val datetime = java.time.ZonedDateTime.of(date, localtime, ZoneId.of("+01:00"))
+    name match {
+      case "parameters=date" =>
+        Map("year" -> 2018, "month" -> 5, "day" -> 8)
+      case "parameters=datetime" =>
+        Map("date" -> date, "time" -> time)
+      case "parameters=dateselection" =>
+        Map("datetime" -> datetime)
+      case "" =>
+        Map()
+    }
+  }
+
+  def text = """
+###assertion=returns-one
+RETURN
+
+date("2018-04-05")
+###
+Returns a date parsed from a string.
+
+###assertion=returns-one
+RETURN
+
+localtime("12:45:30.25")
+###
+
+Returns a time with no timezone.
+
+###assertion=returns-one
+RETURN
+
+time("12:45:30.25+01:00")
+###
+
+Returns a time in a specified timezone.
+
+###assertion=returns-one
+RETURN
+
+localdatetime("2018-04-05T12:34:00")
+###
+
+Returns a datetime with no timezone.
+
+###assertion=returns-one
+RETURN
+
+datetime("2018-04-05T12:34:00[Europe/Berlin]")
+###
+
+Returns a datetime in the specified timezone.
+
+###assertion=returns-one parameters=date
+RETURN
+
+date({year: {year}, month: {month}, day: {day}})
+###
+
+All of the temporal functions can also be called with a map of named components.
+This example returns a date from `year`, `month` and `day` components.
+Each function supports a different set of possible components.
+
+###assertion=returns-one parameters=datetime
+RETURN
+
+datetime({date: {date}, time: {time}})
+###
+
+Temporal types can be created by combining other types. This example creates a `datetime` from a `date` and a `time`.
+
+###assertion=returns-one parameters=dateselection
+RETURN
+
+date({date: {datetime}, day: 5})
+###
+
+Temporal types can be created by selecting from more complex types, as well as overriding individual components.
+This example creates a `date` by selecting from a `datetime`, as well as overriding the `day` component.
+
+###assertion=returns-one parameters=dateselection
+
+
+WITH date("2018-04-05") AS d
+RETURN d.year, d.month, d.day, d.week, d.dayOfWeek
+###
+
+Accessors allow extracting components of temporal types.
+
+"""
+}

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/TemporalFunctionsTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/TemporalFunctionsTest.scala
@@ -69,7 +69,7 @@ RETURN
 localtime("12:45:30.25")
 ###
 
-Returns a time with no timezone.
+Returns a time with no time zone.
 
 ###assertion=returns-one
 RETURN
@@ -77,7 +77,7 @@ RETURN
 time("12:45:30.25+01:00")
 ###
 
-Returns a time in a specified timezone.
+Returns a time in a specified time zone.
 
 ###assertion=returns-one
 RETURN
@@ -85,7 +85,7 @@ RETURN
 localdatetime("2018-04-05T12:34:00")
 ###
 
-Returns a datetime with no timezone.
+Returns a datetime with no time zone.
 
 ###assertion=returns-one
 RETURN
@@ -93,7 +93,7 @@ RETURN
 datetime("2018-04-05T12:34:00[Europe/Berlin]")
 ###
 
-Returns a datetime in the specified timezone.
+Returns a datetime in the specified time zone.
 
 ###assertion=returns-one parameters=date
 RETURN


### PR DESCRIPTION
Adds support for temporal types in two sections, one for temporal instances and one for durations which behave quite differently and so it made more sense to separate it out.

We also have a few small updates to the spatial functions to 3D support and clarification on units.