### PR TITLE
Do not use `WITH` in reltype.

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MatchTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MatchTest.scala
@@ -180,8 +180,7 @@ class MatchTest extends DocumentingTest {
       section("Relationship types with uncommon characters", "rel-types-with-uncommon-chars") {
         val initQuery =
           """MATCH (charlie:Person {name: 'Charlie Sheen'}), (rob:Person {name: 'Rob Reiner'})
-            |CREATE (rob)-[:`TYPE
-            |WITH SPACE`]->(charlie)"""
+            |CREATE (rob)-[:`TYPE INCLUDING A SPACE`]->(charlie)"""
         p("""Sometimes your database will have types with non-letter characters, or with spaces in them.
             | Use ``` (backtick) to quote these.
             | To demonstrate this we can add an additional relationship between *'Charlie Sheen'* and *'Rob Reiner'*:""")
@@ -189,9 +188,9 @@ class MatchTest extends DocumentingTest {
           p("Which leads to the following graph: ")
           graphViz()
         }
-        query("MATCH (n {name: 'Rob Reiner'})-[r:`TYPE\nWITH SPACE`]->() RETURN type(r)", assertRelType("TYPE\nWITH SPACE")) {
+        query("MATCH (n {name: 'Rob Reiner'})-[r:`TYPE INCLUDING A SPACE`]->() RETURN type(r)", assertRelType("TYPE INCLUDING A SPACE")) {
           initQueries(initQuery)
-          p("Returns a relationship type with a space in it")
+          p("Returns a relationship type with spaces in it.")
           resultTable()
         }
       }


### PR DESCRIPTION
That did confuse the docs formatter making it line break before the WITH.

I could not see any graph visualizations when building docs locally, so please check that extra careful.