### PR TITLE
Update Database, Role and User Management

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/index.asciidoc
@@ -12,6 +12,8 @@ This section explains how to use Cypher to manage Neo4j role-based access contro
 *** <<administration-security-users-show, Listing users>>
 *** <<administration-security-users-create, Creating users>>
 *** <<administration-security-users-alter, Modifying users>>
+*** <<administration-security-users-alter-password, Changing logged in users password>>
+*** <<administration-security-users-drop, Deleting users>>
 ** <<administration-security-roles, Role management>>
 *** <<administration-security-roles-show, Listing roles>>
 *** <<administration-security-roles-create, Creating roles>>

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/index.asciidoc
@@ -12,7 +12,7 @@ This section explains how to use Cypher to manage Neo4j role-based access contro
 *** <<administration-security-users-show, Listing users>>
 *** <<administration-security-users-create, Creating users>>
 *** <<administration-security-users-alter, Modifying users>>
-*** <<administration-security-users-alter-password, Changing logged in users password>>
+*** <<administration-security-users-alter-password, Changing the current user's password>>
 *** <<administration-security-users-drop, Deleting users>>
 ** <<administration-security-roles, Role management>>
 *** <<administration-security-roles-show, Listing roles>>

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/index.asciidoc
@@ -15,7 +15,9 @@ This section explains how to use Cypher to manage Neo4j role-based access contro
 ** <<administration-security-roles, Role management>>
 *** <<administration-security-roles-show, Listing roles>>
 *** <<administration-security-roles-create, Creating roles>>
+*** <<administration-security-roles-drop, Deleting roles>>
 *** <<administration-security-roles-grant, Assigning roles>>
+*** <<administration-security-roles-revoke, Revoking roles>>
 * <<administration-security-subgraph, Database, graph and sub-graph access control>>
 ** <<administration-security-subgraph-introduction, The GRANT and DENY commands>>
 ** <<administration-security-subgraph-traverse, The TRAVERSE privilege>>

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/user-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/user-management-syntax.asciidoc
@@ -29,7 +29,7 @@ STATUS {ACTIVE \| SUSPENDED}
 
 | [source, cypher]
 ALTER CURRENT USER SET PASSWORD FROM original TO password
