### PR TITLE
Add new clauses to the Cypher manual glossary.

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/clause.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/clause.asciidoc
@@ -59,6 +59,7 @@ These comprise sub-clauses that must operate as part of reading clauses.
 |===
 |Sub-clause                                         | Description
 |<<query-where,WHERE>>                          | Adds constraints to the patterns in a `MATCH` or `OPTIONAL MATCH` clause or filters the results of a `WITH` clause.
+|<<existential-subqueries, WHERE EXISTS {}>>    | An existential sub-query used to filter the results of a `MATCH`, `OPTIONAL MATCH` or `WITH` clause.
 |<<query-order,ORDER BY [ASC[ENDING] \| DESC[ENDING]]>>                       | A sub-clause following `RETURN` or `WITH`, specifying that the output should be sorted in either ascending (the default) or descending order.
 |<<query-skip,SKIP>>                            | Defines from which row to start including the rows in the output.
 |<<query-limit,LIMIT>>                          | Constrains the number of rows in the output.
@@ -129,7 +130,7 @@ These comprise clauses that both read data from and write data to the database.
 [options="header"]
 |===
 |Clause                             |   Description
-|<<query-call-subquery,CALL {} (subquery)>>  | Evaluates a subquery returning values.
+|<<query-call-subquery,CALL {} (subquery)>>  | Evaluates a subquery, typically used for post-union processing or aggregations.
 |===
 
 [[header-multiple-graphs-clauses]]

--- a/cypher/cypher-docs/src/docs/dev/clause.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/clause.asciidoc
@@ -59,7 +59,7 @@ These comprise sub-clauses that must operate as part of reading clauses.
 |===
 |Sub-clause                                         | Description
 |<<query-where,WHERE>>                          | Adds constraints to the patterns in a `MATCH` or `OPTIONAL MATCH` clause or filters the results of a `WITH` clause.
-|<<existential-subqueries, WHERE EXISTS {}>>    | An existential sub-query used to filter the results of a `MATCH`, `OPTIONAL MATCH` or `WITH` clause.
+|<<existential-subqueries, WHERE EXISTS {...}>> | An existential sub-query used to filter the results of a `MATCH`, `OPTIONAL MATCH` or `WITH` clause.
 |<<query-order,ORDER BY [ASC[ENDING] \| DESC[ENDING]]>>                       | A sub-clause following `RETURN` or `WITH`, specifying that the output should be sorted in either ascending (the default) or descending order.
 |<<query-skip,SKIP>>                            | Defines from which row to start including the rows in the output.
 |<<query-limit,LIMIT>>                          | Constrains the number of rows in the output.
@@ -110,7 +110,7 @@ These comprise clauses that both read data from and write data to the database.
 |<<query-merge,MERGE>>                              |   Ensures that a pattern exists in the graph. Either the pattern already exists, or it needs to be created.
 |--- <<query-merge-on-create-on-match,ON CREATE>>   | Used in conjunction with `MERGE`, this write sub-clause specifies the actions to take if the pattern needs to be created.
 |--- <<query-merge-on-create-on-match,ON MATCH>>    | Used in conjunction with `MERGE`, this write sub-clause specifies the actions to take if the pattern already exists.
-|<<query-call,CALL procedure>>                      | Invokes a procedure deployed in the database and return any results.
+|<<query-call,CALL [...YIELD]>>                      | Invokes a procedure deployed in the database and return any results.
 |===
 
 
@@ -130,7 +130,7 @@ These comprise clauses that both read data from and write data to the database.
 [options="header"]
 |===
 |Clause                             |   Description
-|<<query-call-subquery,CALL {} (subquery)>>  | Evaluates a subquery, typically used for post-union processing or aggregations.
+|<<query-call-subquery,CALL { ... }>>   | Evaluates a subquery, typically used for post-union processing or aggregations.
 |===
 
 [[header-multiple-graphs-clauses]]

--- a/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
@@ -21,8 +21,8 @@ This section comprises a glossary of all the keywords -- grouped by category and
 [options="header"]
 |===
 |Clause                                     | Category      |   Description
-|<<query-call, CALL procedure>>             | Reading/Writing   | Invoke a procedure deployed in the database.
-|<<query-call-subquery, CALL {} (subquery)>> | Reading/Writing   | Evaluates a subquery, typically used for post-union processing or aggregations.
+|<<query-call, CALL [...YIELD]>>            | Reading/Writing   | Invoke a procedure deployed in the database.
+|<<query-call-subquery, CALL {...}>>        | Reading/Writing   | Evaluates a subquery, typically used for post-union processing or aggregations.
 |<<query-create, CREATE>>                    | Writing     |  Create nodes and relationships.
 |<<administration-constraints-syntax, CREATE CONSTRAINT [existence] ON (n:Label) ASSERT exists(n.property)>>  | Schema   | Create a constraint ensuring that all nodes with a particular label have a certain property.
 |<<administration-constraints-syntax, CREATE CONSTRAINT [node_key] ON (n:Label) ASSERT (n.prop1, ..., n.propN) IS NODE KEY>>  |  Schema | Create a constraint ensuring all nodes with a particular label have all the specified properties and that the combination of property values is unique; i.e. ensures existence and uniqueness.
