### PR TITLE
Use new transaction commit url in http server tests

### DIFF
--- a/server-docs/src/test/java/org/neo4j/doc/server/TransactionTimeoutDocIT.java
+++ b/server-docs/src/test/java/org/neo4j/doc/server/TransactionTimeoutDocIT.java
@@ -66,7 +66,7 @@ public class TransactionTimeoutDocIT extends ExclusiveServerTestBase
 
     private String txURI()
     {
-        return server.baseUri().toString() + "db/data/transaction";
+        return server.baseUri().toString() + "db/neo4j/tx";
     }
 
 }

--- a/server-docs/src/test/java/org/neo4j/doc/server/rest/security/CommunityServerTestBase.java
+++ b/server-docs/src/test/java/org/neo4j/doc/server/rest/security/CommunityServerTestBase.java
@@ -53,9 +53,9 @@ public class CommunityServerTestBase extends ExclusiveServerTestBase
         return "Basic " + base64( username + ":" + password );
     }
 
-    protected String dataURL()
+    protected String databaseURL()
     {
-        return server.baseUri().resolve( "db/data/" ).toString();
+        return server.baseUri().resolve( "db/neo4j/" ).toString();
     }
 
     protected String userURL( String username )
@@ -75,7 +75,7 @@ public class CommunityServerTestBase extends ExclusiveServerTestBase
 
     protected String txCommitURL()
     {
-        return dataURL() + "transaction/commit";
+        return databaseURL() + "tx/commit";
     }
 
     protected String simpleCypherRequestBody()

--- a/server-docs/src/test/java/org/neo4j/doc/server/rest/transactional/TransactionDocIT.java
+++ b/server-docs/src/test/java/org/neo4j/doc/server/rest/transactional/TransactionDocIT.java
@@ -72,7 +72,7 @@ public class TransactionDocIT extends AbstractRestFunctionalTestBase
                 .expectedStatus( 201 )
                 .payload( quotedJson( "{ 'statements': [ { 'statement': 'CREATE (n {props}) RETURN n', " +
                         "'parameters': { 'props': { 'name': 'My Node' } } } ] }" ) )
-                .post( getDataUri() + "transaction" );
+                .post( txUri() );
 
         // Then
         Map<String, Object> result = jsonToMap( response.entity() );