-| Change the logged in users password | Normal user
+| Change the current user's password | Normal user
 
 | [source, cypher]
 SHOW USERS

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DatabasesTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DatabasesTest.scala
@@ -65,7 +65,9 @@ class DatabasesTest extends DocumentingTest with QueryStatisticsTestSupport {
       })) {}
       query("CREATE OR REPLACE DATABASE customers", ResultAssertions( r => {
         assertStats(r, systemUpdates = 2)
-      })) {}
+      })) {
+        p("This is equivalent to running `DROP DATABASE customers IF EXISTS` followed by `CREATE DATABASE customers`.")
+      }
     }
     section("Stopping databases", "administration-databases-stop-database") {
       p("Databases can be stopped using the `STOP DATABASE` command.")

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DatabasesTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DatabasesTest.scala
@@ -35,12 +35,12 @@ class DatabasesTest extends DocumentingTest with QueryStatisticsTestSupport {
       query("SHOW DATABASES", assertDatabasesShown) {
         resultTable()
       }
-      p("A particular database can be seen using the `SHOW DATABASE database_name`.")
+      p("A particular database can be seen using the `SHOW DATABASE name`.")
       query("SHOW DATABASE system", assertDatabaseShown("system")) {
         resultTable()
       }
       p("The default database can be seen using the `SHOW DEFAULT DATABASE`.")
-      query("SHOW DATABASE neo4j", assertDatabaseShown("neo4j")) {
+      query("SHOW DEFAULT DATABASE", assertDatabaseShown("neo4j")) {
         resultTable()
       }
       considerations("The `status` of the database is the desired status, and might not necessarily reflect the actual status across all members of a cluster.")
@@ -60,10 +60,10 @@ class DatabasesTest extends DocumentingTest with QueryStatisticsTestSupport {
       p("This command is optionally idempotent, with the default behavior to throw an exception if the database already exists. " +
         "Appending `IF NOT EXISTS` to the command will ensure that no exception is thrown and nothing happens should the database already exist. " +
         "Adding `OR REPLACE` to the command will result in any existing database being deleted and a new one created.")
-      query("CREATE DATABASE customers IF NOT EXISTS", ResultAssertions( r => {
+      query("CREATE DATABASE customers IF NOT EXISTS", ResultAssertions(r => {
         assertStats(r, systemUpdates = 0)
       })) {}
-      query("CREATE OR REPLACE DATABASE customers", ResultAssertions( r => {
+      query("CREATE OR REPLACE DATABASE customers", ResultAssertions(r => {
         assertStats(r, systemUpdates = 2)
       })) {
         p("This is equivalent to running `DROP DATABASE customers IF EXISTS` followed by `CREATE DATABASE customers`.")
@@ -109,7 +109,7 @@ class DatabasesTest extends DocumentingTest with QueryStatisticsTestSupport {
       }
       p("This command is optionally idempotent, with the default behavior to throw an exception if the database does not exists. " +
         "Appending `IF EXISTS` to the command will ensure that no exception is thrown and nothing happens should the database not exist.")
-      query("DROP DATABASE customers IF EXISTS", ResultAssertions( r => {
+      query("DROP DATABASE customers IF EXISTS", ResultAssertions(r => {
         assertStats(r, systemUpdates = 0)
       })) {}
     }

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DatabasesTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DatabasesTest.scala
@@ -48,6 +48,15 @@ class DatabasesTest extends DocumentingTest with QueryStatisticsTestSupport {
       query("SHOW DATABASES", assertDatabaseShown) {
         resultTable()
       }
+      p("This command is optionally idempotent, with the default behavior to throw an exception if the database already exists. " +
+        "Appending `IF NOT EXISTS` to the command will ensure that no exception is thrown and nothing happens should the database already exist. " +
+        "Adding `OR REPLACE` to the command will result in any existing database being deleted and a new one created.")
+      query("CREATE DATABASE customers IF NOT EXISTS", ResultAssertions( r => {
+        assertStats(r, systemUpdates = 0)
+      })) {}
+      query("CREATE OR REPLACE DATABASE customers", ResultAssertions( r => {
+        assertStats(r, systemUpdates = 2)
+      })) {}
     }
     section("Stopping databases", "administration-databases-stop-database") {
       p("Databases can be stopped using the `STOP DATABASE` command.")
@@ -87,6 +96,11 @@ class DatabasesTest extends DocumentingTest with QueryStatisticsTestSupport {
       query("SHOW DATABASES", assertDatabaseShown) {
         resultTable()
       }
+      p("This command is optionally idempotent, with the default behavior to throw an exception if the database does not exists. " +
+        "Appending `IF EXISTS` to the command will ensure that no exception is thrown and nothing happens should the database not exist.")
+      query("DROP DATABASE customers IF EXISTS", ResultAssertions( r => {
+        assertStats(r, systemUpdates = 0)
+      })) {}
     }
   }.build()
 

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityUserAndRoleManagementTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityUserAndRoleManagementTest.scala
@@ -26,6 +26,8 @@ class SecurityUserAndRoleManagementTest extends DocumentingTest with QueryStatis
       section("Creating users", "administration-security-users-create") {
         p("Users can be created using `CREATE USER`.")
         p("include::user-management-syntax-create-user.asciidoc[]")
+        p("If the optional `SET PASSWORD CHANGE [NOT] REQUIRED` is omitted then the default is `CHANGE REQUIRED`. " +
+          "The default for `SET STATUS` is `ACTIVE`.")
         p("For example, we can create the user `jake` in a suspended state and the requirement to change his password.")
         query("CREATE USER jake SET PASSWORD 'abc' CHANGE REQUIRED SET STATUS SUSPENDED", ResultAssertions((r) => {
           assertStats(r, systemUpdates = 1)
@@ -61,6 +63,19 @@ class SecurityUserAndRoleManagementTest extends DocumentingTest with QueryStatis
         query("SHOW USERS", assertNodesShown("User", column = "user")) {
           resultTable()
         }
+      }
+      section("Changing the logged in users password", "administration-security-users-alter-password") {
+        p("Users can be change their own password using `ALTER CURRENT USER SET PASSWORD`, " +
+          "the old password is required in addition to the new. " +
+          "This will both change the password and set the `CHANGE NOT REQUIRED` flag.")
+        query("ALTER CURRENT USER SET PASSWORD FROM 'abc123' TO '123xyz'", ResultAssertions((r) => {
+          assertStats(r, systemUpdates = 1)
+        })) {
+          // Can't pull on the result since the test is run with auth disabled, which is not allowed for this command
+        }
+        note( () => {
+          p("This command cannot be run with auth disabled.")
+        })
       }
       section("Deleting users", "administration-security-users-drop") {
         p("Users can be deleted using `DROP USER`.")

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityUserAndRoleManagementTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityUserAndRoleManagementTest.scala
@@ -37,6 +37,15 @@ class SecurityUserAndRoleManagementTest extends DocumentingTest with QueryStatis
         query("SHOW USERS", assertNodesShown("User", column = "user")) {
           resultTable()
         }
+        p("This command is optionally idempotent, with the default behavior to throw an exception if the user already exists. " +
+          "Appending `IF NOT EXISTS` to the command will ensure that no exception is thrown and nothing happens should the user already exist. " +
+          "Adding `OR REPLACE` to the command will result in any existing user being deleted and a new one created.")
+        query("CREATE USER jake IF NOT EXISTS SET PASSWORD 'xyz'", ResultAssertions( r => {
+          assertStats(r, systemUpdates = 0)
+        })) {}
+        query("CREATE OR REPLACE USER jake SET PASSWORD 'xyz'", ResultAssertions( r => {
+          assertStats(r, systemUpdates = 2)
+        })) {}
       }
       section("Modifying users", "administration-security-users-alter") {
         p("Users can be modified using `ALTER USER`.")
@@ -75,6 +84,15 @@ class SecurityUserAndRoleManagementTest extends DocumentingTest with QueryStatis
         query("SHOW ROLES", assertNodesShown("Role", column = "role")) {
           resultTable()
         }
+        p("This command is optionally idempotent, with the default behavior to throw an exception if the role already exists. " +
+          "Appending `IF NOT EXISTS` to the command will ensure that no exception is thrown and nothing happens should the role already exist. " +
+          "Adding `OR REPLACE` to the command will result in any existing role being deleted and a new one created.")
+        query("CREATE ROLE myrole IF NOT EXISTS", ResultAssertions( r => {
+          assertStats(r, systemUpdates = 0)
+        })) {}
+        query("CREATE OR REPLACE ROLE myrole", ResultAssertions( r => {
+          assertStats(r, systemUpdates = 2)
+        })) {}
       }
       section("Assigning roles to users", "administration-security-roles-grant") {
         p("Users can be give access rights by assigning them roles using `GRANT ROLE`.")

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityUserAndRoleManagementTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityUserAndRoleManagementTest.scala
@@ -36,7 +36,7 @@ class SecurityUserAndRoleManagementTest extends DocumentingTest with QueryStatis
           p("Nothing is returned from this query, except the count of system database changes made.")
           resultTable()
         }
-        p("The user created will appear on the list provided by `SHOW USERS`.")
+        p("The created user will appear on the list provided by `SHOW USERS`.")
         query("SHOW USERS", assertNodesShown("User", column = "user")) {
           resultTable()
         }
@@ -48,7 +48,9 @@ class SecurityUserAndRoleManagementTest extends DocumentingTest with QueryStatis
         })) {}
         query("CREATE OR REPLACE USER jake SET PASSWORD 'xyz'", ResultAssertions( r => {
           assertStats(r, systemUpdates = 2)
-        })) {}
+        })) {
+          p("This is equivalent to running `DROP USER jake IF EXISTS` followed by `CREATE USER jake SET PASSWORD 'xyz'`.")
+        }
       }
       section("Modifying users", "administration-security-users-alter") {
         p("Users can be modified using `ALTER USER`.")
@@ -74,9 +76,9 @@ class SecurityUserAndRoleManagementTest extends DocumentingTest with QueryStatis
         })) {
           // Can't pull on the result since the test is run with auth disabled, which is not allowed for this command
         }
-        note( () => {
+        note {
           p("This command cannot be run with auth disabled.")
-        })
+        }
       }
       section("Deleting users", "administration-security-users-drop") {
         p("Users can be deleted using `DROP USER`.")
@@ -124,15 +126,15 @@ class SecurityUserAndRoleManagementTest extends DocumentingTest with QueryStatis
           p("Nothing is returned from this query, except the count of system database changes made.")
           resultTable()
         }
-        p("The role created will appear on the list provided by `SHOW ROLES`.")
-        query("SHOW ROLES", assertNodesShown("Role", column = "role")) {
-          resultTable()
-        }
         p("A role can also be copied, keeping its privileges, using `CREATE ROLE AS COPY OF`.")
         query("CREATE ROLE mysecondrole AS COPY OF myrole", ResultAssertions((r) => {
           assertStats(r, systemUpdates = 1)
         })) {
           p("Nothing is returned from this query, except the count of system database changes made.")
+          resultTable()
+        }
+        p("The created roles will appear on the list provided by `SHOW ROLES`.")
+        query("SHOW ROLES", assertNodesShown("Role", column = "role")) {
           resultTable()
         }
         p("These command versions are optionally idempotent, with the default behavior to throw an exception if the role already exists. " +
@@ -143,7 +145,9 @@ class SecurityUserAndRoleManagementTest extends DocumentingTest with QueryStatis
         })) {}
         query("CREATE OR REPLACE ROLE myrole", ResultAssertions( r => {
           assertStats(r, systemUpdates = 2)
-        })) {}
+        })) {
+          p("This is equivalent to running `DROP ROLE myrole IF EXISTS` followed by `CREATE ROLE myrole`.")
+        }
       }
       section("Deleting roles", "administration-security-roles-drop") {
         p("Roles can be deleted using `DROP ROLE` command.")

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityUserAndRoleManagementTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityUserAndRoleManagementTest.scala
@@ -22,6 +22,7 @@ class SecurityUserAndRoleManagementTest extends DocumentingTest with QueryStatis
         query("SHOW USERS", assertNodesShown("User")) {
           resultTable()
         }
+        p("The `SHOW USER name PRIVILEGES` command is found in <<administration-security-subgraph-show, Listing privileges>>.")
       }
       section("Creating users", "administration-security-users-create") {
         p("Users can be created using `CREATE USER`.")
@@ -113,6 +114,7 @@ class SecurityUserAndRoleManagementTest extends DocumentingTest with QueryStatis
         query("SHOW POPULATED ROLES WITH USERS", assertNodesShown("Role")) {
           resultTable()
         }
+        p("The `SHOW ROLE name PRIVILEGES` command is found in <<administration-security-subgraph-show, Listing privileges>>.")
       }
       section("Creating roles", "administration-security-roles-create") {
         p("Roles can be created using `CREATE ROLE`.")

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityUserAndRoleManagementTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityUserAndRoleManagementTest.scala
@@ -62,8 +62,27 @@ class SecurityUserAndRoleManagementTest extends DocumentingTest with QueryStatis
           resultTable()
         }
       }
