### PR TITLE
Updated the list of deprecations and removals in 4.0 to be correct for variable binding of variable length relationships

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -43,7 +43,7 @@ Replacement syntax for deprecated and removed features are also indicated.
 | `CREATE UNIQUE`     | Clause | Removed | Running queries with this clause will cause a syntax error. Running with `CYPHER 3.5` will cause a runtime error due to the removal of the rule planner.
 | `START`     | Clause | Removed | Running queries with this clause will cause a syntax error. Running with `CYPHER 3.5` will cause a runtime error due to the removal of the rule planner.
 | Explicit indexes |  Functionality | Removed | The removal of the `RULE` planner in 3.2 was the beginning of the end for explicit indexes. Now they are completely removed, including the removal of the link:https://neo4j.com/docs/cypher-manual/3.5/schema/index/#explicit-indexes-procedures[built-in procedures for Neo4j 3.3 to 3.5].
-| `MATCH (n)-[rs*]-() RETURN rs`     | Syntax | Removed | Replaced by `MATCH p=(n)-[*]-() RETURN relationships(p) AS rs`
+| `MATCH (n)-[rs*]-() RETURN rs`     | Syntax | Deprecated | As in Cypher 3.2, this is replaced by `MATCH p=(n)-[*]-() RETURN relationships(p) AS rs`
 | `MATCH (n)-[:A\|:B\|:C {foo: 'bar'}]-() RETURN n`     | Syntax | Removed | Replaced by `MATCH (n)-[:A\|B\|C {foo: 'bar'}]-() RETURN n`
 | `MATCH (n)-[x:A\|:B\|:C]-() RETURN n`     | Syntax | Removed | Replaced by `MATCH (n)-[x:A\|B\|C]-() RETURN n`
 | `MATCH (n)-[x:A\|:B\|:C*]-() RETURN n`     | Syntax | Removed | Replaced by `MATCH (n)-[x:A\|B\|C*]-() RETURN n`


### PR DESCRIPTION
It was decided to keep it deprecated and not remove it for now.