@@ -89,7 +89,7 @@ public class TransactionDocIT extends AbstractRestFunctionalTestBase
     public void execute_statements_in_an_open_transaction() throws JsonParseException
     {
         // Given
-        String location = POST( getDataUri() + "transaction" ).location();
+        String location = POST( txUri() ).location();
 
         // Document
         ResponseEntity response = gen.get()
@@ -113,7 +113,7 @@ public class TransactionDocIT extends AbstractRestFunctionalTestBase
     public void execute_statements_in_an_open_transaction_using_REST() throws JsonParseException
     {
         // Given
-        String location = POST( getDataUri() + "transaction" ).location();
+        String location = POST( txUri() ).location();
 
         // Document
         ResponseEntity response = gen.get()
@@ -143,7 +143,7 @@ public class TransactionDocIT extends AbstractRestFunctionalTestBase
             throws JsonParseException, ParseException, InterruptedException
     {
         // Given
-        HTTP.Response initialResponse = POST( getDataUri() + "transaction" );
+        HTTP.Response initialResponse = POST( txUri() );
         String location = initialResponse.location();
         long initialExpirationTime = expirationTime( jsonToMap( initialResponse.rawContent() ) );
 
@@ -176,7 +176,7 @@ public class TransactionDocIT extends AbstractRestFunctionalTestBase
     public void commit_an_open_transaction() throws JsonParseException
     {
         // Given
-        String location = POST( getDataUri() + "transaction" ).location();
+        String location = POST( txUri() ).location();
 
         // Document
         ResponseEntity response = gen.get()
@@ -205,7 +205,7 @@ public class TransactionDocIT extends AbstractRestFunctionalTestBase
                 .noGraph()
                 .expectedStatus( 200 )
                 .payload( quotedJson( "{ 'statements': [ { 'statement': 'CREATE (n) RETURN id(n)' } ] }" ) )
-                .post( getDataUri() + "transaction/commit" );
+                .post( txCommitUri() );
 
         // Then
         Map<String, Object> result = jsonToMap( response.entity() );
@@ -227,7 +227,7 @@ public class TransactionDocIT extends AbstractRestFunctionalTestBase
                 .payload( quotedJson( "{ 'statements': [ { 'statement': 'CREATE (n) RETURN id(n)' }, "
                         + "{ 'statement': 'CREATE (n {props}) RETURN n', "
                         + "'parameters': { 'props': { 'name': 'My Node' } } } ] }" ) )
-                .post( getDataUri() + "transaction/commit" );
+                .post( txCommitUri() );
 
         // Then
         Map<String,Object> result = jsonToMap( response.entity() );
@@ -258,7 +258,7 @@ public class TransactionDocIT extends AbstractRestFunctionalTestBase
                         "CREATE p2 = (bike)-[:HAS { position: 2 } ]->(backWheel) " +
                         "RETURN bike, p1, p2', " +
                         "'resultDataContents': ['row','graph']}] }" ) )
-                        .post( getDataUri() + "transaction/commit" );
+                        .post( txCommitUri() );
 
         // Then
         Map<String, Object> result = jsonToMap( response.entity() );
@@ -277,7 +277,7 @@ public class TransactionDocIT extends AbstractRestFunctionalTestBase
     public void rollback_an_open_transaction() throws JsonParseException
     {
         // Given
-        HTTP.Response firstReq = POST( getDataUri() + "transaction",
+        HTTP.Response firstReq = POST( txUri(),
                 HTTP.RawPayload.quotedJson( "{ 'statements': [ { 'statement': 'CREATE (n) RETURN id(n)' } ] }" ) );
         String location = firstReq.location();
 
@@ -314,7 +314,7 @@ public class TransactionDocIT extends AbstractRestFunctionalTestBase
     public void handling_errors() throws JsonParseException
     {
         // Given
-        String location = POST( getDataUri() + "transaction" ).location();
+        String location = POST( txUri() ).location();
 
         // Document
         ResponseEntity response = gen.get()
@@ -337,7 +337,7 @@ public class TransactionDocIT extends AbstractRestFunctionalTestBase
     public void errors_in_open_transaction() throws JsonParseException
     {
         // Given
-        String location = POST( getDataUri() + "transaction" ).location();
+        String location = POST( txUri() ).location();
 
         // Document
         ResponseEntity response = gen.get()
@@ -363,7 +363,7 @@ public class TransactionDocIT extends AbstractRestFunctionalTestBase
                 .expectedStatus( 200 )
                 .payload( quotedJson(
                         "{ 'statements': [ { 'statement': 'CREATE (n) RETURN id(n)', 'includeStats': true } ] }" ) )
-                .post( getDataUri() + "transaction/commit" );
+                .post( txCommitUri() );
 
         // Then
         Map<String,Object> entity = jsonToMap( response.entity() );
@@ -447,6 +447,6 @@ public class TransactionDocIT extends AbstractRestFunctionalTestBase
     {
         return gen.get().expectedStatus( 200 ).payload( quotedJson(
                 "{ 'statements': [ { 'statement': 'MATCH (n) WHERE ID(n) = $nodeId RETURN n' , " + "'parameters': { 'nodeId': " + nodeId + " } } ] }" ) ).post(
-                getDataUri() + "transaction/commit" );
+                txCommitUri() );
     }
 }

--- a/server-examples/src/main/java/org/neo4j/examples/server/CreateSimpleGraph.java
+++ b/server-examples/src/main/java/org/neo4j/examples/server/CreateSimpleGraph.java
@@ -18,18 +18,17 @@
  */
 package org.neo4j.examples.server;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-
-import javax.ws.rs.core.MediaType;
-
 import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import javax.ws.rs.core.MediaType;
+
 public class CreateSimpleGraph
 {
-    private static final String SERVER_ROOT_URI = "http://localhost:7474/db/data/";
+    private static final String SERVER_ROOT_URI = "http://localhost:7474/db/neo4j/";
 
     public static void main( String[] args ) throws URISyntaxException
     {
@@ -143,7 +142,7 @@ public class CreateSimpleGraph
     {
         // tag::createNode[]
         final String nodeEntryPointUri = SERVER_ROOT_URI + "node";
-        // http://localhost:7474/db/data/node
+        // http://localhost:7474/db/neo4j/node
 
         WebResource resource = Client.create()
                 .resource( nodeEntryPointUri );

--- a/server-test-utils/src/main/java/org/neo4j/doc/server/helpers/CommunityServerBuilder.java
+++ b/server-test-utils/src/main/java/org/neo4j/doc/server/helpers/CommunityServerBuilder.java
@@ -64,7 +64,6 @@ public class CommunityServerBuilder
 
     private String[] autoIndexedNodeKeys = null;
     private String[] autoIndexedRelationshipKeys = null;
-    private String[] securityRuleClassNames;
     private boolean persistent;
     private boolean httpsEnabled = false;
 
@@ -141,12 +140,6 @@ public class CommunityServerBuilder
             properties.put( "dbms.auto_index.relationships.enabled", "true" );
             String propertyKeys = org.apache.commons.lang.StringUtils.join( autoIndexedRelationshipKeys, "," );
             properties.put( "dbms.auto_index.relationships.keys", propertyKeys );
-        }
-
-        if ( securityRuleClassNames != null && securityRuleClassNames.length > 0 )
-        {
-            String propertyKeys = org.apache.commons.lang.StringUtils.join( securityRuleClassNames, "," );
-            properties.put( ServerSettings.security_rules.name(), propertyKeys );
         }
 
         properties.put( HttpConnector.enabled.name(), "true" );
@@ -234,12 +227,6 @@ public class CommunityServerBuilder
     public CommunityServerBuilder onHttpsAddress( SocketAddress address )
     {
         this.httpsAddress = address;
-        return this;
-    }
-
-    public CommunityServerBuilder withSecurityRules( String... securityRuleClassNames )
-    {
-        this.securityRuleClassNames = securityRuleClassNames;
         return this;
     }
 

--- a/server-test-utils/src/main/java/org/neo4j/doc/server/helpers/FunctionalTestHelper.java
+++ b/server-test-utils/src/main/java/org/neo4j/doc/server/helpers/FunctionalTestHelper.java
@@ -48,7 +48,7 @@ public final class FunctionalTestHelper
         }
         this.helper = new GraphDbHelper( server.getDatabaseService() );
         this.server = server;
-        this.request = new RestRequest(server.baseUri().resolve("db/data/"));
+        this.request = new RestRequest(server.baseUri().resolve("db/neo4j/"));
     }
 
     public GraphDbHelper getGraphDbHelper()
@@ -56,9 +56,9 @@ public final class FunctionalTestHelper
         return helper;
     }
 
-    public String dataUri()
+    public String databaseUri()
     {
-        return server.baseUri().toString() + "db/data/";
+        return server.baseUri().toString() + "db/neo4j/";
     }
 
     public JaxRsResponse get(String path) {
@@ -72,7 +72,7 @@ public final class FunctionalTestHelper
 
     public String cypherURL()
     {
-        return dataUri() + "transaction/commit";
+        return databaseUri() + "tx/commit";
     }
 
     public String simpleCypherRequestBody()

--- a/server-test-utils/src/main/java/org/neo4j/doc/server/rest/AbstractRestFunctionalTestBase.java
+++ b/server-test-utils/src/main/java/org/neo4j/doc/server/rest/AbstractRestFunctionalTestBase.java
@@ -84,8 +84,8 @@ public class AbstractRestFunctionalTestBase extends SharedServerTestBase impleme
         return SharedServerTestBase.server().getDatabaseService().getDatabase();
     }
 
-    protected static String getDataUri() {
-        return "http://localhost:7474/db/data/";
+    protected static String databaseUri() {
+        return "http://localhost:7474/db/neo4j/";
     }
 
     protected String getDatabaseUri() {
@@ -93,15 +93,15 @@ public class AbstractRestFunctionalTestBase extends SharedServerTestBase impleme
     }
 
     protected String txUri() {
-        return getDataUri() + "transaction";
+        return databaseUri() + "tx";
     }
 
     protected static String txCommitUri() {
-        return getDataUri() + "transaction/commit";
+        return databaseUri() + "tx/commit";
     }
 
     protected String txUri(long txId) {
-        return getDataUri() + "transaction/" + txId;
+        return databaseUri() + "tx/" + txId;
     }
 
     public static long extractTxId(HTTP.Response response) {


### PR DESCRIPTION
The new transactional endpoints for database named `neo4j` is `/db/neo4j/tx`.

For https://github.com/neo-technology/neo4j/pull/2960