### PR TITLE
Removing repository declarations for m2.neo4j.org

### DIFF
--- a/backup/pom.xml
+++ b/backup/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <artifactId>neo4j-manual-parent</artifactId>
         <groupId>org.neo4j.doc</groupId>
-        <version>3.1.10-SNAPSHOT</version>
+        <version>3.1.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-backup-docs</artifactId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
 
     <name>Neo4j - Backup Docs</name>
     <description>Documentation build for Neo4j Backup.</description>

--- a/config-docs/pom.xml
+++ b/config-docs/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-manual-parent</artifactId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.neo4j.doc</groupId>
   <artifactId>neo4j-config-docs</artifactId>
   <name>Neo4j - Config Docs Generation</name>
-  <version>3.1.10-SNAPSHOT</version>
+  <version>3.1.9</version>
 
   <description>Neo4j configuration docs generation</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}/</url>

--- a/contents/pom.xml
+++ b/contents/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-manual-parent</artifactId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.neo4j.doc</groupId>
   <artifactId>neo4j-manual-contents</artifactId>
-  <version>3.1.10-SNAPSHOT</version>
+  <version>3.1.9</version>
 
   <name>Neo4j - Reference Manual Contents</name>
   <description>Neo4j Reference Manual Contents.</description>

--- a/cypher/cypher-docs/pom.xml
+++ b/cypher/cypher-docs/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-cypher-docs-parent</artifactId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
     <relativePath>..</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>neo4j-cypher-docs</artifactId>
   <packaging>jar</packaging>
-  <version>3.1.10-SNAPSHOT</version>
+  <version>3.1.9</version>
   <name>Neo4j - Cypher Documentation</name>
   <description>Neo4j query language documentation</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/cypher/graphgist/pom.xml
+++ b/cypher/graphgist/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-cypher-docs-parent</artifactId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>neo4j-graphgist</artifactId>
-  <version>3.1.10-SNAPSHOT</version>
+  <version>3.1.9</version>
   <name>Neo4j - GraphGist</name>
   <description>Cypher tutorial documentation tool.</description>
 

--- a/cypher/pom.xml
+++ b/cypher/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-manual-parent</artifactId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.neo4j.doc</groupId>
   <artifactId>neo4j-cypher-docs-parent</artifactId>
-  <version>3.1.10-SNAPSHOT</version>
+  <version>3.1.9</version>
   <name>Neo4j - Cypher Documentation Build</name>
   <description>Neo4j - Cypher Documentation Build</description>
   <packaging>pom</packaging>

--- a/cypher/refcard-tests/pom.xml
+++ b/cypher/refcard-tests/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-cypher-docs-parent</artifactId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>neo4j-cypher-refcard-tests</artifactId>
-  <version>3.1.10-SNAPSHOT</version>
+  <version>3.1.9</version>
   <name>Neo4j - Cypher Reference Card Tests</name>
   <description>Test for Reference Card for the Neo4j Cypher Query Language.</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/doctools/pom.xml
+++ b/doctools/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <groupId>org.neo4j.doc</groupId>
         <artifactId>neo4j-manual-parent</artifactId>
-        <version>3.1.10-SNAPSHOT</version>
+        <version>3.1.9</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-doc-tools</artifactId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Documentation Tools</name>

--- a/embedded-examples/pom.xml
+++ b/embedded-examples/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-manual-parent</artifactId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.neo4j.examples</groupId>
   <artifactId>neo4j-examples</artifactId>
   <name>Neo4j - Examples</name>
-  <version>3.1.10-SNAPSHOT</version>
+  <version>3.1.9</version>
 
   <description>Neo4j Embedded Examples</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}/</url>

--- a/enterprise-server-docs/pom.xml
+++ b/enterprise-server-docs/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-manual-parent</artifactId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
     <relativePath>..</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.neo4j.doc</groupId>
   <artifactId>neo4j-server-enterprise-docs</artifactId>
-  <version>3.1.10-SNAPSHOT</version>
+  <version>3.1.9</version>
   <name>Neo4j - Enterprise Server Docs</name>
   <description>Documentation for the Neo4j Enterprise server</description>
 

--- a/graphviz/pom.xml
+++ b/graphviz/pom.xml
@@ -4,13 +4,13 @@
   <parent>
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-manual-parent</artifactId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-graphviz</artifactId>
-  <version>3.1.10-SNAPSHOT</version>
+  <version>3.1.9</version>
 
   <name>Neo4j - Graphviz generation</name>
   <description>Utility component to generate Graphviz .dot notation from Neo4j graphs.</description>

--- a/ha-docs/pom.xml
+++ b/ha-docs/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-manual-parent</artifactId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
     <relativePath>..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.neo4j.doc</groupId>
   <artifactId>neo4j-ha-docs</artifactId>
   <name>Neo4j - High Availability Docs</name>
-  <version>3.1.10-SNAPSHOT</version>
+  <version>3.1.9</version>
 
   <properties>
     <bundle.namespace>org.neo4j.kernel.ha</bundle.namespace>

--- a/import-tool/pom.xml
+++ b/import-tool/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-manual-parent</artifactId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
     <relativePath>..</relativePath>
   </parent>
 
@@ -11,7 +11,7 @@
 
   <groupId>org.neo4j.doc</groupId>
   <artifactId>neo4j-import-tool-docs</artifactId>
-  <version>3.1.10-SNAPSHOT</version>
+  <version>3.1.9</version>
 
   <packaging>jar</packaging>
   <name>Neo4j - Import Tool Documentation</name>

--- a/javadocs/pom.xml
+++ b/javadocs/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-manual-parent</artifactId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.neo4j.doc</groupId>
   <artifactId>neo4j-javadocs</artifactId>
