### PR TITLE
Use the correct spelling of sub-graph

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/administration.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/administration.asciidoc
@@ -43,7 +43,7 @@ These include index and constraint management commands.
 * <<administration-security, Security>>
 ** <<administration-security-introduction, Introduction>>
 ** <<administration-security-users-and-roles, User and role management>>
-** <<administration-security-subgraph, Graph and subgraph access control>>
+** <<administration-security-subgraph, Graph and sub-graph access control>>
 ** <<administration-security-administration, Security of administration>>
 ** <<administration-security-limitations, Known limitations of security>>
 

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/AggregatingFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/AggregatingFunctionsTest.scala
@@ -46,7 +46,7 @@ class AggregatingFunctionsTest extends DocumentingTest {
         |Examples are `avg()` that calculates the average of multiple numeric values, or `min()` that finds the smallest numeric or string value in a set of values.
         |When we say below that an aggregating function operates on a _set of values_, we mean these to be the result of the application of the inner expression (such as `n.age`) to all the records within the same aggregation group.""")
     p(
-      """Aggregation can be computed over all the matching subgraphs, or it can be further divided by introducing grouping keys.
+      """Aggregation can be computed over all the matching paths, or it can be further divided by introducing grouping keys.
         |These are non-aggregate expressions, that are used to group the values going into the aggregate functions.""")
     p("""Assume we have the following return statement:""")
     p(
@@ -59,7 +59,7 @@ class AggregatingFunctionsTest extends DocumentingTest {
       """We have two return expressions: `n`, and `count(*)`.
         |The first, `n`, is not an aggregate function, and so it will be the grouping key.
         |The latter, `count(*)` is an aggregate expression.
-        |The matching subgraphs will be divided into different buckets, depending on the grouping key.
+        |The matching paths will be divided into different buckets, depending on the grouping key.
         |The aggregate function will then be run on these buckets, calculating an aggregate value per bucket.""")
     p(
       """To use aggregations to sort the result set, the aggregation must be included in the `RETURN` to be used in the `ORDER BY`.
@@ -319,10 +319,3 @@ class AggregatingFunctionsTest extends DocumentingTest {
     }
   }.build()
 }
-
-
-
-
-
-
-

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/PredicateFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/PredicateFunctionsTest.scala
@@ -43,7 +43,7 @@ class PredicateFunctionsTest extends DocumentingTest {
         |       (bob)-[:MARRIED]->(eskil)""")
     synopsis(
       """Predicates are boolean functions that return true or false for a given set of non-null input.
-        |They are most commonly used to filter out subgraphs in the `WHERE` part of a query.""".stripMargin)
+        |They are most commonly used to filter out path in the `WHERE` part of a query.""".stripMargin)
     p(
       """Functions:
         |

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/PredicateFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/PredicateFunctionsTest.scala
@@ -43,7 +43,7 @@ class PredicateFunctionsTest extends DocumentingTest {
         |       (bob)-[:MARRIED]->(eskil)""")
     synopsis(
       """Predicates are boolean functions that return true or false for a given set of non-null input.
-        |They are most commonly used to filter out path in the `WHERE` part of a query.""".stripMargin)
+        |They are most commonly used to filter out paths in the `WHERE` part of a query.""".stripMargin)
     p(
       """Functions:
         |

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
@@ -35,7 +35,7 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
         |Privileges control the access rights to graph elements using a combined whitelist/blacklist mechanism.
         |It is possible to grant access, or deny access, or a combination of the two.
         |The user will be able to access the resource if they have a grant (whitelist) and do not have a deny (blacklist) relevant to that resource.
-        |All other combinations of `GRANT` and `DENY` will result in the matching subgraph being invisible.
+        |All other combinations of `GRANT` and `DENY` will result in the matching path being invisible.
         |It will appear to the user as if they have a smaller database (smaller graph).
         |""".stripMargin)
     note {

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/UsingTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/UsingTest.scala
@@ -60,7 +60,7 @@ class UsingTest extends DocumentingTest {
       graphViz()
       query(s"$matchString RETURN 1 AS $columnName", assertIntegersReturned(1)) {
         p("""The following query will be used in some of the examples on this page. It has intentionally been constructed in
-            |such a way that the statistical information will be inaccurate for the particular paths that this query
+            |such a way that the statistical information will be inaccurate for the particular path that this query
             |matches. For this reason, it can be improved by supplying planner hints.""")
         profileExecutionPlan()
       }

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/UsingTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/UsingTest.scala
@@ -60,7 +60,7 @@ class UsingTest extends DocumentingTest {
       graphViz()
       query(s"$matchString RETURN 1 AS $columnName", assertIntegersReturned(1)) {
         p("""The following query will be used in some of the examples on this page. It has intentionally been constructed in
-            |such a way that the statistical information will be inaccurate for the particular subgraph that this query
+            |such a way that the statistical information will be inaccurate for the particular paths that this query
             |matches. For this reason, it can be improved by supplying planner hints.""")
         profileExecutionPlan()
       }

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
@@ -251,9 +251,9 @@ class WhereTest extends DocumentingTest {
             |You can achieve  the same effect by combining multiple patterns with `AND`.""".stripMargin)
         p(
           """Note that you cannot introduce new variables here.
-            |Although it might look very similar to the `MATCH` patterns, the `WHERE` clause is all about eliminating matched subgraphs.
+            |Although it might look very similar to the `MATCH` patterns, the `WHERE` clause is all about eliminating matched paths.
             |`MATCH (a)-[*]->(b)` is very different from `WHERE (a)-[*]->(b)`.
-            |The first will produce a subgraph for every path it can find between `a` and `b`, whereas the latter will eliminate any matched subgraphs where `a` and `b` do not have a directed relationship chain between them.""".stripMargin)
+            |The first will produce a path for every path it can find between `a` and `b`, whereas the latter will eliminate any matched paths where `a` and `b` do not have a directed relationship chain between them.""".stripMargin)
         query(
           """MATCH (timothy:Person {name: 'Timothy'}), (other:Person)
             |WHERE other.name IN ['Andy', 'Peter'] AND (timothy)<--(other)

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MergeTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MergeTest.scala
@@ -91,6 +91,6 @@ MERGE
 
 RETURN r, b###
 
-`MERGE` finds or creates subgraphs attached to the node.
+`MERGE` finds or creates paths attached to the node.
 """
 }


### PR DESCRIPTION
Replaces instances of `subgraph` and `sub graph`, with either `sub-graph` or `path` as appropriate.