### PR TITLE
Added ref card tests for the new security commands

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-deny-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-deny-syntax.asciidoc
@@ -54,10 +54,9 @@ this combines both TRAVERSE and READ allowing an entity to be found and its prop
 +
 this privilege can only be assigned to all nodes, relationships and properties in the entire graph (this means that the entity part of the command must also be `ELEMENTS +*+` and cannot be more specific).
 +
-* _dbname_
+* _name_
 ** The graph or graphs to associate the privilege with. In {neo4j.version} there can be only one graph per database, and therefor this command uses the database name to refer to that graph.
    Note that if you delete a database and create a new one with the same name, the new one will _NOT_ have any of the privileges specifically assigned to the deleted graph.
-** Multiple graph names can be specified, comma-separated.
 ** It can be `+*+` which means all graphs.
   Any new databases created after this command will also be associated with these privileges.
 * _entity_

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentingTestBase.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentingTestBase.scala
@@ -64,6 +64,7 @@ trait DocumentationHelper extends GraphIcing with ExecutionEngineHelper {
     if (parent.isDefined) niceify(parent.get + " " + section + " " + title) else niceify(section + " " + title)
 
   def niceify(in: String): String = in.toLowerCase
+    .replace("(★) ", "")
     .replace(" ", "-")
     .replace("(", "")
     .replace(")", "")

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/AdministrationCommandTestBase.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/AdministrationCommandTestBase.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.docgen.refcard
+
+import org.neo4j.configuration.GraphDatabaseSettings
+import org.neo4j.cypher.docgen.RefcardTest
+import org.neo4j.cypher.docgen.tooling.{DocsExecutionResult, QueryStatisticsTestSupport}
+import org.neo4j.graphdb.{GraphDatabaseService, Transaction}
+
+abstract class AdministrationCommandTestBase extends RefcardTest with QueryStatisticsTestSupport {
+  val graphDescription = List()
+
+  override protected def getGraph: GraphDatabaseService = managementService.database(GraphDatabaseSettings.SYSTEM_DATABASE_NAME)
+
+  override def assert(tx: Transaction, name: String, result: DocsExecutionResult): Unit = {
+    name match {
+      case "update-one" =>
+        assertStats(result, systemUpdates = 1)
+        assert(result.toList.size === 0)
+      case "update-two" =>
+        assertStats(result, systemUpdates = 2)
+        assert(result.toList.size === 0)
+      case "update-ten" =>
+        assertStats(result, systemUpdates = 10)
+        assert(result.toList.size === 0)
+      case "show" =>
+        assertStats(result, systemUpdates = 0)
+        assert(result.toList.size === 1) // there are no default roles or users, nor is the system or neo4j databases shown
+      case "show-nothing" =>
+        assertStats(result, systemUpdates = 0)
+        assert(result.toList.size === 0) // `show default database` finds none due to not listing neo4j
+    }
+  }
+}

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/AdministrationCommandTestBase.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/AdministrationCommandTestBase.scala
@@ -37,12 +37,18 @@ abstract class AdministrationCommandTestBase extends RefcardTest with QueryStati
       case "update-two" =>
         assertStats(result, systemUpdates = 2)
         assert(result.toList.size === 0)
+      case "update-four" =>
+        assertStats(result, systemUpdates = 4)
+        assert(result.toList.size === 0)
       case "update-ten" =>
         assertStats(result, systemUpdates = 10)
         assert(result.toList.size === 0)
-      case "show" =>
+      case "show-one" =>
         assertStats(result, systemUpdates = 0)
         assert(result.toList.size === 1) // there are no default roles or users, nor is the system or neo4j databases shown
+      case "show-two" =>
+        assertStats(result, systemUpdates = 0)
+        assert(result.toList.size === 2) // there are no default users
       case "show-nothing" =>
         assertStats(result, systemUpdates = 0)
         assert(result.toList.size === 0) // `show default database` finds none due to not listing neo4j

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DatabaseManagementTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DatabaseManagementTest.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.docgen.refcard
+
+class DatabaseManagementTest extends AdministrationCommandTestBase {
+  val title = "DATABASE MANAGEMENT"
+  override val linkId = "administration/databases"
+
+  def text: String =
+    """
+###assertion=update-one
+//
+
+CREATE OR REPLACE DATABASE myDatabase
+###
+
+(★) Create a database named `myDatabase`, if there already existed a database with that name then the old is deleted and a new one created.
+
+###assertion=update-one
+//
+
+STOP DATABASE myDatabase
+###
+
+(★) Stop the database `myDatabase`.
+
+###assertion=update-one
+//
+
+START DATABASE myDatabase
+###
+
+(★) Start the database `myDatabase`.
+
+###assertion=show
+//
+
+SHOW DATABASES
+###
+
+List all databases in the system and information about them.
+
+###assertion=show
+//
+
+SHOW DATABASE myDatabase
+###
+
+List all the information about the database `myDatabase`.
+
+###assertion=show-nothing
+//
+
+SHOW DEFAULT DATABASE
+###
+
+List all the information about the current default database.
+
+###assertion=update-one
+//
+
+DROP DATABASE myDatabase IF EXISTS
+###
+
+(★) Delete the database `myDatabase` if it exists.
+
+"""
+}

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DatabaseManagementTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DatabaseManagementTest.scala
@@ -31,7 +31,7 @@ class DatabaseManagementTest extends AdministrationCommandTestBase {
 CREATE OR REPLACE DATABASE myDatabase
 ###
 
-(★) Create a database named `myDatabase`. If a database with that name already existed, then the existing database is deleted and a new one created.
+(★) Create a database named `myDatabase`. If a database with that name exists, then the existing database is deleted and a new one created.
 
 ###assertion=update-one
 //
@@ -71,7 +71,7 @@ List information about the database `myDatabase`.
 SHOW DEFAULT DATABASE
 ###
 
-List information about the current default database.
+List information about the default database.
 
 ###assertion=update-one
 //
@@ -79,7 +79,7 @@ List information about the current default database.
 DROP DATABASE myDatabase IF EXISTS
 ###
 
-(★) Delete the database `myDatabase` if it exists.
+(★) Delete the database `myDatabase`, if it exists.
 
 """
 }

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DatabaseManagementTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DatabaseManagementTest.scala
@@ -31,7 +31,7 @@ class DatabaseManagementTest extends AdministrationCommandTestBase {
 CREATE OR REPLACE DATABASE myDatabase
 ###
 
-(★) Create a database named `myDatabase`, if there already existed a database with that name then the old is deleted and a new one created.
+(★) Create a database named `myDatabase`. If a database with that name already existed, then the existing database is deleted and a new one created.
 
 ###assertion=update-one
 //
@@ -49,7 +49,7 @@ START DATABASE myDatabase
 
 (★) Start the database `myDatabase`.
 
-###assertion=show
+###assertion=show-one
 //
 
 SHOW DATABASES
@@ -57,13 +57,13 @@ SHOW DATABASES
 
 List all databases in the system and information about them.
 
-###assertion=show
+###assertion=show-one
 //
 
 SHOW DATABASE myDatabase
 ###
 
-List all the information about the database `myDatabase`.
+List information about the database `myDatabase`.
 
 ###assertion=show-nothing
 //
@@ -71,7 +71,7 @@ List all the information about the database `myDatabase`.
 SHOW DEFAULT DATABASE
 ###
 
-List all the information about the current default database.
+List information about the current default database.
 
 ###assertion=update-one
 //

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DatabasePrivilegeTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DatabasePrivilegeTest.scala
@@ -128,7 +128,7 @@ Deny privilege to create new relationship types on a specified database to a rol
 REVOKE GRANT CREATE NEW PROPERTY NAMES ON DATABASE bar FROM my_role
 ###
 
-Revoke the grant privilege from a role to create new property names on a specified database.
+Revoke the grant privilege to create new property names on a specified database from a role.
 
 ###assertion=update-two
 //
@@ -144,7 +144,7 @@ Grant privilege to create labels, relationship types, and property names on all 
 GRANT ALL ON DATABASE baz TO my_role
 ###
 
-Grant all privileges on a specified database to a role.
+Grant all database privileges on a specified database to a role.
 
 """
   }

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DatabasePrivilegeTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DatabasePrivilegeTest.scala
@@ -40,7 +40,7 @@ class DatabasePrivilegeTest extends AdministrationCommandTestBase {
 GRANT ACCESS ON DATABASE * TO my_role
 ###
 
-Grant privilege to access and run queries against all databases to the role `my_role`.
+Grant privilege to access and run queries against all databases to a role.
 
 ###assertion=update-one
 //
@@ -48,7 +48,7 @@ Grant privilege to access and run queries against all databases to the role `my_
 GRANT START ON DATABASE * TO my_role
 ###
 
-Grant privilege to start all databases to the role `my_role`.
+Grant privilege to start all databases to a role.
 
 ###assertion=update-one
 //
@@ -56,7 +56,7 @@ Grant privilege to start all databases to the role `my_role`.
 GRANT STOP ON DATABASE * TO my_role
 ###
 
-Grant privilege to stop all databases to the role `my_role`.
+Grant privilege to stop all databases to a role.
 
 ###assertion=update-one
 //
@@ -64,7 +64,7 @@ Grant privilege to stop all databases to the role `my_role`.
 GRANT CREATE INDEX ON DATABASE foo TO my_role
 ###
 
-Grant privilege to create indexes on the database `foo` to the role `my_role`.
+Grant privilege to create indexes on a specified database to a role.
 
 ###assertion=update-one
 //
@@ -72,7 +72,7 @@ Grant privilege to create indexes on the database `foo` to the role `my_role`.
 GRANT DROP INDEX ON DATABASE foo TO my_role
 ###
 
-Grant privilege to drop indexes on the database `foo` to the role `my_role`.
+Grant privilege to drop indexes on a specified database to a role.
 
 ###assertion=update-two
 //
@@ -80,7 +80,7 @@ Grant privilege to drop indexes on the database `foo` to the role `my_role`.
 DENY INDEX MANAGEMENT ON DATABASE bar TO my_role
 ###
 
-Deny privilege to create and drop indexes on the database `bar` to the role `my_role`.
+Deny privilege to create and drop indexes on a specified database to a role.
 
 ###assertion=update-one
 //
@@ -88,7 +88,7 @@ Deny privilege to create and drop indexes on the database `bar` to the role `my_
 GRANT CREATE CONSTRAINT ON DATABASE * TO my_role
 ###
 
-Grant privilege to create constraints on all databases to the role `my_role`.
+Grant privilege to create constraints on all databases to a role.
 
 ###assertion=update-one
 //
@@ -96,7 +96,7 @@ Grant privilege to create constraints on all databases to the role `my_role`.
 DENY DROP CONSTRAINT ON DATABASE * TO my_role
 ###
 
-Deny privilege to drop constraints on all databases to the role `my_role`.
+Deny privilege to drop constraints on all databases to a role.
 
 ###assertion=update-two
 //
@@ -104,7 +104,7 @@ Deny privilege to drop constraints on all databases to the role `my_role`.
 REVOKE CONSTRAINT ON DATABASE * FROM my_role
 ###
 
-Revoke existing privileges (both granted and denied) to create and drop constraints on all databases from the role `my_role`.
+Revoke granted and denied privileges to create and drop constraints on all databases from a role.
 
 ###assertion=update-one
 //
@@ -112,7 +112,7 @@ Revoke existing privileges (both granted and denied) to create and drop constrai
 GRANT CREATE NEW LABELS ON DATABASE * TO my_role
 ###
 
-Grant privilege to create new labels on all databases to the role `my_role`.
+Grant privilege to create new labels on all databases to a role.
 
 ###assertion=update-one
 //
@@ -120,7 +120,7 @@ Grant privilege to create new labels on all databases to the role `my_role`.
 DENY CREATE NEW TYPES ON DATABASE foo TO my_role
 ###
 
-Deny privilege to create new relationship types on the database `foo` to the role `my_role`.
+Deny privilege to create new relationship types on a specified database to a role.
 
 ###assertion=update-one
 //
@@ -128,7 +128,7 @@ Deny privilege to create new relationship types on the database `foo` to the rol
 REVOKE GRANT CREATE NEW PROPERTY NAMES ON DATABASE bar FROM my_role
 ###
 
-Revoke grant privilege to create new property keys on the database `bar` from the role `my_role`.
+Revoke the grant privilege from a role to create new property names on a specified database.
 
 ###assertion=update-two
 //
@@ -136,7 +136,7 @@ Revoke grant privilege to create new property keys on the database `bar` from th
 GRANT NAME MANAGEMENT ON DATABASE * TO my_role
 ###
 
-Grant privilege to create labels, relationship types and property keys on all databases to the role `my_role`.
+Grant privilege to create labels, relationship types, and property names on all databases to a role.
 
 ###assertion=update-ten
 //
@@ -144,7 +144,7 @@ Grant privilege to create labels, relationship types and property keys on all da
 GRANT ALL ON DATABASE baz TO my_role
 ###
 
-Grant all database privileges above on the database `baz` to the role `my_role`.
+Grant all privileges on a specified database to a role.
 
 """
   }

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DatabasePrivilegeTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DatabasePrivilegeTest.scala
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.docgen.refcard
+
+class DatabasePrivilegeTest extends AdministrationCommandTestBase {
+  val title = "(★) DATABASE PRIVILEGES"
+  override val linkId = "administration/security/administration/#administration-security-administration-database-privileges"
+
+  private def setup() = graph.withTx { tx =>
+    tx.execute("CREATE ROLE my_role")
+    tx.execute("CREATE DATABASE foo")
+    tx.execute("CREATE DATABASE bar")
+    tx.execute("CREATE DATABASE baz")
+    tx.execute("GRANT CREATE NEW PROPERTY NAMES ON DATABASE bar TO my_role")
+  }
+
+  def text: String = {
+    setup()
+    """
+###assertion=update-one
+//
+
+GRANT ACCESS ON DATABASE * TO my_role
+###
+
+Grant privilege to access and run queries against all databases to the role `my_role`.
+
+###assertion=update-one
+//
+
+GRANT START ON DATABASE * TO my_role
+###
+
+Grant privilege to start all databases to the role `my_role`.
+
+###assertion=update-one
+//
+
+GRANT STOP ON DATABASE * TO my_role
+###
+
+Grant privilege to stop all databases to the role `my_role`.
+
+###assertion=update-one
+//
+
+GRANT CREATE INDEX ON DATABASE foo TO my_role
+###
+
+Grant privilege to create indexes on the database `foo` to the role `my_role`.
+
+###assertion=update-one
+//
+
+GRANT DROP INDEX ON DATABASE foo TO my_role
+###
+
+Grant privilege to drop indexes on the database `foo` to the role `my_role`.
+
+###assertion=update-two
+//
+
+DENY INDEX MANAGEMENT ON DATABASE bar TO my_role
+###
+
+Deny privilege to create and drop indexes on the database `bar` to the role `my_role`.
+
+###assertion=update-one
+//
+
+GRANT CREATE CONSTRAINT ON DATABASE * TO my_role
+###
+
+Grant privilege to create constraints on all databases to the role `my_role`.
+
+###assertion=update-one
+//
+
+DENY DROP CONSTRAINT ON DATABASE * TO my_role
+###
+
+Deny privilege to drop constraints on all databases to the role `my_role`.
+
+###assertion=update-two
+//
+
+REVOKE CONSTRAINT ON DATABASE * FROM my_role
+###
+
+Revoke existing privileges (both granted and denied) to create and drop constraints on all databases from the role `my_role`.
+
+###assertion=update-one
+//
+
+GRANT CREATE NEW LABELS ON DATABASE * TO my_role
+###
+
+Grant privilege to create new labels on all databases to the role `my_role`.
+
+###assertion=update-one
+//
+
+DENY CREATE NEW TYPES ON DATABASE foo TO my_role
+###
+
+Deny privilege to create new relationship types on the database `foo` to the role `my_role`.
+
+###assertion=update-one
+//
+
+REVOKE GRANT CREATE NEW PROPERTY NAMES ON DATABASE bar FROM my_role
+###
+
+Revoke grant privilege to create new property keys on the database `bar` from the role `my_role`.
+
+###assertion=update-two
+//
+
+GRANT NAME MANAGEMENT ON DATABASE * TO my_role
+###
+
+Grant privilege to create labels, relationship types and property keys on all databases to the role `my_role`.
+
+###assertion=update-ten
+//
+
+GRANT ALL ON DATABASE baz TO my_role
+###
+
+Grant all database privileges on the database `baz` to the role `my_role`.
+This means that users with `my_role` can access, start and stop the database as well as
+create and drop indexes and constraints and create labels, relationship types and property keys on the database.
+
+"""
+  }
+}

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DatabasePrivilegeTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DatabasePrivilegeTest.scala
@@ -144,9 +144,7 @@ Grant privilege to create labels, relationship types and property keys on all da
 GRANT ALL ON DATABASE baz TO my_role
 ###
 
-Grant all database privileges on the database `baz` to the role `my_role`.
-This means that users with `my_role` can access, start and stop the database as well as
-create and drop indexes and constraints and create labels, relationship types and property keys on the database.
+Grant all database privileges above on the database `baz` to the role `my_role`.
 
 """
   }

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/GraphPrivilegeTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/GraphPrivilegeTest.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.docgen.refcard
+
+class GraphPrivilegeTest extends AdministrationCommandTestBase {
+  val title = "(★) GRAPH PRIVILEGES"
+  override val linkId = "administration/security/subgraph"
+
+  private def setup() = graph.withTx { tx =>
+    tx.execute("CREATE ROLE my_role")
+    tx.execute("GRANT WRITE ON GRAPH * TO my_role")
+    tx.execute("CREATE DATABASE foo")
+  }
+
+  def text: String = {
+    setup()
+    """
+###assertion=update-one
+//
+
+GRANT TRAVERSE ON GRAPH * NODES * TO my_role
+###
+
+Grant `traverse` privilege on all nodes and all graphs to the role `my_role`.
+
+###assertion=update-one
+//
+
+DENY READ {prop} ON GRAPH foo NODES Label TO my_role
+###
+
+Deny `read` privilege on property `prop` on all nodes with label `Label` on the graph `foo` to the role `my_role`.
+
+###assertion=update-two
+//
+
+GRANT MATCH {*} ON GRAPH foo NODES Label TO my_role
+###
+
+Grant `read` and `traverse` privileges to the role `my_role`.
+Here the `read` privilege is on all properties on all nodes with label `Label` on the graph `foo` and
+the `traverse` privilege on all nodes with label `Label` on the graph `foo`.
+
+###assertion=update-two
+//
+
+REVOKE WRITE ON GRAPH * FROM my_role
+###
+
+Revoke `write` privilege on all graphs from the role `my_role`.
+
+"""
+  }
+}

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/GraphPrivilegeTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/GraphPrivilegeTest.scala
@@ -38,7 +38,7 @@ class GraphPrivilegeTest extends AdministrationCommandTestBase {
 GRANT TRAVERSE ON GRAPH * NODES * TO my_role
 ###
 
-Grant `traverse` privilege on all nodes and all graphs to the role `my_role`.
+Grant `traverse` privilege on all nodes and all graphs to a role.
 
 ###assertion=update-one
 //
@@ -46,7 +46,7 @@ Grant `traverse` privilege on all nodes and all graphs to the role `my_role`.
 DENY READ {prop} ON GRAPH foo RELATIONSHIP Type TO my_role
 ###
 
-Deny `read` privilege on property `prop` on all nodes with label `Label` in the graph `foo` to the role `my_role`.
+Deny `read` privilege on a specified property, on all nodes with label `Label` in the graph `foo`, to the role `my_role`.
 
 ###assertion=update-four
 //
@@ -54,8 +54,8 @@ Deny `read` privilege on property `prop` on all nodes with label `Label` in the 
 GRANT MATCH {*} ON GRAPH foo ELEMENTS Label TO my_role
 ###
 
-Grant `read` privilege on all properties and `traverse` privilege to the role `my_role`.
-Here both privileges apply to all nodes with label `Label` in the graph `foo`.
+Grant `read` privilege on all properties and `traverse` privilege to a role.
+Here, both privileges apply to all nodes with a specified label in the graph.
 
 ###assertion=update-two
 //
@@ -63,7 +63,7 @@ Here both privileges apply to all nodes with label `Label` in the graph `foo`.
 REVOKE WRITE ON GRAPH * FROM my_role
 ###
 
-Revoke `write` privilege on all graphs from the role `my_role`.
+Revoke `write` privilege on all graphs from a role.
 
 """
   }

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/GraphPrivilegeTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/GraphPrivilegeTest.scala
@@ -46,7 +46,7 @@ Grant `traverse` privilege on all nodes and all graphs to a role.
 DENY READ {prop} ON GRAPH foo RELATIONSHIP Type TO my_role
 ###
 
-Deny `read` privilege on a specified property, on all nodes with label `Label` in the graph `foo`, to the role `my_role`.
+Deny `read` privilege on a specified property, on all relationships with a specified type in a specified graph, to a role.
 
 ###assertion=update-four
 //
@@ -54,7 +54,7 @@ Deny `read` privilege on a specified property, on all nodes with label `Label` i
 GRANT MATCH {*} ON GRAPH foo ELEMENTS Label TO my_role
 ###
 
-Grant `read` privilege on all properties and `traverse` privilege to a role.
+Grant `read` privilege on all properties and `traverse` privilege to a role.+
 Here, both privileges apply to all nodes with a specified label in the graph.
 
 ###assertion=update-two

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/GraphPrivilegeTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/GraphPrivilegeTest.scala
@@ -43,20 +43,19 @@ Grant `traverse` privilege on all nodes and all graphs to the role `my_role`.
 ###assertion=update-one
 //
 
-DENY READ {prop} ON GRAPH foo NODES Label TO my_role
+DENY READ {prop} ON GRAPH foo RELATIONSHIP Type TO my_role
 ###
 
-Deny `read` privilege on property `prop` on all nodes with label `Label` on the graph `foo` to the role `my_role`.
+Deny `read` privilege on property `prop` on all nodes with label `Label` in the graph `foo` to the role `my_role`.
 
-###assertion=update-two
+###assertion=update-four
 //
 
-GRANT MATCH {*} ON GRAPH foo NODES Label TO my_role
+GRANT MATCH {*} ON GRAPH foo ELEMENTS Label TO my_role
 ###
 
-Grant `read` and `traverse` privileges to the role `my_role`.
-Here the `read` privilege is on all properties on all nodes with label `Label` on the graph `foo` and
-the `traverse` privilege on all nodes with label `Label` on the graph `foo`.
+Grant `read` privilege on all properties and `traverse` privilege to the role `my_role`.
+Here both privileges apply to all nodes with label `Label` in the graph `foo`.
 
 ###assertion=update-two
 //

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ListPrivilegeTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ListPrivilegeTest.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.docgen.refcard
+
+class ListPrivilegeTest extends AdministrationCommandTestBase {
+  val title = "(★) SHOW PRIVILEGES"
+  override val linkId = "administration/security/subgraph/#administration-security-subgraph-show"
+
+  private def setup() = graph.withTx { tx =>
+    tx.execute("CREATE ROLE my_role")
+    tx.execute("GRANT ACCESS ON DATABASE * TO my_role")
+    tx.execute("CREATE USER alice SET PASSWORD 'secret'")
+    tx.execute("GRANT ROLE my_role TO alice")
+  }
+
+  def text: String = {
+    setup()
+    """
+###assertion=show
+//
+
+SHOW PRIVILEGES
+###
+
+List all privileges in the system, what privilege it is, what resource and segment its on and which role it is assigned to.
+
+###assertion=show
+//
+
+SHOW ROLE my_role PRIVILEGES
+###
+
+List all privileges belonging to the role `my_role`, what privilege it is and what resource and segment its on.
+
+###assertion=show
+//
+
+SHOW USER alice PRIVILEGES
+###
+
+List all privileges belonging to the user `alice`, what privilege it is, what resource and segment its on and which role it is assigned to.
+
+"""
+  }
+}

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ListPrivilegeTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ListPrivilegeTest.scala
@@ -33,29 +33,29 @@ class ListPrivilegeTest extends AdministrationCommandTestBase {
   def text: String = {
     setup()
     """
-###assertion=show
+###assertion=show-one
 //
 
 SHOW PRIVILEGES
 ###
 
-List all privileges in the system, what privilege it is, what resource and segment its on and which role it is assigned to.
+List all privileges in the system and which roles they are assigned to.
 
-###assertion=show
+###assertion=show-one
 //
 
 SHOW ROLE my_role PRIVILEGES
 ###
 
-List all privileges belonging to the role `my_role`, what privilege it is and what resource and segment its on.
+List all privileges assigned to the role `my_role`.
 
-###assertion=show
+###assertion=show-one
 //
 
 SHOW USER alice PRIVILEGES
 ###
 
-List all privileges belonging to the user `alice`, what privilege it is, what resource and segment its on and which role it is assigned to.
+List all privileges belonging to the user `alice` and which role it is assigned to.
 
 """
   }

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ListPrivilegeTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ListPrivilegeTest.scala
@@ -39,7 +39,7 @@ class ListPrivilegeTest extends AdministrationCommandTestBase {
 SHOW PRIVILEGES
 ###
 
-List all privileges in the system and which roles they are assigned to.
+List all privileges in the system, and the roles that they are assigned to.
 
 ###assertion=show-one
 //
@@ -47,7 +47,7 @@ List all privileges in the system and which roles they are assigned to.
 SHOW ROLE my_role PRIVILEGES
 ###
 
-List all privileges assigned to the role `my_role`.
+List all privileges assigned to a role.
 
 ###assertion=show-one
 //
@@ -55,7 +55,7 @@ List all privileges assigned to the role `my_role`.
 SHOW USER alice PRIVILEGES
 ###
 
-List all privileges belonging to the user `alice` and which role it is assigned to.
+List all privileges of a user, and the role that they are assigned to.
 
 """
   }

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/RoleManagementPrivilegeTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/RoleManagementPrivilegeTest.scala
@@ -37,7 +37,7 @@ class RoleManagementPrivilegeTest extends AdministrationCommandTestBase {
 GRANT CREATE ROLE ON DBMS TO my_role
 ###
 
-Grant the privilege to create roles to the role `my_role`.
+Grant the privilege to create roles to a role.
 
 ###assertion=update-one
 //
@@ -45,7 +45,7 @@ Grant the privilege to create roles to the role `my_role`.
 GRANT DROP ROLE ON DBMS TO my_role
 ###
 
-Grant the privilege to delete roles to the role `my_role`.
+Grant the privilege to delete roles to a role.
 
 ###assertion=update-one
 //
@@ -53,7 +53,7 @@ Grant the privilege to delete roles to the role `my_role`.
 DENY ASSIGN ROLE ON DBMS TO my_role
 ###
 
-Deny the privilege to assign roles to users to the role `my_role`.
+Deny the privilege to assign roles to users to a role.
 
 ###assertion=update-one
 //
@@ -61,7 +61,7 @@ Deny the privilege to assign roles to users to the role `my_role`.
 DENY REMOVE ROLE ON DBMS TO my_role
 ###
 
-Deny the privilege to remove roles from users to the role `my_role`.
+Deny the privilege to remove roles from users to a role.
 
 ###assertion=update-one
 //
@@ -69,7 +69,7 @@ Deny the privilege to remove roles from users to the role `my_role`.
 REVOKE DENY SHOW ROLE ON DBMS FROM my_role
 ###
 
-Revoke the existing denied privilege to show roles from the role `my_role`.
+Revoke the denied privilege to show roles from a role.
 
 ###assertion=update-one
 //
@@ -77,7 +77,7 @@ Revoke the existing denied privilege to show roles from the role `my_role`.
 GRANT ROLE MANAGEMENT ON DBMS TO my_role
 ###
 
-Grant all the above privileges to manage roles to the role `my_role`.
+Grant all privileges to manage roles to a role.
 
 """
   }

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/RoleManagementPrivilegeTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/RoleManagementPrivilegeTest.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.docgen.refcard
+
+class RoleManagementPrivilegeTest extends AdministrationCommandTestBase {
+  val title = "(★) ROLE MANAGEMENT PRIVILEGES"
+  override val linkId = "administration/security/administration/#administration-security-administration-dbms-privileges-role-management"
+
+  private def setup() = graph.withTx { tx =>
+    tx.execute("CREATE ROLE my_role")
+    tx.execute("DENY SHOW ROLE ON DBMS TO my_role")
+  }
+
+  def text: String = {
+    setup()
+    """
+###assertion=update-one
+//
+
+GRANT CREATE ROLE ON DBMS TO my_role
+###
+
+Grant the privilege to create roles to the role `my_role`.
+
+###assertion=update-one
+//
+
+GRANT DROP ROLE ON DBMS TO my_role
+###
+
+Grant the privilege to delete roles to the role `my_role`.
+
+###assertion=update-one
+//
+
+DENY ASSIGN ROLE ON DBMS TO my_role
+###
+
+Deny the privilege to assign roles to users to the role `my_role`.
+
+###assertion=update-one
+//
+
+DENY REMOVE ROLE ON DBMS TO my_role
+###
+
+Deny the privilege to remove roles from users to the role `my_role`.
+
+###assertion=update-one
+//
+
+REVOKE DENY SHOW ROLE ON DBMS FROM my_role
+###
+
+Revoke the existing denied privilege to show roles from the role `my_role`.
+
+###assertion=update-one
+//
+
+GRANT ROLE MANAGEMENT ON DBMS TO my_role
+###
+
+Grant the privileges to create, delete, assign, remove and show roles to the role `my_role`.
+
+"""
+  }
+}

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/RoleManagementPrivilegeTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/RoleManagementPrivilegeTest.scala
@@ -77,7 +77,7 @@ Revoke the existing denied privilege to show roles from the role `my_role`.
 GRANT ROLE MANAGEMENT ON DBMS TO my_role
 ###
 
-Grant the privileges to create, delete, assign, remove and show roles to the role `my_role`.
+Grant all the above privileges to manage roles to the role `my_role`.
 
 """
   }

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/RoleManagementTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/RoleManagementTest.scala
@@ -36,7 +36,7 @@ class RoleManagementTest extends AdministrationCommandTestBase {
 CREATE ROLE my_role
 ###
 
-Create a role named `my_role`.
+Create a role.
 
 ###assertion=update-one
 //
@@ -44,7 +44,7 @@ Create a role named `my_role`.
 CREATE ROLE my_second_role IF NOT EXISTS AS COPY OF my_role
 ###
 
-Create a role named `my_second_role` unless it already exists, as a copy of the existing role `my_role`.
+Create a role named `my_second_role`, unless it already exists, as a copy of the existing `my_role`.
 
 ###assertion=update-two
 //
@@ -52,7 +52,7 @@ Create a role named `my_second_role` unless it already exists, as a copy of the 
 GRANT ROLE my_role, my_second_role TO alice
 ###
 
-Assign the roles `my_role` and `my_second_role` to the user `alice`.
+Assign roles to a user.
 
 ###assertion=update-one
 //
@@ -60,7 +60,7 @@ Assign the roles `my_role` and `my_second_role` to the user `alice`.
 REVOKE ROLE my_second_role FROM alice
 ###
 
-Remove the role `my_second_role` from the user `alice`.
+Remove a specified role from a user.
 
 ###assertion=show-two
 //
@@ -76,7 +76,7 @@ List all roles in the system.
 SHOW POPULATED ROLES WITH USERS
 ###
 
-List all roles that are assigned to at least one user in the system and the users assigned to them.
+List all roles that are assigned to at least one user in the system, and the users assigned to those roles.
 
 ###assertion=update-one
 //
@@ -84,7 +84,7 @@ List all roles that are assigned to at least one user in the system and the user
 DROP ROLE my_role
 ###
 
-Delete the role `my_role`.
+Delete a role.
 
 """
   }

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/RoleManagementTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/RoleManagementTest.scala
@@ -62,13 +62,21 @@ REVOKE ROLE my_second_role FROM alice
 
 Remove the role `my_second_role` from the user `alice`.
 
-###assertion=show
+###assertion=show-two
+//
+
+SHOW ROLES
+###
+
+List all roles in the system.
+
+###assertion=show-one
 //
 
 SHOW POPULATED ROLES WITH USERS
 ###
 
-List all roles, and their users, that are assigned to users in the system.
+List all roles that are assigned to at least one user in the system and the users assigned to them.
 
 ###assertion=update-one
 //

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/RoleManagementTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/RoleManagementTest.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.docgen.refcard
+
+class RoleManagementTest extends AdministrationCommandTestBase {
+  val title = "(★) ROLE MANAGEMENT"
+  override val linkId = "administration/security/users-and-roles/#administration-security-roles"
+
+  private def setup() = graph.withTx { tx =>
+    tx.execute("CREATE USER alice SET PASSWORD 'secret' CHANGE NOT REQUIRED")
+  }
+
+  def text: String = {
+    setup()
+    """
+###assertion=update-one
+//
+
+CREATE ROLE my_role
+###
+
+Create a role named `my_role`.
+
+###assertion=update-one
+//
+
+CREATE ROLE my_second_role IF NOT EXISTS AS COPY OF my_role
+###
+
+Create a role named `my_second_role` unless it already exists, as a copy of the existing role `my_role`.
+
+###assertion=update-two
+//
+
+GRANT ROLE my_role, my_second_role TO alice
+###
+
+Assign the roles `my_role` and `my_second_role` to the user `alice`.
+
+###assertion=update-one
+//
+
+REVOKE ROLE my_second_role FROM alice
+###
+
+Remove the role `my_second_role` from the user `alice`.
+
+###assertion=show
+//
+
+SHOW POPULATED ROLES WITH USERS
+###
+
+List all roles, and their users, that are assigned to users in the system.
+
+###assertion=update-one
+//
+
+DROP ROLE my_role
+###
+
+Delete the role `my_role`.
+
+"""
+  }
+}

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/UserManagementTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/UserManagementTest.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.docgen.refcard
+
+class UserManagementTest extends AdministrationCommandTestBase {
+  val title = "USER MANAGEMENT"
+  override val linkId = "administration/security/users-and-roles/#administration-security-users"
+
+  override def parameters(name: String): Map[String, Any] =
+    name match {
+      case "parameters=create" =>
+        Map("password" -> "secret")
+      case "parameters=update" =>
+        Map("password" -> "new_secret")
+      case _ =>
+        Map.empty
+    }
+
+  def text: String =
+    """
+###assertion=update-one parameters=create
+//
+
+CREATE USER alice SET PASSWORD $password
+###
+
+Create a user with the username `alice` that needs to change her password on first login.
+
+###assertion=update-one parameters=update
+//
+
+ALTER USER alice SET PASSWORD $password CHANGE NOT REQUIRED
+###
+
+(★) Change the password for `alice` and update so that she is not required to change password on next login.
+
+###dontrun
+// Can't be run since we can't log in as a user, and have auth disabled
+
+ALTER CURRENT USER SET PASSWORD FROM $old TO $new
+###
+
+Change the password for the logged in user and update so that a password change is not required on next login.
+
+###assertion=show
+//
+
+SHOW USERS
+###
+
+List all users in the system, if they need to update their password, their status and roles.
+(★) Status and roles are enterprise only.
+
+###assertion=update-one
+//
+
+DROP USER alice
+###
+
+Delete the user `alice`.
+
+"""
+}

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/UserManagementTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/UserManagementTest.scala
@@ -41,7 +41,7 @@ class UserManagementTest extends AdministrationCommandTestBase {
 CREATE USER alice SET PASSWORD $password
 ###
 
-Create a user with the username `alice` that needs to change her password on first login.
+Create a new user and a password. This password must be changed on the first login.
 
 ###assertion=update-one parameters=update
 //
@@ -49,7 +49,7 @@ Create a user with the username `alice` that needs to change her password on fir
 ALTER USER alice SET PASSWORD $password CHANGE NOT REQUIRED
 ###
 
-(★) Change the password for the user `alice` and update so that she is not required to change password on next login.
+(★) Set a new password for a user. This user will not be required to change this password on the next login.
 
 ###assertion=update-one parameters=update
 //
@@ -57,7 +57,7 @@ ALTER USER alice SET PASSWORD $password CHANGE NOT REQUIRED
 ALTER USER alice SET STATUS SUSPENDED
 ###
 
-(★) Change the status for the user `alice` so that she is suspended. Use `SET STATUS ACTIVE` to reactivate `alice`.
+(★) Change the user status to suspended. Use `SET STATUS ACTIVE` to reactivate the user name.
 
 ###dontrun
 // Can't be run since we can't log in as a user, and have auth disabled
@@ -65,7 +65,7 @@ ALTER USER alice SET STATUS SUSPENDED
 ALTER CURRENT USER SET PASSWORD FROM $old TO $new
 ###
 
-Change the password for the logged in user and update so that a password change is not required on next login.
+Change the password of the logged-in user, and update. The user will not be required to change this password on the next login.
 
 ###assertion=show-one
 //
@@ -73,8 +73,8 @@ Change the password for the logged in user and update so that a password change 
 SHOW USERS
 ###
 
-List all users in the system, their status, roles and if they need to change their password.\n
-(★) Status and roles are enterprise only.
+List all users in the system, their status, roles and if they need to change their password. +
+(★) Status and roles are Enterprise Edition only.
 
 ###assertion=update-one
 //
@@ -82,7 +82,7 @@ List all users in the system, their status, roles and if they need to change the
 DROP USER alice
 ###
 
-Delete the user `alice`.
+Delete the user.
 
 """
 }

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/UserManagementTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/UserManagementTest.scala
@@ -57,7 +57,7 @@ ALTER USER alice SET PASSWORD $password CHANGE NOT REQUIRED
 ALTER USER alice SET STATUS SUSPENDED
 ###
 
-(★) Change the user status to suspended. Use `SET STATUS ACTIVE` to reactivate the user name.
+(★) Change the user status to suspended. Use `SET STATUS ACTIVE` to reactivate the user.
 
 ###dontrun
 // Can't be run since we can't log in as a user, and have auth disabled
@@ -65,7 +65,7 @@ ALTER USER alice SET STATUS SUSPENDED
 ALTER CURRENT USER SET PASSWORD FROM $old TO $new
 ###
 
-Change the password of the logged-in user, and update. The user will not be required to change this password on the next login.
+Change the password of the logged-in user. The user will not be required to change this password on the next login.
 
 ###assertion=show-one
 //

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/UserManagementTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/UserManagementTest.scala
@@ -49,7 +49,15 @@ Create a user with the username `alice` that needs to change her password on fir
 ALTER USER alice SET PASSWORD $password CHANGE NOT REQUIRED
 ###
 
-(★) Change the password for `alice` and update so that she is not required to change password on next login.
+(★) Change the password for the user `alice` and update so that she is not required to change password on next login.
+
+###assertion=update-one parameters=update
+//
+
+ALTER USER alice SET STATUS SUSPENDED
+###
+
+(★) Change the status for the user `alice` so that she is suspended. Use `SET STATUS ACTIVE` to reactivate `alice`.
 
 ###dontrun
 // Can't be run since we can't log in as a user, and have auth disabled
@@ -59,13 +67,13 @@ ALTER CURRENT USER SET PASSWORD FROM $old TO $new
 
 Change the password for the logged in user and update so that a password change is not required on next login.
 
-###assertion=show
+###assertion=show-one
 //
 
 SHOW USERS
 ###
 
-List all users in the system, if they need to update their password, their status and roles.
+List all users in the system, their status, roles and if they need to change their password.\n
 (★) Status and roles are enterprise only.
 
 ###assertion=update-one


### PR DESCRIPTION
Added in manual modeling so they can become visible :) https://github.com/neo-technology/neo4j-manual-modeling/pull/994

Note: role management privileges links to section which is merged but not yet visible in the preview so it might currently be dead if merged