+      section("Deleting users", "administration-security-users-drop") {
+        p("Users can be deleted using `DROP USER`.")
+        query("DROP USER jake", ResultAssertions((r) => {
+          assertStats(r, systemUpdates = 1)
+        })) {
+          p("Nothing is returned from this query, except the count of system database changes made.")
+          resultTable()
+        }
+        p("When a user has been deleted, it will no longer appear on the list provided by `SHOW USERS`.")
+        query("SHOW USERS", assertNodesShown("User", column = "user")) {
+          resultTable()
+        }
+        p("This command is optionally idempotent, with the default behavior to throw an exception if the user does not exists. " +
+          "Appending `IF EXISTS` to the command will ensure that no exception is thrown and nothing happens should the user not exist.")
+        query("DROP USER jake IF EXISTS", ResultAssertions( r => {
+          assertStats(r, systemUpdates = 0)
+        })) {}
+      }
     }
     section("Role Management", "administration-security-roles") {
+      initQueries("CREATE USER jake SET PASSWORD 'abc123' CHANGE NOT REQUIRED")
       p("Roles can be created and managed using a set of Cypher administration commands executed against the `system` database.")
       p("include::role-management-syntax.asciidoc[]")
       section("Listing roles", "administration-security-roles-show") {
@@ -94,7 +113,26 @@ class SecurityUserAndRoleManagementTest extends DocumentingTest with QueryStatis
           assertStats(r, systemUpdates = 2)
         })) {}
       }
