### PR TITLE
Update Cypher versions for 4.3.

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -278,8 +278,8 @@ These features will result in runtime errors. See the table at <<cypher-deprecat
 Neo4j {neo4j-version} supports the following versions of the Cypher language:
 
 * Neo4j Cypher 3.5
-* Neo4j Cypher 4.1
 * Neo4j Cypher 4.2
+* Neo4j Cypher 4.3
 
 [TIP]
 Each release of Neo4j supports a limited number of old Cypher Language Versions.

--- a/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
@@ -68,8 +68,8 @@ Here we detail the available versions:
 |===
 | Query option | Description | Default
 | `3.5` | This will force the query to use Neo4j Cypher 3.5. |
-| `4.1` | This will force the query to use Neo4j Cypher 4.1. |
-| `4.2` | This will force the query to use Neo4j Cypher 4.2. As this is the default version, it is not necessary to use this option explicitly. | X
+| `4.2` | This will force the query to use Neo4j Cypher 4.2. |
+| `4.3` | This will force the query to use Neo4j Cypher 4.3. As this is the default version, it is not necessary to use this option explicitly. | X
 |===
 
 [WARNING]


### PR DESCRIPTION
The Cypher versions supported in 4.3 are 3.5, 4.2 and 4.3 (last minor of previous major, previous minor and current minor).

Should go in together with https://github.com/neo-technology/neo4j-manual-modeling/pull/1569