### PR TITLE
Fix iBob docs

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
@@ -151,6 +151,6 @@ The same goes for labels, where declaring labels on both the start and end nodes
 
 include::../parsed-graphgists/query-tuning/basic-query-tuning-example.asciidoc[leveloffset=+1]
 
-include::ql/query-using.adoc[leveloffset=+1]
-
 include::../parsed-graphgists/query-tuning/advanced-query-tuning-example.asciidoc[leveloffset=+1]
+
+include::ql/query-using.adoc[leveloffset=+1]

--- a/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
@@ -25,7 +25,6 @@ To read more about the execution plan operators mentioned in this chapter, see <
 * <<how-do-i-profile-a-query,Profiling a query>>
 * <<cypherdoc-basic-query-tuning-example,Basic query tuning example>>
 * <<cypher-index-values-order,Index Values and Order>>
-** <<cypherdoc-advanced-query-tuning-example,Advanced query tuning example>>
 * <<query-using,Planner hints and the `USING` keyword>>
 ** <<query-using-introduction,Introduction>>
 ** <<query-using-index-hint,Index hints>>
@@ -154,24 +153,4 @@ include::../parsed-graphgists/query-tuning/basic-query-tuning-example.asciidoc[l
 
 include::ql/query-using.adoc[leveloffset=+1]
 
-
-[[cypher-index-values-order]]
-== Index Values and Order
-
-[abstract]
---
-This section describes some more subtle optimizations based on new native index capabilities
---
-
-One of the most important and useful ways of optimizing Cypher queries involves creating appropriate indexes.
-This is described in more detail in the section on '<<query-schema-index,Indexes>>', and demonstrated in the <<cypherdoc-basic-query-tuning-example,basic query tuning example>>.
-In summary an index will be based on the combination of a `Label` and a `property`.
-Any Cypher query that searches for nodes with a specific label and some predicate on the property (equality, range or existence) will be planned to use
-the index if the cost planner deems that to be the most efficient solution.
-
-In order to benefit from some recent enhancements added to Neo4j 3.5, it is useful to understand when _index-backed property lookup_ and _index-backed order-by_ will come into play.
-In versions of Neo4j prior to 3.5, the fact that the index contains the property value, and the results are returned in a specific order, was not used improve the performance of any later part of the query that might depend on the property value or result order.
-
-Let's explain how to use these features with a more <<cypherdoc-basic-query-tuning-example,advanced query tuning example>>.
-
-include::../parsed-graphgists/query-tuning/advanced-query-tuning-example.asciidoc[leveloffset=+2]
+include::../parsed-graphgists/query-tuning/advanced-query-tuning-example.asciidoc[leveloffset=+1]

--- a/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
@@ -55,8 +55,8 @@ Here we detail the available versions:
 |===
 | Query option | Description | Default?
 | `2.3` | This will force the query to use Neo4j Cypher 2.3. |
-| `3.3` | This will force the query to use Neo4j Cypher 3.3. |
-| `3.4` | This will force the query to use Neo4j Cypher 3.4. As this is the default version, it is not necessary to use this option explicitly. | X
+| `3.4` | This will force the query to use Neo4j Cypher 3.4. |
+| `3.5` | This will force the query to use Neo4j Cypher 3.5. As this is the default version, it is not necessary to use this option explicitly. | X
 |===
 
 

--- a/cypher/cypher-docs/src/docs/graphgists/query-tuning/advanced-query-tuning-example.asciidoc
+++ b/cypher/cypher-docs/src/docs/graphgists/query-tuning/advanced-query-tuning-example.asciidoc
@@ -79,7 +79,7 @@ Now that we have a model of movies, actors and directors we can ask a question l
 
 [source, cypher]
 ----
-MATCH (p:Person)-[:ACTED_IN]->(m:Movie) USING INDEX p:Person(name) WHERE p.name STARTS WITH 'Tom'
+MATCH (p:Person)-[:ACTED_IN]->(m:Movie) WHERE p.name STARTS WITH 'Tom'
 RETURN p.name, count(m)
 ----
 
@@ -88,15 +88,16 @@ RETURN p.name, count(m)
 We have asked the database to return all the actors with the first name 'Tom'. There are three of them _'Tom Cruise'_, _'Tom Skerritt'_ and _'Tom Hanks'_.
 In previous versions of Neo4j, the final clause `RETURN p.name` would cause the database to take the node `p` and lookup its properties and return the value
 of the property `name`.
-In Neo4j 3.5 we can now leverage the fact that indexes store the property values and. In this case, it means that the names can be looked up directly from
-the index. This allows Cypher to avoid the second call to the database to find the property, which can save time on very large queries. If we profile the
-above query, we see that the `NodeIndexScan` in the Variables column contains `cached[p.name]`, which means that `p.name` is retrieved from the index.
+In Neo4j 3.5 we can now leverage the fact that indexes store the property values.
+In this case, it means that the names can be looked up directly from the index.
+This allows Cypher to avoid the second call to the database to find the property, which can save time on very large queries.
+If we profile the above query, we see that the `NodeIndexScan` in the Variables column contains `cached[p.name]`, which means that `p.name` is retrieved from the index.
 We can also see that the `Projection` has no DB Hits, which means it does not have to access the database again.
 
 [source, cypher]
 ----
 PROFILE
-MATCH (p:Person)-[:ACTED_IN]->(m:Movie) USING INDEX p:Person(name) WHERE p.name STARTS WITH 'Tom'
+MATCH (p:Person)-[:ACTED_IN]->(m:Movie) WHERE p.name STARTS WITH 'Tom'
 RETURN p.name, count(m)
 ----
 
@@ -143,7 +144,7 @@ Now consider the following refinement to the query:
 
 [source, cypher]
 ----
-MATCH (p:Person)-[:ACTED_IN]->(m:Movie) USING INDEX p:Person(name) WHERE p.name STARTS WITH 'Tom'
+MATCH (p:Person)-[:ACTED_IN]->(m:Movie) WHERE p.name STARTS WITH 'Tom'
 RETURN p.name, count(m) ORDER BY p.name
 ----
 
@@ -154,11 +155,11 @@ In Neo4j 3.4 and earlier, Cypher would plan a `Sort` operation to sort the resul
 For large result sets this can be expensive in both memory and time. In Neo4j 3.5, if you are using the native index, Cypher will recognise that the index already
 returns data in the correct order, and skip the `Sort` operation.
 
-However, indexes storing values of the spatial type `Point` and non-native indexes do not store the values in the correct order. That means, Cypher needs a
-predicate that fixes the type of the property to some type that is guaranteed to be in the right order.
+However, indexes storing values of the spatial type `Point` and non-native indexes cannot be relied on to return the values in the correct order.
+This means that for Cypher to enable this optimization the query needs a predicate that limits the type of the property to some type that is guaranteed to be in the right order.
 
-To demonstrate this effect, let's remove the String prefix predicate so that Cypher no longer knows the type of the property, and replace it with an existance
-predicate. Now the database can no longer guarantee the order. If we profile the query we will see the `Sort` operation:
+To demonstrate this effect, let's remove the String prefix predicate so that Cypher no longer knows the type of the property, and replace it with an existence predicate.
+Now the database can no longer guarantee the order. If we profile the query we will see the `Sort` operation:
 
 [source, cypher]
 ----
@@ -176,19 +177,19 @@ we will see the `Sort` operation is no longer there:
 [source, cypher]
 ----
 PROFILE
-MATCH (p:Person)-[:ACTED_IN]->(m:Movie) USING INDEX p:Person(name) WHERE p.name STARTS WITH 'Tom'
+MATCH (p:Person)-[:ACTED_IN]->(m:Movie) WHERE p.name STARTS WITH 'Tom'
 RETURN p.name, count(m) ORDER BY p.name
 ----
 
 //profile
 
-We also see that the `Order` column contains `p.name ASC` from the beginning, meaning that the rows are ordered by `p.name` in ascending order.
+We also see that the `Order` column contains `p.name ASC` from the index seek operation, meaning that the rows are ordered by `p.name` in ascending order.
 
 Index-backed order-by can just as well be used for queries that expect their results is descending order, but with slightly lower performance.
 
 ==== Restrictions
 
-The optimization can only work on new native indexes and only if we are returning no values of the spatial type `Point`.
+The optimization can only work on new native indexes and only if we query for a specific type in order to rule out the spatial type `Point`.
 Predicates that can be used to enable this optimization are:
 
 * Equality (e.g. `WHERE n.name = 'Tom Hanks'`)

--- a/cypher/cypher-docs/src/docs/graphgists/query-tuning/advanced-query-tuning-example.asciidoc
+++ b/cypher/cypher-docs/src/docs/graphgists/query-tuning/advanced-query-tuning-example.asciidoc
@@ -120,8 +120,8 @@ RETURN p.name, count(m)
 
 It is important to note, however, that not all property types are supported, because not all have been ported to the new native index.
 In addition some property types, like the spatial type `Point`, are indexed in an index that is designed to be approximate and cannot return the values.
-For non-native indexes and the spatial type `Point`, there will still be a second DB access to retrieve those values. In indexes with mixed values,
-only those values that cannot be lookup up from the index will trigger another database access, while the other values will not.
+For non-native indexes and the spatial type `Point`, there will still be a second DB access to retrieve those values.
+In indexes with mixed values, only those values that cannot be looked up from the index will trigger another database access action, while the other values will not.
 
 Note also that if you have pre-existing indexes that were build on lucene, upgrading to Neo4j 3.5 is _not sufficient_ to use the new index.
 It is necessary to drop and re-create the index in order to port it to the native index.
@@ -154,8 +154,8 @@ RETURN p.name, count(m) ORDER BY p.name
 
 We are asking for the results in ascending alphabetical order. The new native index happens to store the String properties in ascending alphabetical order, and Cypher knows this.
 In Neo4j 3.4 and earlier, Cypher would plan a `Sort` operation to sort the results, which means building a collection in memory and running a sort algorithm on it.
-For large result sets this can be expensive in terms of both memory and time. In Neo4j 3.5, if you are using the native index, Cypher will recognise that the index already
-returns data in the correct order, and skip the `Sort` operation.
+For large result sets this can be expensive in terms of both memory and time.
+In Neo4j 3.5, if you are using the native index, Cypher will recognise that the index already returns data in the correct order, and skip the `Sort` operation.
 
 However, indexes storing values of the spatial type `Point` and non-native indexes cannot be relied on to return the values in the correct order.
 This means that for Cypher to enable this optimization, the query needs a predicate that limits the type of the property to some type that is guaranteed to be in the right order.

--- a/cypher/cypher-docs/src/docs/graphgists/query-tuning/advanced-query-tuning-example.asciidoc
+++ b/cypher/cypher-docs/src/docs/graphgists/query-tuning/advanced-query-tuning-example.asciidoc
@@ -1,4 +1,23 @@
-= Advanced query tuning example
+[[cypher-index-values-order]]
+= Index Values and Order
+
+[abstract]
+--
+This section describes some more subtle optimizations based on new native index capabilities
+--
+
+One of the most important and useful ways of optimizing Cypher queries involves creating appropriate indexes.
+This is described in more detail in the section on '<<query-schema-index,Indexes>>', and demonstrated in the <<cypherdoc-basic-query-tuning-example,basic query tuning example>>.
+In summary an index will be based on the combination of a `Label` and a `property`.
+Any Cypher query that searches for nodes with a specific label and some predicate on the property (equality, range or existence) will be planned to use
+the index if the cost planner deems that to be the most efficient solution.
+
+In order to benefit from some recent enhancements added to Neo4j 3.5, it is useful to understand when _index-backed property lookup_ and _index-backed order-by_ will come into play.
+In versions of Neo4j prior to 3.5, the fact that the index contains the property value, and the results are returned in a specific order, was not used improve the performance of any later part of the query that might depend on the property value or result order.
+
+Let's explain how to use these features with a more advanced query tuning example.
+
+== Advanced query tuning example
 
 As with the <<cypherdoc-basic-query-tuning-example,basic query tuning example>> we'll use a movies data set to demonstrate how to do some more advanced query tuning.
 This time we'll create the index up-front. If you want to see the effect of adding an index, refer back to the <<cypherdoc-basic-query-tuning-example,basic query tuning example>>.
@@ -54,7 +73,7 @@ CALL db.indexes
 
 //table
 
-== Index-backed property-lookup
+=== Index-backed property-lookup
 
 Now that we have a model of movies, actors and directors we can ask a question like 'find persons with the name Tom that acted in a movie':
 
@@ -67,20 +86,58 @@ RETURN p.name, count(m)
 //table
 
 We have asked the database to return all the actors with the first name 'Tom'. There are three of them _'Tom Cruise'_, _'Tom Skerritt'_ and _'Tom Hanks'_.
-In previous versions of Neo4j, the final clause `RETURN p.name` would cause the database to take the node `p` and lookup its properties and return the value of the property `name`.
-In Neo4j 3.5 we can now support string properties in the native index, and this index is capable of returning the indexed property value together with the indexed nodes.
-This allows Cypher to avoid the second call to the database to find the property, which can save time on very large queries.
+In previous versions of Neo4j, the final clause `RETURN p.name` would cause the database to take the node `p` and lookup its properties and return the value
+of the property `name`.
+In Neo4j 3.5 we can now leverage the fact that indexes store the property values and. In this case, it means that the names can be looked up directly from
+the index. This allows Cypher to avoid the second call to the database to find the property, which can save time on very large queries. If we profile the
+above query, we see that the `NodeIndexScan` in the Variables column contains `cached[p.name]`, which means that `p.name` is retrieved from the index.
+We can also see that the `Projection` has no DB Hits, which means it does not have to access the database again.
+
+[source, cypher]
+----
+PROFILE
+MATCH (p:Person)-[:ACTED_IN]->(m:Movie) USING INDEX p:Person(name) WHERE p.name STARTS WITH 'Tom'
+RETURN p.name, count(m)
+----
+
+//profile
+
+If we change the query, such that it cannot use an index any more, we will see that there will be no `cached[p.name]` in the Variables, and that the
+`Projection` now has DB Hits, since it accesses the database again to retrieve the name.
+
+[source, cypher]
+----
+PROFILE
+MATCH (p:Person)-[:ACTED_IN]->(m:Movie)
+RETURN p.name, count(m)
+----
+
+//profile
+
 
 It is important to note, however, that not all property types are supported, because not all have been ported to the new native index.
 In addition some property types, like the spatial type `Point`, are indexed in an index that is designed to be approximate and cannot return the values.
-For this reason Cypher needs to know the property type in order to benefit from this feature.
-In the query above, the fact that we have a predicate comparing `p.name` to the String `'Tom'` is enough for Cypher to know the query is only interested in `String` properties, and we can skip the property lookup.
+For non-native indexes and the spatial type `Point`, there will still be a second DB access to retrieve those values. In indexes with mixed values,
+only those values that cannot be lookup up from the index will trigger another database access, while the other values will not.
 
 Note also that if you have pre-existing indexes that were build on lucene, upgrading to Neo4j 3.5 is _not sufficient_ to use the new index.
 It is necessary to drop and re-create the index in order to port it to the native index.
-Read more about this in the <<operations-manual#index-configuration-upgrade-considerations, Operations Manual -> Index Configuration Upgrade Considerations>>.
+For information on native index support see the _Operations Manual_:
 
-== Index-backed order-by
+* <<operations-manual#index-configuration-native-indexes, Property types supported by the native index>>
+* <<operations-manual#index-configuration-index-providers, Index providers and property types>>
+* <<operations-manual#index-configuration-upgrade-considerations, Index configuration upgrade considerations>>
+
+Predicates that can be used to enable this optimization are:
+
+* Existance (`WHERE exists(n.name)`)
+* Equality (e.g. `WHERE n.name = 'Tom Hanks'`)
+* Range (eg. `WHERE n.uid > 1000 AND n.uid < 2000`)
+* Prefix (eg. `WHERE n.name STARTS WITH 'Tom'`)
+* Suffix (eg. `WHERE n.name ENDS WITH 'Hanks'`)
+* Substring (eg. `WHERE n.name CONTAINS 'a'`)
+
+=== Index-backed order-by
 
 Now consider the following refinement to the query:
 
@@ -93,11 +150,15 @@ RETURN p.name, count(m) ORDER BY p.name
 //table
 
 We are asking for the results in ascending alphabetical order. The new native index happens to store the String properties in ascending alphabetical order, and Cypher knows this.
-In Neo4j 3.4 and earlier, Cypher would plan a `Sort` operation to eagerly sort the results, which means building a collection in memory and running a sort algorithm on it.
-For large result sets this can be expensive in both memory and time. In Neo4j 3.5, if you are using the native index, Cypher will recognise that the index already returns data in the correct order, and skip the `Sort` operation.
+In Neo4j 3.4 and earlier, Cypher would plan a `Sort` operation to sort the results, which means building a collection in memory and running a sort algorithm on it.
+For large result sets this can be expensive in both memory and time. In Neo4j 3.5, if you are using the native index, Cypher will recognise that the index already
+returns data in the correct order, and skip the `Sort` operation.
 
-To demonstrate this effect, let's remove the predicate so that Cypher no longer knows the type of the property, and the database can no longer guarantee the order.
-If we profile the query we will see the `Sort` operation:
+However, indexes storing values of the spatial type `Point` and non-native indexes do not store the values in the correct order. That means, Cypher needs a
+predicate that fixes the type of the property to some type that is guaranteed to be in the right order.
+
+To demonstrate this effect, let's remove the String prefix predicate so that Cypher no longer knows the type of the property, and replace it with an existance
+predicate. Now the database can no longer guarantee the order. If we profile the query we will see the `Sort` operation:
 
 [source, cypher]
 ----
@@ -108,32 +169,34 @@ RETURN p.name, count(m) ORDER BY p.name
 
 //profile
 
-Now if we add a predicate that gives us the property type information, we will see the `Sort` operation is no longer there:
+We can also see a new column in the profile, that was added in Neo4j 3.5: `Order`. This column describes the order of rows after each operator. We see that
+the order is undefined until the Sort operator. Now if we add back the predicate that gives us the property type information,
+we will see the `Sort` operation is no longer there:
 
 [source, cypher]
 ----
 PROFILE
-MATCH (p:Person)-[:ACTED_IN]->(m:Movie) USING INDEX p:Person(name) WHERE p.name >= 'a'
+MATCH (p:Person)-[:ACTED_IN]->(m:Movie) USING INDEX p:Person(name) WHERE p.name STARTS WITH 'Tom'
 RETURN p.name, count(m) ORDER BY p.name
 ----
 
 //profile
 
-== Restrictions
+We also see that the `Order` column contains `p.name ASC` from the beginning, meaning that the rows are ordered by `p.name` in ascending order.
 
+Index-backed order-by can just as well be used for queries that expect their results is descending order, but with slightly lower performance.
+
+==== Restrictions
+
+The optimization can only work on new native indexes and only if we are returning no values of the spatial type `Point`.
 Predicates that can be used to enable this optimization are:
 
+* Equality (e.g. `WHERE n.name = 'Tom Hanks'`)
 * Range (eg. `WHERE n.uid > 1000 AND n.uid < 2000`)
 * Prefix (eg. `WHERE n.name STARTS WITH 'Tom'`)
+* Suffix (eg. `WHERE n.name ENDS WITH 'Hanks'`)
+* Substring (eg. `WHERE n.name CONTAINS 'a'`)
 
 Predicates that will not work:
 
 * Existence (eg. `WHERE exists(n.email)`) because no property type information is given
-* Substring (eg. `WHERE n.name CONTAINS 'a'`) because string order is defined from the start of the string
-* Suffix (eg. `WHERE n.name ENDS WITH 'Cruise'`) because string order is defined from the start of the string
-
-For information on native index support see the _Operations Manual_:
-
-* <<operations-manual#index-configuration-native-indexes, Property types supported by the native index>>
-* <<operations-manual#index-configuration-index-providers, Index providers and property types>>
-* <<operations-manual#index-configuration-upgrade-considerations, Index configuration upgrade considerations>>

--- a/cypher/cypher-docs/src/docs/graphgists/query-tuning/advanced-query-tuning-example.asciidoc
+++ b/cypher/cypher-docs/src/docs/graphgists/query-tuning/advanced-query-tuning-example.asciidoc
@@ -8,11 +8,11 @@ This section describes some more subtle optimizations based on new native index 
 
 One of the most important and useful ways of optimizing Cypher queries involves creating appropriate indexes.
 This is described in more detail in the section on '<<query-schema-index,Indexes>>', and demonstrated in the <<cypherdoc-basic-query-tuning-example,basic query tuning example>>.
-In summary an index will be based on the combination of a `Label` and a `property`.
+In summary, an index will be based on the combination of a `Label` and a `property`.
 Any Cypher query that searches for nodes with a specific label and some predicate on the property (equality, range or existence) will be planned to use
 the index if the cost planner deems that to be the most efficient solution.
 
-In order to benefit from some recent enhancements added to Neo4j 3.5, it is useful to understand when _index-backed property lookup_ and _index-backed order-by_ will come into play.
+In order to benefit from some recent enhancements added to Neo4j 3.5, it is useful to understand when _index-backed property lookup_ and _index-backed order by_ will come into play.
 In versions of Neo4j prior to 3.5, the fact that the index contains the property value, and the results are returned in a specific order, was not used improve the performance of any later part of the query that might depend on the property value or result order.
 
 Let's explain how to use these features with a more advanced query tuning example.
@@ -22,7 +22,7 @@ Let's explain how to use these features with a more advanced query tuning exampl
 As with the <<cypherdoc-basic-query-tuning-example,basic query tuning example>> we'll use a movies data set to demonstrate how to do some more advanced query tuning.
 This time we'll create the index up-front. If you want to see the effect of adding an index, refer back to the <<cypherdoc-basic-query-tuning-example,basic query tuning example>>.
 In this example we want to demonstrate the impact the new native indexes can have on query performance under certain conditions.
-In order to benefit from some recent enhancements added to Neo4j 3.5, it is useful to understand when _index-backed property lookup_ and _index-backed order-by_ will come into play.
+In order to benefit from some recent enhancements added to Neo4j 3.5, it is useful to understand when _index-backed property lookup_ and _index-backed order by_ will come into play.
 
 //file:movies.csv
 //file:actors.csv
@@ -85,13 +85,15 @@ RETURN p.name, count(m)
 
 //table
 
-We have asked the database to return all the actors with the first name 'Tom'. There are three of them _'Tom Cruise'_, _'Tom Skerritt'_ and _'Tom Hanks'_.
-In previous versions of Neo4j, the final clause `RETURN p.name` would cause the database to take the node `p` and lookup its properties and return the value
-of the property `name`.
-In Neo4j 3.5 we can now leverage the fact that indexes store the property values.
+We have asked the database to return all the actors with the first name 'Tom'.
+There are three of them _'Tom Cruise'_, _'Tom Skerritt'_ and _'Tom Hanks'_.
+In previous versions of Neo4j, the final clause `RETURN p.name` would cause the database to take the node `p`
+and look up its properties and return the value of the property `name`.
+In Neo4j 3.5, we can now leverage the fact that indexes store the property values.
 In this case, it means that the names can be looked up directly from the index.
 This allows Cypher to avoid the second call to the database to find the property, which can save time on very large queries.
-If we profile the above query, we see that the `NodeIndexScan` in the Variables column contains `cached[p.name]`, which means that `p.name` is retrieved from the index.
+If we profile the above query, we see that the `NodeIndexScan` in the Variables column contains `cached[p.name]`,
+which means that `p.name` is retrieved from the index.
 We can also see that the `Projection` has no DB Hits, which means it does not have to access the database again.
 
 [source, cypher]
@@ -103,7 +105,7 @@ RETURN p.name, count(m)
 
 //profile
 
-If we change the query, such that it cannot use an index any more, we will see that there will be no `cached[p.name]` in the Variables, and that the
+If we change the query, such that it can no longer use an index, we will see that there will be no `cached[p.name]` in the Variables, and that the
 `Projection` now has DB Hits, since it accesses the database again to retrieve the name.
 
 [source, cypher]
@@ -138,7 +140,7 @@ Predicates that can be used to enable this optimization are:
 * Suffix (eg. `WHERE n.name ENDS WITH 'Hanks'`)
 * Substring (eg. `WHERE n.name CONTAINS 'a'`)
 
-=== Index-backed order-by
+=== Index-backed order by
 
 Now consider the following refinement to the query:
 
@@ -152,14 +154,15 @@ RETURN p.name, count(m) ORDER BY p.name
 
 We are asking for the results in ascending alphabetical order. The new native index happens to store the String properties in ascending alphabetical order, and Cypher knows this.
 In Neo4j 3.4 and earlier, Cypher would plan a `Sort` operation to sort the results, which means building a collection in memory and running a sort algorithm on it.
-For large result sets this can be expensive in both memory and time. In Neo4j 3.5, if you are using the native index, Cypher will recognise that the index already
+For large result sets this can be expensive in terms of both memory and time. In Neo4j 3.5, if you are using the native index, Cypher will recognise that the index already
 returns data in the correct order, and skip the `Sort` operation.
 
 However, indexes storing values of the spatial type `Point` and non-native indexes cannot be relied on to return the values in the correct order.
-This means that for Cypher to enable this optimization the query needs a predicate that limits the type of the property to some type that is guaranteed to be in the right order.
+This means that for Cypher to enable this optimization, the query needs a predicate that limits the type of the property to some type that is guaranteed to be in the right order.
 
 To demonstrate this effect, let's remove the String prefix predicate so that Cypher no longer knows the type of the property, and replace it with an existence predicate.
-Now the database can no longer guarantee the order. If we profile the query we will see the `Sort` operation:
+Now the database can no longer guarantee the order.
+If we profile the query we will see the `Sort` operation:
 
 [source, cypher]
 ----
@@ -170,8 +173,10 @@ RETURN p.name, count(m) ORDER BY p.name
 
 //profile
 
-We can also see a new column in the profile, that was added in Neo4j 3.5: `Order`. This column describes the order of rows after each operator. We see that
-the order is undefined until the Sort operator. Now if we add back the predicate that gives us the property type information,
+We can also see a new column in the profile, that was added in Neo4j 3.5: `Order`.
+This column describes the order of rows after each operator.
+We see that the order is undefined until the `Sort` operator.
+Now if we add back the predicate that gives us the property type information,
 we will see the `Sort` operation is no longer there:
 
 [source, cypher]
@@ -185,7 +190,7 @@ RETURN p.name, count(m) ORDER BY p.name
 
 We also see that the `Order` column contains `p.name ASC` from the index seek operation, meaning that the rows are ordered by `p.name` in ascending order.
 
-Index-backed order-by can just as well be used for queries that expect their results is descending order, but with slightly lower performance.
+Index-backed order by can just as well be used for queries that expect their results is descending order, but with slightly lower performance.
 
 ==== Restrictions
 

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/OrderByTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/OrderByTest.scala
@@ -58,6 +58,12 @@ class OrderByTest extends DocumentingTest {
         """Lastly, it is not allowed to use aggregating expressions in the `ORDER BY` sub-clause if they are not also listed in the projecting clause.
            This last rule is to make sure that `ORDER BY` does not change the results, only the order of them.
         """.stripMargin)
+      p(
+        """The performance of Cypher queries using `ORDER BY` on node properties can be influenced by the existence and use of an index for finding the nodes.
+          | If the index can provide the nodes in the order requested in the query, Cypher can avoid the use of an expensive `Sort` operation.
+          | Read more about this capability in the section on <<cypher-index-values-order,Index Values and Order>>.
+        """.stripMargin
+      )
       graphViz()
     }
     section("Order nodes by property", "order-nodes-by-property") {


### PR DESCRIPTION
The documentation for index backed order by was out of date.

This also updates the current Neo4j version to 3.5 in the same chapter.