### PR TITLE
Update imports after Cypher refactoring.

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentingTestBase.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentingTestBase.scala
@@ -32,7 +32,7 @@ import org.neo4j.cypher.export.{DatabaseSubGraph, SubGraphExporter}
 import org.neo4j.cypher.internal.ExecutionEngine
 import org.neo4j.cypher.internal.javacompat.{GraphDatabaseCypherService, GraphImpl, ResultSubscriber}
 import org.neo4j.cypher.internal.runtime.{RuntimeJavaValueConverter, isGraphKernelResultValue}
-import org.neo4j.cypher.internal.v4_0.util.Eagerly
+import org.neo4j.cypher.internal.util.Eagerly
 import org.neo4j.cypher.{ExecutionEngineHelper, GraphIcing}
 import org.neo4j.dbms.api.{DatabaseManagementService, DatabaseManagementServiceBuilder}
 import org.neo4j.doc.test.GraphDatabaseServiceCleaner.cleanDatabaseContent

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/Document.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/Document.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.docgen.tooling.RunnableInitialization.InitializationFunc
 import org.neo4j.cypher.example.JavaExecutionEngineDocTest
 import org.neo4j.cypher.internal.javacompat.GraphDatabaseCypherService
 import org.neo4j.kernel.GraphDatabaseQueryService
-import org.neo4j.cypher.internal.v4_0.util.Eagerly
+import org.neo4j.cypher.internal.util.Eagerly
 import org.neo4j.exceptions.InternalException
 
 import scala.collection.JavaConverters._

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/DocumentingTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/DocumentingTest.scala
@@ -25,7 +25,7 @@ import org.neo4j.cypher.GraphIcing
 import org.neo4j.cypher.internal.CypherSerializer
 import org.neo4j.cypher.internal.runtime.interpreted.TransactionBoundQueryContext.IndexSearchMonitor
 import org.neo4j.cypher.internal.runtime.interpreted.{TransactionBoundQueryContext, TransactionalContextWrapper}
-import org.neo4j.cypher.internal.v4_0.util.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.util.test_helpers.CypherFunSuite
 import org.neo4j.kernel.GraphDatabaseQueryService
 import org.neo4j.kernel.impl.coreapi.InternalTransaction
 import org.neo4j.kernel.impl.query.Neo4jTransactionalContextFactory

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/captureStateAsGraphViz.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/captureStateAsGraphViz.scala
@@ -23,7 +23,7 @@ import java.io.ByteArrayOutputStream
 
 import org.neo4j.cypher.GraphIcing
 import org.neo4j.cypher.internal.javacompat.GraphDatabaseCypherService
-import org.neo4j.cypher.internal.v4_0.util._
+import org.neo4j.cypher.internal.util._
 import org.neo4j.visualization.graphviz.{AsciiDocSimpleStyle, GraphvizWriter}
 import org.neo4j.walk.Walker
 

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/contentAndResultMerger.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/contentAndResultMerger.scala
@@ -19,8 +19,8 @@
  */
 package org.neo4j.cypher.docgen.tooling
 
-import org.neo4j.cypher.internal.v4_0.util.Rewritable._
-import org.neo4j.cypher.internal.v4_0.util.{Rewriter, bottomUp}
+import org.neo4j.cypher.internal.util.Rewritable._
+import org.neo4j.cypher.internal.util.{Rewriter, bottomUp}
 
 /**
  * Takes the document tree and the execution results and rewrites the

--- a/cypher/cypher-prettifier/src/main/scala/org/neo4j/cypher/docgen/tooling/PrettifierParser.scala
+++ b/cypher/cypher-prettifier/src/main/scala/org/neo4j/cypher/docgen/tooling/PrettifierParser.scala
@@ -19,9 +19,9 @@
  */
 package org.neo4j.cypher.docgen.tooling
 
-import org.neo4j.cypher.internal.v4_0.parser.Base
-import org.neo4j.cypher.internal.v4_0.parser.Strings
-import org.neo4j.cypher.internal.v4_0.parser.WSChar
+import org.neo4j.cypher.internal.parser.Base
+import org.neo4j.cypher.internal.parser.Strings
+import org.neo4j.cypher.internal.parser.WSChar
 import org.neo4j.exceptions.SyntaxException
 import org.parboiled.scala._
 

--- a/cypher/cypher-prettifier/src/test/scala/org/neo4j/cypher/docgen/tooling/ParserTestBase.scala
+++ b/cypher/cypher-prettifier/src/test/scala/org/neo4j/cypher/docgen/tooling/ParserTestBase.scala
@@ -20,8 +20,8 @@
 package org.neo4j.cypher.docgen.tooling
 
 import org.neo4j.cypher.GraphIcing
-import org.neo4j.cypher.internal.v4_0.parser.BufferPosition
-import org.neo4j.cypher.internal.v4_0.parser.InvalidInputErrorFormatter
+import org.neo4j.cypher.internal.parser.BufferPosition
+import org.neo4j.cypher.internal.parser.InvalidInputErrorFormatter
 import org.parboiled.errors.InvalidInputError
 import org.parboiled.scala._
 import org.scalatest.Assertions


### PR DESCRIPTION
All `v4_0` was removed from the file structures in the Cypher frontend so the imports needs updating.

Should be merged together with https://github.com/neo-technology/neo4j/pull/4141