### PR TITLE
Updated broken links to Duration Functions since the section had moved

### DIFF
--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DurationFunctionsTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DurationFunctionsTest.scala
@@ -28,7 +28,7 @@ import org.neo4j.values.storable.DurationValue
 class DurationFunctionsTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT KNOWS A")
   val title = "Duration Functions"
-  override val linkId = "functions/duration"
+  override val linkId = "functions/temporal/duration/"
 
   override def assert(name: String, result: DocsExecutionResult): Unit = {
     name match {


### PR DESCRIPTION
Found that when updating the 4.0 ref card that the 3.5 ref card also had a broken link so updates it here  as well.

Already fixed in 4.0: https://github.com/neo4j/neo4j-documentation/pull/480