### PR TITLE
Replace usage of sub-graph with path

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
@@ -223,7 +223,7 @@ This section comprises a glossary of all the keywords -- grouped by category and
 |<<functions-sin, sin()>>                       | Trigonometric     | Returns the sine of a number.
 |<<functions-single, single()>>                  | Predicate         | Returns true if the predicate holds for exactly one of the elements in a list.
 |<<functions-size, size()>>                      | Scalar            | Returns the number of items in a list.
-|<<functions-size-of-pattern-expression, size() applied to pattern expression>>  | Scalar   | Returns the number of sub-graphs matching the pattern expression.
+|<<functions-size-of-pattern-expression, size() applied to pattern expression>>  | Scalar   | Returns the number of paths matching the pattern expression.
 |<<functions-size-of-string, size() applied to string>>  | Scalar          | Returns the number of Unicode characters in a string.
 |<<functions-split, split()>>                    | String            | Returns a list of strings resulting from the splitting of the original string around matches of the given delimiter.
 |<<functions-sqrt, sqrt()>>                     | Logarithmic       | Returns the square root of a number.

--- a/cypher/cypher-docs/src/docs/dev/ql/functions/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/functions/index.asciidoc
@@ -60,7 +60,7 @@ These functions return a single value.
 | <<functions-properties,properties()>>                               | Returns a map containing all the properties of a node or relationship.
 | <<functions-randomuuid, randomUUID()>>                              | Returns a string value corresponding to a randomly-generated UUID.
 | <<functions-size,size()>>                                           | Returns the number of items in a list.
-| <<functions-size-of-pattern-expression,size() applied to pattern expression>> | Returns the number of sub-graphs matching the pattern expression.
+| <<functions-size-of-pattern-expression,size() applied to pattern expression>> | Returns the number of paths matching the pattern expression.
 | <<functions-size-of-string,size() applied to string>>                         | Returns the number of Unicode characters in a string.
 | <<functions-startnode,startNode()>>                                 | Returns the start node of a relationship.
 | <<functions-timestamp,timestamp()>>                                 | Returns the difference, measured in milliseconds, between the current time and midnight, January 1, 1970 UTC.

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MatchTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MatchTest.scala
@@ -93,7 +93,7 @@ class MatchTest extends DocumentingTest {
       p( """`MATCH` can occur at the beginning of the query or later, possibly after a `WITH`.
            |If it is the first clause, nothing will have been bound yet, and Neo4j will design a search to find the results matching the clause and any associated predicates specified in any `WHERE` part.
            |This could involve a scan of the database, a search for nodes having a certain label, or a search of an index to find starting points for the pattern matching.
-           |Nodes and relationships found by this search are available as _bound pattern elements,_ and can be used for pattern matching of sub-graphs.
+           |Nodes and relationships found by this search are available as _bound pattern elements,_ and can be used for pattern matching of paths.
            |They can also be used in any further `MATCH` clauses, where Neo4j will use the known elements, and from there find further unknown elements.""")
       p( """Cypher is declarative, and so usually the query itself does not specify the algorithm to use to perform the search.
            |Neo4j will automatically work out the best approach to finding start nodes and matching patterns.

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ScalarFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ScalarFunctionsTest.scala
@@ -218,7 +218,7 @@ class ScalarFunctionsTest extends DocumentingTest {
           r.toList should equal(List(Map("fof" -> 3)))
         })) {
         resultTable()
-        p("The number of sub-graphs matching the pattern expression is returned.")
+        p("The number of paths matching the pattern expression is returned.")
       }
     }
     section("size() applied to string", "functions-size-of-string") {


### PR DESCRIPTION
Suggested replacement of `sub-graphs` with `paths`, via @petraselmer 

> The term "sub-graphs", whilst technically correct (in that a path is a simple form of a sub-graph), is highly misleading. `size(pattern)` is forbidden in the context of multiple path patterns, so referring to `sub-graphs` could lead to users trying to use `size` erroneously. The explanatory text correctly refers to paths only. 