### PR TITLE
Prevent test assertion overwriting the generated request/response for …

### DIFF
--- a/server-docs/src/test/java/org/neo4j/doc/server/rest/transactional/TransactionDocIT.java
+++ b/server-docs/src/test/java/org/neo4j/doc/server/rest/transactional/TransactionDocIT.java
@@ -438,8 +438,9 @@ public class TransactionDocIT extends AbstractRestFunctionalTestBase
 
     private void verifyNodeDoesNotExist( long nodeId )
     {
-        ResponseEntity response = getNodeById( nodeId );
-        Assert.assertThat( response.entity(), not( Matchers.containsString( "node" ) ) );
+        HTTP.Response firstReq = POST( txCommitUri(),
+                                       HTTP.RawPayload.quotedJson( "{ 'statement': 'MATCH (n) WHERE ID(n) = $nodeId RETURN n' , \" + \"'parameters': { 'nodeId': " + nodeId + " } }" ) );
+        Assert.assertThat( firstReq.rawContent(), not( Matchers.containsString( "node" ) ) );
     }
 
     private ResponseEntity getNodeById( long nodeId )


### PR DESCRIPTION
Prevent test assertion overwriting the generated request/response example for rolling back an http-api transaction.