### PR TITLE
Only remove users and roles when setting up for test

### DIFF
--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/RefcardTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/RefcardTest.scala
@@ -262,8 +262,7 @@ abstract class RefcardTest extends Assertions with DocumentationHelper with Grap
     val graph = getGraph
     db = new GraphDatabaseCypherService(graph)
 
-    GraphDatabaseServiceCleaner.cleanDatabaseContent(db.getGraphDatabaseService)
-
+    cleanGraph
 
       val g = new GraphImpl(graphDescription.toArray[String])
       val description = GraphDescription.create(g)
@@ -284,6 +283,8 @@ abstract class RefcardTest extends Assertions with DocumentationHelper with Grap
 
   // override to start against SYSTEM_DATABASE_NAME or another database
   protected def getGraph: GraphDatabaseService = managementService.database(DEFAULT_DATABASE_NAME)
+
+  protected def cleanGraph: Unit = GraphDatabaseServiceCleaner.cleanDatabaseContent(db.getGraphDatabaseService)
 
   protected def newDatabaseManagementService(directory: File): DatabaseManagementService = new EnterpriseDatabaseManagementServiceBuilder(directory).build()
 

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DatabaseManagementTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DatabaseManagementTest.scala
@@ -49,7 +49,7 @@ START DATABASE myDatabase
 
 (★) Start the database `myDatabase`.
 
-###assertion=show-one
+###assertion=show-three
 //
 
 SHOW DATABASES
@@ -65,7 +65,7 @@ SHOW DATABASE myDatabase
 
 List information about the database `myDatabase`.
 
-###assertion=show-nothing
+###assertion=show-one
 //
 
 SHOW DEFAULT DATABASE


### PR DESCRIPTION
Clearing away everything in the system graph makes the system think
that it is not initialized and will make queries fail