### PR TITLE
Rename CausalClusteringSettings path

### DIFF
--- a/config-docs/pom.xml
+++ b/config-docs/pom.xml
@@ -151,7 +151,7 @@
                                     <arg value="org.neo4j.dbms.DatabaseManagementSystemSettings" />
                                     <arg value="org.neo4j.metrics.MetricsSettings" />
                                     <arg value="org.neo4j.ext.udc.UdcSettings" />
-                                    <arg value="org.neo4j.causalclustering.core.CausalClusteringSettings" />
+                                    <arg value="com.neo4j.causalclustering.core.CausalClusteringSettings" />
                                     <arg value="org.neo4j.consistency.ConsistencyCheckSettings" />
                                     <arg value="com.neo4j.server.enterprise.CommercialServerSettings" />
                                     <arg value="com.neo4j.server.security.enterprise.configuration.SecuritySettings" />


### PR DESCRIPTION
As the enterprise and commercial versions of causal clustering are being merged in in 4.0 and onwards, I need to rename the package of the `CausalClusteringSettings` class