### PR TITLE
Remove DatabaseRule.createNodeId.

### DIFF
--- a/test-framework/src/main/java/org/neo4j/doc/test/rule/DatabaseRule.java
+++ b/test-framework/src/main/java/org/neo4j/doc/test/rule/DatabaseRule.java
@@ -465,12 +465,6 @@ public abstract class DatabaseRule extends ExternalResource implements GraphData
     }
 
     @Override
-    public Long createNodeId()
-    {
-        return database.createNodeId();
-    }
-
-    @Override
     public Relationship getRelationshipById( long id )
     {
         return database.getRelationshipById( id );


### PR DESCRIPTION
This method has been removed from the GraphDatabaseService product API.

Companion PR https://github.com/neo-technology/neo4j/pull/1378