### PR TITLE
Document discovery metrics in separate class

### DIFF
--- a/metrics-docs/pom.xml
+++ b/metrics-docs/pom.xml
@@ -54,6 +54,7 @@
                                     <arg value="--output=${project.build.directory}/docs/ops/cc-metrics.asciidoc" />
                                     <arg value="com.neo4j.metrics.source.causalclustering.RaftCoreMetrics" />
                                     <arg value="com.neo4j.metrics.source.causalclustering.ReadReplicaMetrics" />
+                                    <arg value="com.neo4j.metrics.source.causalclustering.DiscoveryCoreMetrics" />
                                 </java>
                             </target>
                         </configuration>


### PR DESCRIPTION
Adds the discovery metrics from #595 (from @andrewkerr9000) following the merging of #600 (from @craigtaverner) 

The renaming of `CoreMetrics` to `RaftCoreMetrics` in Andrews PR was resolved in Craigs, so is no longer required. 