### PR TITLE
An entity passed as a parameter must come from an open transaction

### DIFF
--- a/cypher/cypher-docs/src/test/java/org/neo4j/cypher/example/JavaExecutionEngineDocTest.java
+++ b/cypher/cypher-docs/src/test/java/org/neo4j/cypher/example/JavaExecutionEngineDocTest.java
@@ -291,9 +291,12 @@ public class JavaExecutionEngineDocTest
     {
         try ( Transaction transaction = db.beginTx() )
         {
+            // It's only possible to send an entity as a parameter if the transaction of the entity is still open.
+            Node nodeInOtherTransaction = transaction.getNodeById( bobNode.getId() );
+
             // tag::exampleWithParameterForNodeObject[]
             Map<String,Object> params = new HashMap<>();
-            params.put( "node", bobNode );
+            params.put( "node", nodeInOtherTransaction );
             String query = "MATCH (n:Person) WHERE n = $node RETURN n.name";
             Result result = transaction.execute( query, params );
             // end::exampleWithParameterForNodeObject[]


### PR DESCRIPTION
Build broke after merging PR https://github.com/neo-technology/neo4j/pull/7077.

It should only be possible to pass entities from another transaction if the transaction is still.