### PR TITLE
Remove note about dropping admin

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/BuiltInRolesAdministrationTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/BuiltInRolesAdministrationTest.scala
@@ -248,12 +248,9 @@ class BuiltInRolesAdministrationTest extends DocumentingTest with QueryStatistic
       section("How to recreate the `admin` role", "administration-built-in-roles-admin-recreate") {
         initQueries(
           "DROP ROLE admin")  // setup so that later when the grant query gets executed, it will show systemUpdates: 1
-        note(p("In Neo4j {neo4j-version-exact} it is *not* possible to fully recreate a dropped `admin` role. " +
-          "Specifically, the ability to run procedures with the `@Admin` annotation, such as  `dbms.listConfig`, can *not* be restored." +
-          " Because of that, dropping the `admin` role is strongly discouraged."))
         p(
           """
-            |To restore the role to its original capabilities (minus the ability to run admin procedures) two steps are needed. First, if not already done, execute `DROP ROLE admin`.
+            |To restore the role to its original capabilities two steps are needed. First, if not already done, execute `DROP ROLE admin`.
             |Secondly, the following queries must be run in order to set up the privileges:""".stripMargin)
         query("CREATE ROLE admin", ResultAssertions((r) => {
           assertStats(r, systemUpdates = 1)


### PR DESCRIPTION
The underlying problem is fixed in Neo4j 4.1.1 so please publicize accordingly. 