### PR TITLE
Fix the problem with empty tables.

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/Document.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/Document.scala
@@ -218,7 +218,7 @@ case class ResultRow(values: Seq[String])
 case class QueryResultTable(columns: Seq[String], rows: Seq[ResultRow], footer: String) extends Content with NoQueries {
   override def asciiDoc(level: Int): String = {
 
-    val header = if (columns.nonEmpty) "header," else ""
+    val header = if (rows.nonEmpty) "header," else ""
     val cols = if (columns.isEmpty) 1 else columns.size
     val rowsOutput: String = if (rows.isEmpty) s"$cols+|(empty result)"
     else {


### PR DESCRIPTION
The no results line was put in the header instead of the table body
when there where columns but no rows.