+      section("Deleting roles", "administration-security-roles-drop") {
+        p("Roles can be deleted using `DROP ROLE` command.")
+        query("DROP ROLE myrole", ResultAssertions((r) => {
+          assertStats(r, systemUpdates = 1)
+        })) {
+          p("Nothing is returned from this query, except the count of system database changes made.")
+          resultTable()
+        }
+        p("When a role has been deleted, it will no longer appear on the list provided by `SHOW ROLES`.")
+        query("SHOW ROLES", assertNodesShown("Role", column = "role")) {
+          resultTable()
+        }
+        p("This command is optionally idempotent, with the default behavior to throw an exception if the role does not exists. " +
+          "Appending `IF EXISTS` to the command will ensure that no exception is thrown and nothing happens should the role not exist.")
+        query("DROP ROLE myrole IF EXISTS", ResultAssertions( r => {
+          assertStats(r, systemUpdates = 0)
+        })) {}
+      }
       section("Assigning roles to users", "administration-security-roles-grant") {
+        initQueries("CREATE ROLE myrole")
         p("Users can be give access rights by assigning them roles using `GRANT ROLE`.")
         query("GRANT ROLE myrole TO jake", ResultAssertions((r) => {
           assertStats(r, systemUpdates = 1)


### PR DESCRIPTION
Include information about `IF [NOT] EXIST` and `OR REPLACE` for create and drop.

Updated with more information about dropping users and roles, and other missing sections.