### PR TITLE
SHOW USER PRIVILEGES will show currently logged in user

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/user-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/user-management-syntax.asciidoc
@@ -14,7 +14,7 @@ SHOW USERS
 
 | [source, cypher]
 ----
-SHOW USER name PRIVILEGES
+SHOW USER [name] PRIVILEGES
 ----
 | List the privileges granted to a user. | Admin | `-` | `+`
 
@@ -60,7 +60,7 @@ ALTER CURRENT USER SET PASSWORD FROM original TO password
 DROP USER name [IF EXISTS]
 ----
 | Remove an existing user.
-| Admin 
+| Admin
 | `+`
 | `+`
 |===

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
@@ -84,6 +84,12 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
         p("Lists all privileges for user 'jake'")
         resultTable()
       }
+
+      p("The same command can be used at all times to review available privileges for the current user. " +
+        "For this purpose also exists a shorter form of the command: `SHOW USER PRIVILEGES`.")
+      query("SHOW USER PRIVILEGES", ResultAssertions((r) => {
+        assertStats(r)
+      })){}
     }
 
     section("The `TRAVERSE` privilege", "administration-security-subgraph-traverse", "enterprise-edition") {

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
@@ -86,7 +86,7 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
       }
 
       p("The same command can be used at all times to review available privileges for the current user. " +
-        "For this purpose also exists a shorter form of the command: `SHOW USER PRIVILEGES`.")
+        "For this purpose, a shorter form of the the command also exists: SHOW USER PRIVILEGES.")
       query("SHOW USER PRIVILEGES", ResultAssertions((r) => {
         assertStats(r)
       })){}

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ListPrivilegeTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ListPrivilegeTest.scala
@@ -57,6 +57,14 @@ SHOW USER alice PRIVILEGES
 
 List all privileges of a user, and the role that they are assigned to.
 
+###assertion=show-nothing
+//
+
+SHOW USER PRIVILEGES
+###
+
+Lists all privileges of the currently logged in user, and the role that they are assigned to.
+
 """
   }
 }


### PR DESCRIPTION
There is no need to specify the username here.
Also: This command is always available to all users that can access system