### PR TITLE
Backport failing test fix (result order change)

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityUserAndRoleManagementTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityUserAndRoleManagementTest.scala
@@ -291,13 +291,8 @@ class SecurityUserAndRoleManagementTest extends DocumentingTest with QueryStatis
     }
   })
 
-<<<<<<< HEAD
-  private def assertRolesShown(expected: Seq[String] = List.empty) = ResultAndDbAssertions((p, db) => {
-    val tx = db.beginTransaction(Type.explicit, AnonymousContext.read())
-=======
   private def assertRolesShown(expected: Seq[String] = List.empty, ignore: Seq[String] = List.empty) = ResultAndDbAssertions((p, db) => {
     val tx = db.beginTransaction(Type.EXPLICIT, AnonymousContext.read())
->>>>>>> 88e5b880a0... Fixed failing tests due to change in result order
     try {
       val result = p.columnAs[String]("role").toList.filter(!ignore.contains(_))
       result.toSet should equal(expected.toSet)

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityUserAndRoleManagementTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityUserAndRoleManagementTest.scala
@@ -172,7 +172,7 @@ class SecurityUserAndRoleManagementTest extends DocumentingTest with QueryStatis
           "To only show roles that are assigned to users, the command is `SHOW POPULATED ROLES`. " +
           "To see which users are assigned to roles `WITH USERS` can be appended to the commands. " +
           "This will give one result row for each user, so if a role is assigned to two users then it will show up twice in the result.")
-        query("SHOW POPULATED ROLES WITH USERS", assertRolesShown(Seq("admin"))) {
+        query("SHOW POPULATED ROLES WITH USERS", assertRolesShown(Seq("admin"), Seq("PUBLIC"))) {
           p("The table of results contains two columns, the first is the role name, and the other a flag indicating whether the role is a built-in role or a custom role.")
           resultTable()
         }
@@ -282,23 +282,25 @@ class SecurityUserAndRoleManagementTest extends DocumentingTest with QueryStatis
     val tx = db.beginTransaction(Type.explicit, AnonymousContext.read())
     try {
       val nodes = tx.findNodes(Label.label(label)).asScala.toList
-      // TODO: Remove this conditional once we have system graph initialization working OK
-      if (nodes.nonEmpty) {
-        nodes.length should be > 0
-        val props = nodes.map(n => n.getProperty("name"))
-        val result = p.columnAs[String](column).toList
-        result should equal(props)
-      }
+      nodes.length should be > 0
+      val props = nodes.map(n => n.getProperty("name"))
+      val result = p.columnAs[String](column).toList
+      result.toSet should equal(props.toSet)
     } finally {
       tx.close()
     }
   })
 
+<<<<<<< HEAD
   private def assertRolesShown(expected: Seq[String] = List.empty) = ResultAndDbAssertions((p, db) => {
     val tx = db.beginTransaction(Type.explicit, AnonymousContext.read())
+=======
+  private def assertRolesShown(expected: Seq[String] = List.empty, ignore: Seq[String] = List.empty) = ResultAndDbAssertions((p, db) => {
+    val tx = db.beginTransaction(Type.EXPLICIT, AnonymousContext.read())
+>>>>>>> 88e5b880a0... Fixed failing tests due to change in result order
     try {
-      val result = p.columnAs[String]("role").toList
-      result should equal(expected)
+      val result = p.columnAs[String]("role").toList.filter(!ignore.contains(_))
+      result.toSet should equal(expected.toSet)
     } finally {
       tx.close()
     }

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityUserAndRoleManagementTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityUserAndRoleManagementTest.scala
@@ -292,7 +292,7 @@ class SecurityUserAndRoleManagementTest extends DocumentingTest with QueryStatis
   })
 
   private def assertRolesShown(expected: Seq[String] = List.empty, ignore: Seq[String] = List.empty) = ResultAndDbAssertions((p, db) => {
-    val tx = db.beginTransaction(Type.EXPLICIT, AnonymousContext.read())
+    val tx = db.beginTransaction(Type.explicit, AnonymousContext.read())
     try {
       val result = p.columnAs[String]("role").toList.filter(!ignore.contains(_))
       result.toSet should equal(expected.toSet)

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WithTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WithTest.scala
@@ -104,7 +104,7 @@ class WithTest extends DocumentingTest {
           |LIMIT 1
           |MATCH (m)--(o)
           |RETURN o.name""".stripMargin, ResultAssertions((r) => {
-          r.toList should equal(List(Map("o.name" -> "Bossman"), Map("o.name" -> "Anders")))
+          r.toSet should equal(Set(Map("o.name" -> "Bossman"), Map("o.name" -> "Anders")))
         })) {
         p("Starting at *'Anders'*, find all matching nodes, order by name descending and get the top result, then find all the nodes connected to that top result, and return their names.")
         resultTable()


### PR DESCRIPTION
Do not merge to 4.1 (https://github.com/neo4j/neo4j-documentation/commit/88e5b880a0e0bbd80fcab29f596450910da677ab)