### PR TITLE
Add Cypher deprecations

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -112,6 +112,7 @@ An example of this is `CALL db.index.explicit.searchNodes('my_index','email:me*'
 [options="header"]
 |===
 | Feature          | Type | Change | Details
+| `CYPHER runtime=compiled` (Compiled runtime)    | Functionality | Deprecated | The compiled runtime will be discontinued on the next major release. It might still be used for default queries in order to not cause regressions, but explicitly requesting it will not be possible.
 |===
 
 [[cypher-compatibility]]

--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -112,7 +112,9 @@ An example of this is `CALL db.index.explicit.searchNodes('my_index','email:me*'
 [options="header"]
 |===
 | Feature          | Type | Change | Details
-| `CYPHER runtime=compiled` (Compiled runtime)    | Functionality | Deprecated | The compiled runtime will be discontinued on the next major release. It might still be used for default queries in order to not cause regressions, but explicitly requesting it will not be possible.
+| `CYPHER runtime=compiled` (Compiled runtime)    | Functionality | Deprecated | The compiled runtime will be discontinued in the next major release. It might still be used for default queries in order to not cause regressions, but explicitly requesting it will not be possible.
+| `extract()`   | Function  | Deprecated | Replaced by <<cypher-list-comprehension, list comprehension>>
+| `filter()`   | Function  | Deprecated | Replaced by <<cypher-list-comprehension, list comprehension>>
 |===
 
 [[cypher-compatibility]]

--- a/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
@@ -162,8 +162,8 @@ This section comprises a glossary of all the keywords -- grouped by category and
 |<<functions-endnode, endNode()>>                | Scalar            | Returns the end node of a relationship.
 |<<functions-exists, exists()>>                  | Predicate         | Returns true if a match for the pattern exists in the graph, or if the specified property exists in the node, relationship or map.
 |<<functions-exp, exp()>>                       | Logarithmic       | Returns `e^n`, where `e` is the base of the natural logarithm, and `n` is the value of the argument expression.
-|<<functions-extract, extract()>>                | List              | Returns a list `l~result~` containing the values resulting from an expression which has been applied to each element in a list `list`.
-|<<functions-filter, filter()>>                  | List              | Returns a list `l~result~` containing all the elements from a list `list` that comply with a predicate.
+|<<functions-extract, extract()>>                | List              | [deprecated]#Returns a list `l~result~` containing the values resulting from an expression which has been applied to each element in a list `list`.#
+|<<functions-filter, filter()>>                  | List              | [deprecated]#Returns a list `l~result~` containing all the elements from a list `list` that comply with a predicate.#
 |<<functions-floor, floor()>>                   | Numeric           | Returns the largest floating point number that is less than or equal to a number and equal to a mathematical integer.
 |<<functions-haversin, haversin()>>             | Trigonometric     | Returns half the versine of a number.
 |<<functions-head, head()>>                      | Scalar            | Returns the first element in a list.
@@ -271,10 +271,10 @@ This section comprises a glossary of all the keywords -- grouped by category and
 |===
 |Name           | Type | Description
 | <<cypher-version, CYPHER $version query>>  | Version | This will force `'query'` to use Neo4j Cypher `$version`. The default is `3.3`.
-| <<cypher-planner, CYPHER planner=rule query>> | Planner | This will force `'query'` to use the rule planner. As the rule planner was removed in 3.2, doing this will cause `'query'` to fall back to using Cypher 3.1.
+| <<cypher-planner, CYPHER planner=rule query>> | Planner | [deprecated]#This will force `'query'` to use the rule planner. As the rule planner was removed in 3.2, doing this will cause `'query'` to fall back to using Cypher 3.1.#
 | <<cypher-planner, CYPHER planner=cost query>> | Planner | Neo4j {neo4j-version} uses the cost planner for all queries.
 | <<cypher-runtime, CYPHER runtime=interpreted query>> | Runtime | This will force the query planner to use the interpreted runtime. This is the only option in Neo4j Community Edition.
 | <<cypher-runtime, CYPHER runtime=slotted query>> | Runtime | This will cause the query planner to use the slotted runtime. This is only available in Neo4j Enterprise Edition.
-| <<cypher-runtime, CYPHER runtime=compiled query>> | Runtime | This will cause the query planner to use the compiled runtime if it supports `'query'`. This is only available in Neo4j Enterprise Edition.
+| <<cypher-runtime, CYPHER runtime=compiled query>> | Runtime | [deprecated]#This will cause the query planner to use the compiled runtime if it supports `'query'`. This is only available in Neo4j Enterprise Edition.#
 |===
 

--- a/cypher/cypher-docs/src/docs/dev/ql/functions/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/functions/index.asciidoc
@@ -104,8 +104,8 @@ Further details and examples of lists may be found in <<cypher-lists>>.
 [options="header"]
 |===
 |Function                                       | Description
-|<<functions-extract,extract()>>                | Returns a list `l~result~` containing the values resulting from an expression which has been applied to each element in a list `list`.
-|<<functions-filter,filter()>>                  | Returns a list `l~result~` containing all the elements from a list `list` that comply with a predicate.
+|<<functions-extract,extract()>>                | [deprecated]#Returns a list `l~result~` containing the values resulting from an expression which has been applied to each element in a list `list`.#
+|<<functions-filter,filter()>>                  | [deprecated]#Returns a list `l~result~` containing all the elements from a list `list` that comply with a predicate.#
 |<<functions-keys,keys()>>                      | Returns a list containing the string representations for all the property names of a node, relationship, or map.
 |<<functions-labels,labels()>>                  | Returns a list containing the string representations for all the labels of a node.
 |<<functions-nodes,nodes()>>                    | Returns a list containing all the nodes in a path.

--- a/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
@@ -69,15 +69,18 @@ The execution plan tells Neo4j which operations to perform when executing the qu
 
 Neo4j uses a _cost_-based execution planning strategy (known as the 'cost' planner): the statistics service in Neo4j is used to assign a cost to alternative plans and picks the cheapest one.
 
+[role=deprecated]
+.Cypher rule planner
 All versions of Neo4j prior to Neo4j 3.2 also included a rule-based planner, which used rules to produce execution plans.
 This planner considered available indexes, but did not use statistical information to guide the query compilation.
 The rule planner was removed in Neo4j 3.2 owing to inferior query execution performance when compared with the cost planner.
+It can still be used, but doing so will fallback to the Neo4j 3.1 rule planner.
 
 
 [options="header"]
 |===
 | Option         | Description | Default?
-| `planner=rule` | This will force the query to use the rule planner, and will therefore cause the query to fall back to using Cypher 3.1.  |
+| `planner=rule` | [deprecated]#This will force the query to use the rule planner, and will therefore cause the query to fall back to using Cypher 3.1.#  |
 | `planner=cost` | Neo4j {neo4j-version} uses the cost planner for _all_ queries, and therefore it is not necessary to use this option explicitly. | X
 |===
 
@@ -93,7 +96,7 @@ These index decisions are only valid until the schema changes, so adding or remo
 [[cypher-runtime]]
 === Cypher runtime
 
-Using the execution plan, the query is executed -- and records returned -- by the Cypher query planner, or _runtime_.
+Using the execution plan, the query is executed -- and records returned -- by the Cypher _runtime_.
 Depending on whether Neo4j Enterprise Edition or Neo4j Community Edition is used, there are three different runtimes available.
 In Enterprise Edition, the Cypher query planner selects the runtime, falling back to alternative runtimes as follows:
 
@@ -122,7 +125,7 @@ While this should lead to superior performance in most cases (over both the inte
 | Option | Description | Default?
 | `runtime=interpreted` | This will force the query planner to use the interpreted runtime. | This is not used in Enterprise Edition unless explicitly asked for. It is the only option for all queries in Community Edition--it is not necessary to specify this option in Community Edition.
 | `runtime=slotted` | This will cause the query planner to use the slotted runtime. | [enterprise-edition]#This is the default option for all queries which are not supported by `runtime=compiled` in Enterprise Edition.#
-| `runtime=compiled` | This will cause the query planner to use the compiled runtime if it supports the query. If the compiled runtime does not support the query, the planner will fall back to the slotted runtime. | [enterprise-edition]#This is the default option for some queries in Enterprise Edition.#
+| `runtime=compiled` | [deprecated]#This will cause the query planner to use the compiled runtime if it supports the query. If the compiled runtime does not support the query, the planner will fall back to the slotted runtime.# | [enterprise-edition]#This is the default option for some queries in Enterprise Edition.#
 |===
 
 

--- a/cypher/cypher-docs/src/docs/dev/tutorials/gists/cypher/finding-paths.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/tutorials/gists/cypher/finding-paths.asciidoc
@@ -110,8 +110,7 @@ But that's a lot of data, we just want to look at the names and titles of the no
 [source, cypher]
 ----
 MATCH p = (:Actor {name: 'Keanu Reeves'})-[:ACTS_IN*0..5]-(:Actor {name: 'Carrie-Anne Moss'})
-RETURN extract(n IN nodes(p) |
-         coalesce(n.title,n.name)) AS `names and titles`,
+RETURN [n IN nodes(p) | coalesce(n.title,n.name)] AS `names and titles`,
        length(p)
 ORDER BY length(p)
 LIMIT 10;

--- a/cypher/cypher-docs/src/docs/graphgists/intro/data-structures.adoc
+++ b/cypher/cypher-docs/src/docs/graphgists/intro/data-structures.adoc
@@ -54,14 +54,14 @@ There are list predicates to satisfy conditions for `all`, `any`, `none` and `si
 ----
 MATCH path = (:Person)-->(:Movie)<--(:Person)
 WHERE any(n in nodes(path) WHERE n.name = 'Michael Douglas')
-RETURN extract(n IN nodes(path)| coalesce(n.name, n.title))
+RETURN [n IN nodes(path) | coalesce(n.name, n.title)]
 ----
 
 //table
 
 == List Processing
 
-Sometimes you want to process lists to `filter`, aggregate (`reduce`) or transform (`extract`) their values.
+Sometimes you want to process lists to filter, aggregate (`reduce`) or transform their values.
 Those transformations can be done within Cypher or in the calling code.
 This kind of list-processing can reduce the amount of data handled and returned, so it might make sense to do it within the Cypher statement.
 
@@ -70,8 +70,8 @@ A simple, non-graph example would be:
 [source, cypher]
 ----
 WITH range(1, 10) as numbers
-WITH extract(n IN numbers | n*n) AS squares
-WITH filter(n IN squares WHERE n > 25) AS large_squares
+WITH [n IN numbers | n*n] AS squares
+WITH [n IN squares WHERE n > 25] AS large_squares
 RETURN reduce(a = 0, n IN large_squares | a + n) AS sum_large_squares
 ----
 
@@ -84,7 +84,7 @@ In a graph-query you can filter or aggregate collected values instead or work on
 ----
 MATCH (m:Movie)<-[r:ACTED_IN]-(a:Person)
 WITH m.title AS movie, collect({name: a.name, roles: r.roles}) AS cast
-RETURN movie, filter(actor IN cast WHERE actor.name STARTS WITH 'M')
+RETURN movie, [actor IN cast WHERE actor.name STARTS WITH 'M']
 ----
 
 //table

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ListFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ListFunctionsTest.scala
@@ -44,6 +44,7 @@ class ListFunctionsTest extends DocumentingTest {
     p("Further details and examples of lists may be found in <<cypher-lists>> and <<query-operators-list>>.")
     note {
       p("The function `rels()` has been superseded by `relationships()`, and will be removed in a future release.")
+      p("The functions `extract()` and `filter()` have been deprecated and will be removed in a future release. Consider using a list comprehension (e.g. `[x IN xs WHERE predicate | extraction]`) instead.")
     }
     p(
       """Functions:

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ListFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ListFunctionsTest.scala
@@ -44,7 +44,7 @@ class ListFunctionsTest extends DocumentingTest {
     p("Further details and examples of lists may be found in <<cypher-lists>> and <<query-operators-list>>.")
     note {
       p("The function `rels()` has been superseded by `relationships()`, and will be removed in a future release.")
-      p("The functions `extract()` and `filter()` have been deprecated and will be removed in a future release. Consider using a list comprehension (e.g. `[x IN xs WHERE predicate | extraction]`) instead.")
+      p("The functions `extract()` and `filter()` have been deprecated and will be removed in a future release. Consider using a <<cypher-list-comprehension, list comprehension>> (e.g. `[x IN xs WHERE predicate | extraction]`) instead.")
     }
     p(
       """Functions:
@@ -63,7 +63,7 @@ class ListFunctionsTest extends DocumentingTest {
     section("extract()", "functions-extract") {
       p(
         """`extract()` returns a list `l~result~` containing the values resulting from an expression which has been applied to each element in a list `list`.
-           |This function is analogous to the `map` method in functional languages such as Lisp and Scala.""".stripMargin)
+          |This function is analogous to the `map` method in functional languages such as Lisp and Scala. Note that this function has been deprecated, consider using a <<cypher-list-comprehension, list comprehension>> (e.g. `[variable IN list | expression]`) instead.""".stripMargin)
       function("extract(variable IN list | expression)", "A list containing heterogeneous elements; the types of the elements are determined by `expression`.", ("list", "An expression that returns a list."), ("variable", "The closure will have a variable introduced in its context. We decide here which variable to use."), ("expression", "This expression will run once per value in `list`, and add it to the list which is returned by `extract()`."))
       considerations("Any `null` values in `list` are preserved.")
       p(
@@ -83,7 +83,7 @@ class ListFunctionsTest extends DocumentingTest {
       }
     }
     section("filter()", "functions-filter") {
-      p("""`filter()` returns a list `l~result~` containing all the elements from a list `list` that comply with the given predicate.""")
+      p("""`filter()` returns a list `l~result~` containing all the elements from a list `list` that comply with the given predicate. Note that this function has been deprecated, consider using a <<cypher-list-comprehension, list comprehension>> (e.g. `[variable IN list WHERE predicate]`) instead.""")
       function("filter(variable IN list WHERE predicate)", "A list containing heterogeneous elements; the types of the elements are determined by the elements in `list`.", ("list", "An expression that returns a list."), ("variable", "This is the variable that can be used from the predicate."), ("predicate", "A predicate that is tested against all elements in `list`."))
       query(
         """MATCH (a)


### PR DESCRIPTION
Add deprecation warnings to

 * rule planner
 * compiled runtime
 * extract, filter, all, any, none, single

I noticed that these things are also in the refcard, but am unsure of how to deprecate content there, or if it's actually better to just remove deprecated things from there and replace them with the relevant list-comprehension. Which conveniently bring me to wonder: is there any place where list-comprehensions (e.g. `[x IN xs WHERE x.name = "johan" | x.age / 10]`) are presented. I couldn't really find it, maybe we should add more on that.