### PR TITLE
fixed so that the default roles will be generated

### DIFF
--- a/procedures/src/main/java/org/neo4j/doc/ProcedureReferenceGenerator.java
+++ b/procedures/src/main/java/org/neo4j/doc/ProcedureReferenceGenerator.java
@@ -155,7 +155,7 @@ public class ProcedureReferenceGenerator {
             this.signature = (String) row.get("signature");
             this.description = (String) row.get("description");
             this.mode = (String) row.get("mode");
-            this.roles = (List<String>) row.get("roles");
+            this.roles = (List<String>) row.get("defaultBuiltInRoles");
             this.enterpriseOnly = false;
         }
 


### PR DESCRIPTION
https://neo4j.com/docs/operations-manual/4.0/reference/procedures/

The enterprise edition have role-based access control.

Cherry pick this to 4.1 and 4.2 and 4.3