### PR TITLE
Adapt QueryPlanTest to new Create operator

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/execution-plans.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/execution-plans.asciidoc
@@ -64,10 +64,9 @@ This table comprises all the execution plan operators ordered lexicographically.
 | <<query-plan-cartesian-product, CartesianProduct>>                 | Produces a cartesian product of the inputs from the left-hand and right-hand operators.  | |
 | <<query-plan-conditional-apply, ConditionalApply>>                         | Performs a nested loop. If a variable is not `null`, the right-hand side will be executed.  | |
 | <<query-plan-create-index, CreateIndex>>              | Creates an index on a property for all nodes having a certain label.  | Y | Y
-| <<query-plan-create-node, CreateNode>>              | Creates a node.  | Y | Y
+| <<query-plan-create, Create>>              | Creates nodes and relationships.  | | Y
 | <<query-plan-create-node-key-constraint, CreateNodeKeyConstraint>>     |  Creates a Node Key on a set of properties for all nodes having a certain label.  | Y | Y
 | <<query-plan-create-node-property-existence-constraint, CreateNodePropertyExistenceConstraint>>     |  Creates an existence constraint on a property for all nodes having a certain label.  | Y | Y
-| <<query-plan-create-relationship, CreateRelationship>>              | Creates a relationship.  | | Y
 | <<query-plan-create-relationship-property-existence-constraint, CreateRelationshipPropertyExistenceConstraint>>     | Creates an existence constraint on a property for all relationships of a certain type.  | Y | Y
 | <<query-plan-create-unique-constraint, CreateUniqueConstraint>>                  | Creates a unique constraint on a property for all nodes having a certain label.  | Y | Y
 | <<query-plan-delete, Delete>>                                          | Deletes a node or relationship.  | | Y

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
@@ -308,25 +308,16 @@ class QueryPlanTest extends DocumentingTestBase with SoftReset {
     )
   }
 
-  @Test def createNode() {
+  @Test def create() {
     profileQuery(
-      title = "Create Node",
+      title = "Create Nodes / Relationships",
       text =
-        """The `CreateNode` operator is used to create a node.""".stripMargin,
-      queryText = """CREATE (:Person {name: 'Jack'})""",
-      assertions = (p) => assertThat(p.executionPlanDescription().toString, containsString("CreateNode"))
-    )
-  }
-
-  @Test def createRelationship() {
-    profileQuery(
-      title = "Create Relationship",
-      text =
-        """The `CreateRelationship` operator is used to create a relationship.""".stripMargin,
+        """The `Create` operator is used to create nodes and relationships.""".stripMargin,
       queryText =
-        """MATCH (a:Person {name: 'Max'}), (b:Person {name: 'Chris'})
-          |CREATE (a)-[:FRIENDS_WITH]->(b)""".stripMargin,
-      assertions = (p) => assertThat(p.executionPlanDescription().toString, containsString("CreateRelationship"))
+        """CREATE (max:Person {name: 'Max'}), (chris:Person {name: 'Chris'})
+          |CREATE (max)-[:FRIENDS_WITH]->(chris)""".stripMargin,
+
+      assertions = p => assertThat(p.executionPlanDescription().toString, containsString("Create"))
     )
   }
 


### PR DESCRIPTION
We are changing creates to flatten `CreateNode` and `CreateRelationship` into one operator `Create`. This PR changes docs to reflect this.