### PR TITLE
Added info about revoking compound privileges also revokes sub-privileges

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-create-drop-index-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-create-drop-index-syntax.asciidoc
@@ -1,0 +1,6 @@
+.Add `CREATE INDEX` and `DROP INDEX` privileges
+[source, cypher]
+-----
+GRANT CREATE INDEX ON DATABASE * TO indexUsers
+GRANT DROP INDEX ON DATABASE * TO indexUsers
+-----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/revoke-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/revoke-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 REVOKE
-    [ { GRANT | DENY } ] graph-privilege
+    [ { GRANT | DENY } ] privilege
     FROM roles
 -----


### PR DESCRIPTION
Should not be forwarded to 4.1 since it works differently there.