-  <version>3.1.10-SNAPSHOT</version>
+  <version>3.1.9</version>
 
   <name>Neo4j - Javadocs</name>
   <packaging>pom</packaging>

--- a/kernel/pom.xml
+++ b/kernel/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <groupId>org.neo4j.doc</groupId>
         <artifactId>neo4j-manual-parent</artifactId>
-        <version>3.1.10-SNAPSHOT</version>
+        <version>3.1.9</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-kernel-docs</artifactId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
 
     <name>Neo4j - Kernel Docs</name>
     <description>Documentation build for the Neo4j kernel.</description>

--- a/lucene/pom.xml
+++ b/lucene/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <groupId>org.neo4j.doc</groupId>
         <artifactId>neo4j-manual-parent</artifactId>
-        <version>3.1.10-SNAPSHOT</version>
+        <version>3.1.9</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-lucene-index-docs</artifactId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
 
     <name>Neo4j - Lucene Index Docs</name>
     <description>Documentation build for Neo4j Lucene index integration.</description>

--- a/metrics-docs/pom.xml
+++ b/metrics-docs/pom.xml
@@ -6,13 +6,13 @@
   <parent>
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-manual-parent</artifactId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.neo4j.doc</groupId>
   <artifactId>neo4j-metrics-docs</artifactId>
-  <version>3.1.10-SNAPSHOT</version>
+  <version>3.1.9</version>
 
   <name>Neo4j - Metrics Kernel Extension docs</name>
   <packaging>jar</packaging>

--- a/neo4j-harness-enterprise-test/pom.xml
+++ b/neo4j-harness-enterprise-test/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>org.neo4j.doc</groupId>
         <artifactId>neo4j-manual-parent</artifactId>
-        <version>3.1.10-SNAPSHOT</version>
+        <version>3.1.9</version>
         <relativePath>..</relativePath>
     </parent>
 
     <groupId>org.neo4j.test</groupId>
     <artifactId>neo4j-harness-enterprise-test</artifactId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
 
     <packaging>jar</packaging>
 

--- a/neo4j-harness-test/pom.xml
+++ b/neo4j-harness-test/pom.xml
@@ -5,14 +5,14 @@
   <parent>
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-manual-parent</artifactId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
     <relativePath>..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.neo4j.test</groupId>
   <artifactId>neo4j-harness-test</artifactId>
-  <version>3.1.10-SNAPSHOT</version>
+  <version>3.1.9</version>
 
   <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
   <groupId>org.neo4j.doc</groupId>
   <artifactId>neo4j-manual-parent</artifactId>
-  <version>3.1.10-SNAPSHOT</version>
+  <version>3.1.9</version>
 
   <name>Neo4j - Reference Manual Build</name>
   <description>Neo4j Reference Manual Build.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -145,55 +145,5 @@
     </pluginManagement>
   </build>
 
-  <repositories>
-    <repository>
-      <id>neo4j-release-repository</id>
-      <name>Neo4j Maven 2 release repository</name>
-      <url>http://m2.neo4j.org/content/repositories/releases</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>neo4j-snapshot-repository</id>
-      <name>Neo4j Maven 2 snapshot repository</name>
-      <url>http://m2.neo4j.org/content/repositories/snapshots</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>neo4j-plugin-release-repository</id>
-      <name>Neo4j Maven 2 plugin release repository</name>
-      <url>http://m2.neo4j.org/content/repositories/releases</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </pluginRepository>
-    <pluginRepository>
-      <id>neo4j-plugin-snapshot-repository</id>
-      <name>Neo4j Maven 2 plugin snapshot repository</name>
-      <url>http://m2.neo4j.org/content/repositories/snapshots</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-    </pluginRepository>
-  </pluginRepositories>
-
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
   </parent>
   <groupId>org.neo4j.doc</groupId>
   <artifactId>neo4j-manual-parent</artifactId>

--- a/procedures/pom.xml
+++ b/procedures/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>neo4j-manual-parent</artifactId>
     <groupId>org.neo4j.doc</groupId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/server-docs/pom.xml
+++ b/server-docs/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-manual-parent</artifactId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
     <relativePath>..</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.neo4j.doc</groupId>
   <artifactId>neo4j-server-docs</artifactId>
-  <version>3.1.10-SNAPSHOT</version>
+  <version>3.1.9</version>
   <name>Neo4j - Server Docs</name>
   <description>Documentation for the Neo4j server</description>
 

--- a/server-examples/pom.xml
+++ b/server-examples/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-manual-parent</artifactId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.neo4j.examples</groupId>
   <artifactId>neo4j-server-examples</artifactId>
   <name>Neo4j - Server Examples</name>
-  <version>3.1.10-SNAPSHOT</version>
+  <version>3.1.9</version>
 
   <description>Neo4j Server Plugin Examples</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}/</url>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <groupId>org.neo4j.doc</groupId>
         <artifactId>neo4j-manual-parent</artifactId>
-        <version>3.1.10-SNAPSHOT</version>
+        <version>3.1.9</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-shell-docs</artifactId>
-    <version>3.1.10-SNAPSHOT</version>
+    <version>3.1.9</version>
 
     <name>Neo4j - Generic shell Docs</name>
     <description>Documentation build for Neo4j Shell.</description>


### PR DESCRIPTION
These declarations at best make m2.neo4j.org a SPOF when building docs. Instead, let Maven Central and it's CDN provide released dependencies.

The problem you have been seeing occur whenever Maven sees a dependency declared as a snapshot version. Because it then picks the abandoned m2.neo4j.org to resolve it, fails, and _reports m2.neo4j.org as the failure_ which is just hella misleading.

This change solves all the above mentioned problems once and or all 🎉 

This can be forward merged to 3.2 and 3.3 which have similar repository declarations.