### PR TITLE
Add information about quoting in csv format

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/ql/load-csv/csv-file-format.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/load-csv/csv-file-format.asciidoc
@@ -9,4 +9,5 @@ The CSV file to use with `LOAD CSV` must have the following characteristics:
 * the field terminator character can be change by using the option `FIELDTERMINATOR` available in the `LOAD CSV` command;
 * quoted strings are allowed in the CSV file and the quotes are dropped when reading the data;
 * the character for string quotation is double quote `"`;
-* the escape character is `\`.
+* if `dbms.import.csv.legacy_quote_escaping` is set to the default value of `true`, `\` is used as an escape character;
+* a double quote must be in a quoted string and escaped, either with the escape character or a second double quote.

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CsvFile.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CsvFile.scala
@@ -32,15 +32,19 @@ class CsvFile(fileName: String, delimiter: Char = ',')(implicit csvFilesDir: Fil
   import CsvFile._
 
   def withContents(lines: Seq[String]*): String = {
-    val csvFile = withContentsF(lines:_*)
+    val csvFile = withContentsF(false, lines:_*)
     urify(csvFile)
   }
 
   def withContentsF(lines: Seq[String]*): File = {
+    withContentsF(false, lines:_*)
+  }
+
+  def withContentsF(quoted: Boolean, lines: Seq[String]*): File = {
     val csvFile = new File(csvFilesDir, fileName)
     val writer = new PrintWriter(csvFile, StandardCharsets.UTF_8.name())
     lines.foreach(line => {
-      writer.println(line.map(s => '"' + s + '"').mkString(delimiter.toString))
+      writer.println(line.map(s => if (quoted) '"' + s + '"' else s).mkString(delimiter.toString))
     })
     writer.flush()
     writer.close()

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/LoadCSVTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/LoadCSVTest.scala
@@ -56,7 +56,7 @@ class LoadCSVTest extends DocumentingTestBase with QueryStatisticsTestSupport wi
     Seq("4", "The Cardigans", "1992")
   )
 
-  private val artistsWithEscapeChar = new CsvFile("artists-with-escaped-char.csv").withContentsF(
+  private val artistsWithEscapeChar = new CsvFile("artists-with-escaped-char.csv").withContentsF(quoted = true,
     Seq("1", "The \"\"Symbol\"\"", "1992")
   )
 


### PR DESCRIPTION
More explicit information about how escaping works.

Replaces https://github.com/neo4j/neo4j-documentation/pull/261