@@ -58,7 +58,7 @@ This section comprises a glossary of all the keywords -- grouped by category and
 |<<query-using-scan-hint, USING SCAN variable:Label>>              | Hint | Scan hints are used to force the planner to do a label scan (followed by a filtering operation) instead of using an index.
 |<<query-with, WITH ... [AS]>>                        | Projecting   |  Allows query parts to be chained together, piping the results from one to be used as starting points or criteria in the next.
 |<<query-where, WHERE>>                          | Reading sub-clause | A sub-clause used to add constraints to the patterns in a `MATCH` or `OPTIONAL MATCH` clause, or to filter the results of a `WITH` clause.
-|<<existential-subqueries, WHERE EXISTS {}>>  | Reading sub-clause | An existential sub-query used to filter the results of a `MATCH`, `OPTIONAL MATCH` or `WITH` clause.
+|<<existential-subqueries, WHERE EXISTS {...}>>  | Reading sub-clause | An existential sub-query used to filter the results of a `MATCH`, `OPTIONAL MATCH` or `WITH` clause.
 |===
 
 

--- a/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
@@ -21,7 +21,8 @@ This section comprises a glossary of all the keywords -- grouped by category and
 [options="header"]
 |===
 |Clause                                     | Category      |   Description
-|<<query-call, CALL [...YIELD]>>                        | Reading/Writing   | Invoke a procedure deployed in the database.
+|<<query-call, CALL procedure>>             | Reading/Writing   | Invoke a procedure deployed in the database.
+|<<query-call-subquery, CALL {} (subquery)>> | Reading/Writing   | Evaluates a subquery, typically used for post-union processing or aggregations.
 |<<query-create, CREATE>>                    | Writing     |  Create nodes and relationships.
 |<<administration-constraints-syntax, CREATE CONSTRAINT [existence] ON (n:Label) ASSERT exists(n.property)>>  | Schema   | Create a constraint ensuring that all nodes with a particular label have a certain property.
 |<<administration-constraints-syntax, CREATE CONSTRAINT [node_key] ON (n:Label) ASSERT (n.prop1, ..., n.propN) IS NODE KEY>>  |  Schema | Create a constraint ensuring all nodes with a particular label have all the specified properties and that the combination of property values is unique; i.e. ensures existence and uniqueness.
@@ -49,6 +50,7 @@ This section comprises a glossary of all the keywords -- grouped by category and
 |<<query-union, UNION>>                      | Set operations   |  Combines the result of multiple queries. Duplicates are removed.
 |<<query-union, UNION ALL>>                      | Set operations   |  Combines the result of multiple queries. Duplicates are retained.
 |<<query-unwind, UNWIND ... [AS]>>                    | Projecting   |  Expands a list into a sequence of rows.
+|<<query-use, USE>>                           | Multiple graphs | [fabric]#Determines which graph a query, or query part, is executed against.#
 |<<query-using-index-hint, USING INDEX variable:Label(property)>>  | Hint | Index hints are used to specify which index, if any, the planner should use as a starting point.
 |<<query-using-index-hint, USING INDEX SEEK variable:Label(property)>>  | Hint | Index seek hint instructs the planner to use an index seek for this clause.
 |<<query-using-join-hint, USING JOIN ON variable>>                 | Hint | Join hints are used to enforce a join operation at specified points.
@@ -56,6 +58,7 @@ This section comprises a glossary of all the keywords -- grouped by category and
 |<<query-using-scan-hint, USING SCAN variable:Label>>              | Hint | Scan hints are used to force the planner to do a label scan (followed by a filtering operation) instead of using an index.
 |<<query-with, WITH ... [AS]>>                        | Projecting   |  Allows query parts to be chained together, piping the results from one to be used as starting points or criteria in the next.
 |<<query-where, WHERE>>                          | Reading sub-clause | A sub-clause used to add constraints to the patterns in a `MATCH` or `OPTIONAL MATCH` clause, or to filter the results of a `WITH` clause.
+|<<existential-subqueries, WHERE EXISTS {}>>  | Reading sub-clause | An existential sub-query used to filter the results of a `MATCH`, `OPTIONAL MATCH` or `WITH` clause.
 |===
 
 


### PR DESCRIPTION
Added the following clauses to the glossary:
- existential subqueries
- CALL subqueries
- USE (fabric only)
