### PR TITLE
4.1 plan description autogenerated names

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SchemaIndexTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SchemaIndexTest.scala
@@ -173,7 +173,7 @@ class SchemaIndexTest extends DocumentingTestBase with QueryStatisticsTestSuppor
           assertEquals(1, p.size)
 
           checkPlanDescription(p)("NodeIndexSeek")
-          checkPlanDescription(p)("n:Person(age, country) WHERE age = $`  AUTOINT0` AND country = $`  AUTOSTRING1`")
+          checkPlanDescription(p)("n:Person(age, country) WHERE age = $autoint_0 AND country = $autostring_1")
       }
     )
   }
@@ -214,7 +214,7 @@ class SchemaIndexTest extends DocumentingTestBase with QueryStatisticsTestSuppor
           assertEquals(1, p.size)
 
           checkPlanDescription(p)("NodeIndexSeek")
-          checkPlanDescription(p)("person:Person(firstname, highScore) WHERE firstname > $  AUTOSTRING0 AND exists(highScore)")
+          checkPlanDescription(p)("person:Person(firstname, highScore) WHERE firstname > $autostring_0 AND exists(highScore)")
       }
     )
   }
@@ -255,7 +255,7 @@ class SchemaIndexTest extends DocumentingTestBase with QueryStatisticsTestSuppor
           assertEquals(1, p.size)
 
           checkPlanDescription(p)("NodeIndexSeek")
-          checkPlanDescriptionArgument(p)("person:Person(highScore, name) WHERE highScore > $  AUTOINT1 AND highScore < $  AUTOINT0 AND exists(name)")
+          checkPlanDescriptionArgument(p)("person:Person(highScore, name) WHERE highScore > $autoint_1 AND highScore < $autoint_0 AND exists(name)")
       }
     )
   }
@@ -308,7 +308,7 @@ class SchemaIndexTest extends DocumentingTestBase with QueryStatisticsTestSuppor
           assertEquals(1, p.size)
 
           checkPlanDescription(p)("NodeIndexSeek")
-          checkPlanDescription(p)("person:Person(age, country) WHERE age IN $`  AUTOLIST0` AND country IN $`  AUTOLIST1`")
+          checkPlanDescription(p)("person:Person(age, country) WHERE age IN $autolist_0 AND country IN $autolist_1")
       }
     )
   }
@@ -359,7 +359,7 @@ class SchemaIndexTest extends DocumentingTestBase with QueryStatisticsTestSuppor
         (p) =>
           assertEquals(1, p.size)
           checkPlanDescription(p)("NodeIndexSeek")
-          checkPlanDescription(p)("person:Person(firstname, surname) WHERE firstname STARTS WITH $`  AUTOSTRING0` AND exists(surname)")
+          checkPlanDescription(p)("person:Person(firstname, surname) WHERE firstname STARTS WITH $autostring_0 AND exists(surname)")
       }
     )
   }
@@ -539,7 +539,7 @@ class SchemaIndexTest extends DocumentingTestBase with QueryStatisticsTestSuppor
         (p) =>
           assertEquals(9, p.size)
           checkPlanDescription(p)("NodeIndexSeek")
-          checkPlanDescriptionArgument(p)("p:Person(place, name) WHERE distance(place, point($`  AUTOINT0`, $`  AUTOINT1`)) < $`  AUTOINT2` AND exists(name)")
+          checkPlanDescriptionArgument(p)("p:Person(place, name) WHERE distance(place, point($autoint_0, $autoint_1)) < $autoint_2 AND exists(name)")
       }
     )
   }
@@ -583,7 +583,7 @@ class SchemaIndexTest extends DocumentingTestBase with QueryStatisticsTestSuppor
         (p) =>
           assertEquals(1, p.size)
           checkPlanDescription(p)("NodeIndexSeek")
-          checkPlanDescriptionArgument(p)("person:Person(place, firstname) WHERE place > point({x: $  AUTOINT2, y: $  AUTOINT3}) AND place < point({x: $  AUTOINT0, y: $  AUTOINT1}) AND exists(firstname)")
+          checkPlanDescriptionArgument(p)("person:Person(place, firstname) WHERE place > point({x: $autoint_2, y: $autoint_3}) AND place < point({x: $autoint_0, y: $autoint_1}) AND exists(firstname)")
       }
     )
   }


### PR DESCRIPTION
In PR https://github.com/neo-technology/neo4j/pull/5605 the rendering of autogenerated parameters was changed.  In this PR we have updated the tests with parameters accordingly.