### PR TITLE
Amend the Pattern comprehension example to match the movie graph example

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ListsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ListsTest.scala
@@ -164,7 +164,7 @@ class ListsTest extends DocumentingTest {
       graphViz()
       query(
         """MATCH (a:Person {name: 'Keanu Reeves'})
-          |RETURN [(a)-->(b) WHERE b:Movie | b.released] AS Years ORDER BY YEARS ASC""", ResultAssertions((r) => {
+          |RETURN [(a)-->(b) WHERE b:Movie | b.released] AS Years ORDER BY Years ASC""", ResultAssertions((r) => {
           r.toList should equal(List(Map("Years" -> List(1995, 1997, 1999, 2000, 2003, 2003, 2003))))
         })) {
         resultTable()

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ListsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ListsTest.scala
@@ -29,12 +29,12 @@ class ListsTest extends DocumentingTest {
     initQueries(
       """CREATE (keanu:Person {name: 'Keanu Reeves'}),
                 |(johnnymnemonic:Movie {title: 'Johnny Mnemonic', released: 1995}),
-                |(somethingsgottagive:Movie {title: 'Something's Gotta Give', released: 2003}),
+                |(somethingsgottagive:Movie {title: 'Somethings Gotta Give', released: 2003}),
                 |(thematrixrevolutions:Movie {title: 'The Matrix Revolutions', released: 2003}),
                 |(thematrixreloaded:Movie {title: 'The Matrix Reloaded', released: 2003}),
                 |(thereplacements:Movie {title: 'The Replacements', released: 2000}),
                 |(thematrix:Movie {title: 'The Matrix', released: 1999}),
-                |(thedevilsadvocate:Movie {title: 'The Devil's Advocate', released: 1997}),
+                |(thedevilsadvocate:Movie {title: 'The Devils Advocate', released: 1997}),
                 |
                 |(keanu)-[:ACTED_IN]->(johnnymnemonic),
                 |(keanu)-[:ACTED_IN]->(somethingsgottagive),

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ListsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ListsTest.scala
@@ -164,7 +164,7 @@ class ListsTest extends DocumentingTest {
       graphViz()
       query(
         """MATCH (a:Person {name: 'Keanu Reeves'})
-          |RETURN [(a)-->(b) WHERE b:Movie | b.released] AS Years """, ResultAssertions((r) => {
+          |RETURN [(a)-->(b) WHERE b:Movie | b.released] AS years """, ResultAssertions((r) => {
           r.toList.head("years").equals(List(1995, 1997, 1999, 2000, 2003, 2003, 2003))
         })) {
         resultTable()

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ListsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ListsTest.scala
@@ -164,8 +164,8 @@ class ListsTest extends DocumentingTest {
       graphViz()
       query(
         """MATCH (a:Person {name: 'Keanu Reeves'})
-          |RETURN [(a)-->(b) WHERE b:Movie | b.released] AS Years""", ResultAssertions((r) => {
-          r.toList should equal(List(Map("Years" -> List(1995, 2003, 2003, 2003, 2000, 1999, 1997))))
+          |RETURN [(a)-->(b) WHERE b:Movie | b.released] AS Years ORDER BY YEARS ASC""", ResultAssertions((r) => {
+          r.toList should equal(List(Map("Years" -> List(1995, 1997, 1999, 2000, 2003, 2003, 2003))))
         })) {
         resultTable()
       }

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ListsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ListsTest.scala
@@ -165,7 +165,7 @@ class ListsTest extends DocumentingTest {
       query(
         """MATCH (a:Person {name: 'Keanu Reeves'})
           |RETURN [(a)-->(b) WHERE b:Movie | b.released] AS Years""", ResultAssertions((r) => {
-          r.toList should equal(List(Map("years" -> List(1979, 1984, 1987))))
+          r.toList should equal(List(Map("Years" -> List(1995, 2003, 2003, 2003, 2000, 1999, 1997))))
         })) {
         resultTable()
       }

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ListsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ListsTest.scala
@@ -27,17 +27,22 @@ class ListsTest extends DocumentingTest {
   override def doc = new DocBuilder {
     doc("Lists", "cypher-lists")
     initQueries(
-      """CREATE (charlie:Person {name: 'Charlie Sheen',  realName: 'Carlos Irwin Estévez'}),
-                |(martin:Person {name: 'Martin Sheen'}),
-                |(wallstreet:Movie {title: 'Wall Street', year: 1987}),
-                |(reddawn:Movie {title: 'Red Dawn', year: 1984}),
-                |(apocalypsenow:Movie {title: 'Apocalypse Now', year: 1979}),
+      """CREATE (keanu:Person {name: 'Keanu Reeves'}),
+                |(johnnymnemonic:Movie {title: 'Johnny Mnemonic', released: 1995}),
+                |(somethingsgottagive:Movie {title: 'Something's Gotta Give', released: 2003}),
+                |(thematrixrevolutions:Movie {title: 'The Matrix Revolutions', released: 2003}),
+                |(thematrixreloaded:Movie {title: 'The Matrix Reloaded', released: 2003}),
+                |(thereplacements:Movie {title: 'The Replacements', released: 2000}),
+                |(thematrix:Movie {title: 'The Matrix', released: 1999}),
+                |(thedevilsadvocate:Movie {title: 'The Devil's Advocate', released: 1997}),
                 |
-                |(charlie)-[:ACTED_IN]->(wallstreet),
-                |(charlie)-[:ACTED_IN]->(reddawn),
-                |(charlie)-[:ACTED_IN]->(apocalypsenow),
-                |(martin)-[:ACTED_IN]->(wallstreet),
-                |(martin)-[:ACTED_IN]->(apocalypsenow)
+                |(keanu)-[:ACTED_IN]->(johnnymnemonic),
+                |(keanu)-[:ACTED_IN]->(somethingsgottagive),
+                |(keanu)-[:ACTED_IN]->(thematrixrevolutions),
+                |(keanu)-[:ACTED_IN]->(thematrixreloaded),
+                |(keanu)-[:ACTED_IN]->(thereplacements),
+                |(keanu)-[:ACTED_IN]->(thematrix),
+                |(keanu)-[:ACTED_IN]->(thedevilsadvocate)
 
       """.stripMargin)
     synopsis("Cypher has comprehensive support for lists.")
@@ -158,8 +163,8 @@ class ListsTest extends DocumentingTest {
       p("The following graph is used for the example below:")
       graphViz()
       query(
-        """MATCH (a:Person {name: 'Charlie Sheen'})
-          |RETURN [(a)-->(b) WHERE b:Movie | b.year] AS years""", ResultAssertions((r) => {
+        """MATCH (a:Person {name: 'Keanu Reeves'})
+          |RETURN [(a)-->(b) WHERE b:Movie | b.released] AS Years""", ResultAssertions((r) => {
           r.toList should equal(List(Map("years" -> List(1979, 1984, 1987))))
         })) {
         resultTable()

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ListsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ListsTest.scala
@@ -164,8 +164,8 @@ class ListsTest extends DocumentingTest {
       graphViz()
       query(
         """MATCH (a:Person {name: 'Keanu Reeves'})
-          |RETURN [(a)-->(b) WHERE b:Movie | b.released] AS Years ORDER BY Years ASC""", ResultAssertions((r) => {
-          r.toList should equal(List(Map("Years" -> List(1995, 1997, 1999, 2000, 2003, 2003, 2003))))
+          |RETURN [(a)-->(b) WHERE b:Movie | b.released] AS Years """, ResultAssertions((r) => {
+          r.toList.head("years").equals(List(1995, 1997, 1999, 2000, 2003, 2003, 2003))
         })) {
         resultTable()
       }


### PR DESCRIPTION
The current example uses movies of Charlie Sheen to demonstrate pattern comprehension. As-is, this example is correct, but this example is not one that can be tested in the movie-graph demo, which is playable via the browser.

This PR changes the example to one that can be run from the demo, using Keanu Reeves as the selected node in the graph.