### PR TITLE
Removal of a reference to non-existent doc jar

### DIFF
--- a/contents/pom.xml
+++ b/contents/pom.xml
@@ -135,13 +135,6 @@
             <groupId>org.neo4j.examples</groupId>
             <artifactId>neo4j-server-examples</artifactId>
             <version>${project.version}</version>
-            <classifier>docs</classifier>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.neo4j.examples</groupId>
-            <artifactId>neo4j-server-examples</artifactId>
-            <version>${project.version}</version>
             <classifier>sources</classifier>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
Documentation of server-examples has been removed some time ago
and doc jar gets created only if the doc directory exists
in the subproject.
This commit removes a forgotten reference
to server-examples doc jar