### PR TITLE
Update jersey version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
             -Dorg.neo4j.kernel.impl.api.KernelStatement.trackStatements=false
         </test.runner.jvm.settings.additional>
         <license-text.header>build/AGPL-3-header.txt</license-text.header>
-        <jersey.version>2.27</jersey.version>
+        <jersey.version>2.30.1</jersey.version>
         <junit.version>5.5.2</junit.version>
         <java9.exports/>
     </properties>


### PR DESCRIPTION
As per discussions with @michael-simons 

This lifts the version of Jersey to match Neo4j. Should resolve build errors in the 4.1 branch when forward merged.