### PR TITLE
Documentation for CREATE / ALTER USER SET DEFAULT DATABASE

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/admin-role-database.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/admin-role-database.asciidoc
@@ -38,8 +38,7 @@ If you delete a database and create a new one with the same name, the new one wi
 ** The _name_ component can be `+*+`, which means all databases.
 Databases created after this command execution will also be associated with these privileges.
 ** The `DATABASE[S] _name_` part of the command may be replaced by `DEFAULT DATABASE`. This refers to
-   the default database configured for a user, or in the event that this database is unavailable
-   or if that user does not have a default database configured, the system wide default.
+   the default database configured for a user or, if that user does not have a default database configured, the system wide default.
    If the user's default database changes for any reason after this command execution, the new
    one will be associated with these privileges. This can be quite powerful as it allows permissions to be switched
    from one database to another simply by changing a user's default database.

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/admin-role-database.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/admin-role-database.asciidoc
@@ -37,8 +37,12 @@ If you delete a database and create a new one with the same name, the new one wi
 ====
 ** The _name_ component can be `+*+`, which means all databases.
 Databases created after this command execution will also be associated with these privileges.
-** The `DATABASE[S] _name_` part of the command can be replaced by `DEFAULT DATABASE`.
-  If you restart the server and choose a new default database after this command execution, the new one will be associated with these privileges.
+** The `DATABASE[S] _name_` part of the command may be replaced by `DEFAULT DATABASE`. This refers to
+   the default database configured for a user, or in the event that this database is unavailable
+   or if that user does not have a default database configured, the system wide default.
+   If the user's default database changes for any reason after this command execution, the new
+   one will be associated with these privileges. This can be quite powerful as it allows permissions to be switched
+   from one database to another simply by changing a user's default database.
 
 * _role[, ...]_
 ** The role or roles to associate the privilege with, comma-separated.

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/dbms/user-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/dbms/user-management-syntax.asciidoc
@@ -34,6 +34,12 @@ GRANT SET USER STATUS
 | Enable the specified roles to modify the account status of users.
 
 | [source, cypher]
+GRANT SET USER DEFAULT DATABASE
+ON DBMS
+TO role[, ...]
+| Enable the specified roles to modify a user's default database.
+
+| [source, cypher]
 GRANT SHOW USER
 ON DBMS
 TO role[, ...]

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-deny-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-deny-syntax.asciidoc
@@ -20,6 +20,12 @@ If you delete a database and create a new one with the same name, the new one wi
 ** It can be `+*+` which means all graphs.
 Graphs created after this command execution will also be associated with these privileges.
 
+** `DEFAULT GRAPH` refers to the graph associated with the default database for that user. The default database may be
+   configured at user level, and there is also a system wide default database which will be used if the user-configured
+   default is unavailable or if a user does not have a default database configured. If the user's default database changes
+   for any reason after privileges have been created then these privileges will be associated with the graph attached to the
+   new database. This can be quite powerful as it allows permissions to be switched from one graph to another simply by changing a user's default database.
+
 * _entity_
 ** The graph elements this privilege applies to:
 *** `NODES` label (nodes with the specified label(s)).

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-deny-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-deny-syntax.asciidoc
@@ -21,10 +21,10 @@ If you delete a database and create a new one with the same name, the new one wi
 Graphs created after this command execution will also be associated with these privileges.
 
 ** `DEFAULT GRAPH` refers to the graph associated with the default database for that user. The default database may be
-   configured at user level, and there is also a system wide default database which will be used if the user-configured
-   default is unavailable or if a user does not have a default database configured. If the user's default database changes
-   for any reason after privileges have been created then these privileges will be associated with the graph attached to the
-   new database. This can be quite powerful as it allows permissions to be switched from one graph to another simply by changing a user's default database.
+   configured at user level, and there is also a system wide default database which will be used if a user does not have a default 
+   database configured. If the user's default database changes for any reason after privileges have been created then these privileges
+   will be associated with the graph attached to the new database. This can be quite powerful as it allows permissions to be switched 
+   from one graph to another simply by changing a user's default database.
 
 * _entity_
 ** The graph elements this privilege applies to:

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/list-users-table-columns.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/list-users-table-columns.asciidoc
@@ -1,5 +1,5 @@
 .List users output
-[options="header", width="100%", cols="1a,4,^.^,^"]
+[options="header", width="100%", cols="2a,4,^.^,^.^"]
 |===
 | Column
 | Description
@@ -23,6 +23,19 @@
 
 | suspended
 | If `true`, the user is currently suspended (cannot log in).
+| `-`
+|`+`
+
+| requestedDefaultDatabase
+| The default database configured for this user. If the user does not have a default database configured
+this will be `null`.
+| `-`
+|`+`
+
+| currentDefaultDatabase
+| The database the user will connect to if they do not specify a database when logging in.
+This may be different to `requestedDefaultDatabase` if that database is unavailable. If the user does not
+have a default database configured this will be the system default database.
 | `-`
 |`+`
 |===

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/list-users-table-columns.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/list-users-table-columns.asciidoc
@@ -26,16 +26,10 @@
 | `-`
 |`+`
 
-| requestedDefaultDatabase
+| defaultDatabase
 | The default database configured for this user. If the user does not have a default database configured
-this will be `null`.
-| `-`
-|`+`
-
-| currentDefaultDatabase
-| The database the user will connect to if they do not specify a database when logging in.
-This may be different to `requestedDefaultDatabase` if that database is unavailable. If the user does not
-have a default database configured this will be the system default database.
+this will be `null`. If this database is unavailable and the user does not specify a database to use they will 
+not be able to log in. 
 | `-`
 |`+`
 |===

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/user-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/user-management-syntax.asciidoc
@@ -46,6 +46,7 @@ CREATE USER name [IF NOT EXISTS]
   SET [PLAINTEXT \| ENCRYPTED] PASSWORD password
   [[SET PASSWORD] CHANGE [NOT] REQUIRED]
   [SET STATUS {ACTIVE \| SUSPENDED}]
+  [SET DEFAULT DATABASE databaseName]
 ----
 | Create a new user.
 | <<administration-security-administration-dbms-privileges-user-management, CREATE USER>>
@@ -58,6 +59,7 @@ CREATE OR REPLACE USER name
   SET [PLAINTEXT \| ENCRYPTED] PASSWORD password
   [[SET PASSWORD] CHANGE [NOT] REQUIRED]
   [SET STATUS {ACTIVE \| SUSPENDED}]
+  [SET DEFAULT DATABASE databaseName]
 ----
 | Create a new user, or if a user with the same name exists, replace it.
 | <<administration-security-administration-dbms-privileges-user-management, CREATE USER>> and
@@ -74,10 +76,12 @@ ALTER USER name SET {
 PASSWORD CHANGE [NOT] REQUIRED
             [SET STATUS {ACTIVE \| SUSPENDED}] \|
 STATUS {ACTIVE \| SUSPENDED}
+            [SET DEFAULT DATABASE databaseName]
 ----
 | Modify the settings for an existing user.
-| <<administration-security-administration-dbms-privileges-user-management, SET PASSWORD>> and/or
-<<administration-security-administration-dbms-privileges-user-management, SET USER STATUS>>
+| <<administration-security-administration-dbms-privileges-user-management, SET PASSWORD>>,
+<<administration-security-administration-dbms-privileges-user-management, SET USER STATUS>> and/or
+<<administration-security-administration-dbms-privileges-user-management, SET USER DEFAULT DATABASE>>
 | `+`
 | `+`
 

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityUserAndRoleManagementTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityUserAndRoleManagementTest.scala
@@ -94,7 +94,7 @@ class SecurityUserAndRoleManagementTest extends DocumentingTest with QueryStatis
           }
         }
         p("The created user will appear on the list provided by `SHOW USERS`.")
-        query("SHOW USERS YIELD user, suspended, passwordChangeRequired, roles, requestedDefaultDatabase WHERE user = 'jake'", assertUsersShown(Seq("jake"))) {
+        query("SHOW USERS YIELD user, suspended, passwordChangeRequired, roles, defaultDatabase WHERE user = 'jake'", assertUsersShown(Seq("jake"))) {
           p(
             """In this example we also:
               |

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityUserAndRoleManagementTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityUserAndRoleManagementTest.scala
@@ -38,7 +38,10 @@ class SecurityUserAndRoleManagementTest extends DocumentingTest with QueryStatis
       p("When connected to the DBMS over bolt, administration commands are automatically routed to the `system` database.")
       p("include::user-management-syntax.asciidoc[]")
       section("Listing current user", "administration-security-users-show-current") {
-        initQueries("CREATE USER jake SET PASSWORD 'abc123' CHANGE NOT REQUIRED")
+        initQueries(
+          "CREATE DATABASE anotherDefault",
+          "CREATE USER jake SET PASSWORD 'abc123' CHANGE NOT REQUIRED"
+        )
         p("The currently logged-in user can be seen using `SHOW CURRENT USER` which will produce a table with four columns:")
         p("include::list-users-table-columns.asciidoc[]")
         login("jake", "abc123")
@@ -67,23 +70,31 @@ class SecurityUserAndRoleManagementTest extends DocumentingTest with QueryStatis
       section("Creating users", "administration-security-users-create") {
         p("Users can be created using `CREATE USER`.")
         p("include::user-management-syntax-create-user.asciidoc[]")
-        p("If the optional `SET PASSWORD CHANGE [NOT] REQUIRED` is omitted then the default is `CHANGE REQUIRED`. " +
-          "The default for `SET STATUS` is `ACTIVE`. The `password` can either be a string value or a string parameter. " +
-          "The optional `PLAINTEXT` in `SET PLAINTEXT PASSWORD` has the same behaviour as `SET PASSWORD`. " +
-          "The optional `ENCRYPTED` can be used to create a user when the plaintext password is unknown but the encrypted password is available (e.g. from a database backup). " +
-          "With `ENCRYPTED`, the password string is expected to be on the format `<encryption-version>,<hash>,<salt>`."
+        p("""
+            | * For `SET PASSWORD`:
+            | ** If the optional `SET PASSWORD CHANGE [NOT] REQUIRED` is omitted then the default is `CHANGE REQUIRED`.
+            | ** The optional `PLAINTEXT` in `SET PLAINTEXT PASSWORD` has the same behaviour as `SET PASSWORD`.
+            | ** The optional `ENCRYPTED` can be used to create a user when the plaintext password is unknown but the encrypted password is available
+            |    (e.g. from a database backup). In this case the password string is expected to be on the format `<encryption-version>,<hash>,<salt>`.
+            | * The default for `SET STATUS` is `ACTIVE`. The `password` can either be a string value or a string parameter.
+            | * `SET DEFAULT DATABASE` can be used to configure a default database at a user level which takes precedence over the system wide default.
+          """.stripMargin
         )
-        p("For example, we can create the user `jake` in a suspended state and the requirement to change his password.")
-        query("CREATE USER jake SET PASSWORD 'abc' CHANGE REQUIRED SET STATUS SUSPENDED", ResultAssertions((r) => {
+        p(
+          """For example, we can create the user `jake` in a suspended state, with the default database `anotherDefault`
+            |and the requirement to change his password.""".stripMargin)
+        query("CREATE USER jake SET PASSWORD 'abc' CHANGE REQUIRED SET STATUS SUSPENDED SET DEFAULT DATABASE anotherDefault", ResultAssertions((r) => {
           assertStats(r, systemUpdates = 1)
         })) {
           statsOnlyResultTable()
           note {
-            p("[enterprise-edition]#The `SET STATUS {ACTIVE | SUSPENDED}` part of the command is only available in Enterprise Edition.#")
+            p(
+              """[enterprise-edition]#The `SET STATUS {ACTIVE | SUSPENDED}` and `SET DEFAULT DATABASE anotherDefault` parts of the command are
+                |only available in Enterprise Edition.#""".stripMargin)
           }
         }
         p("The created user will appear on the list provided by `SHOW USERS`.")
-        query("SHOW USERS YIELD user, suspended, passwordChangeRequired, roles WHERE user = 'jake'", assertUsersShown(Seq("jake"))) {
+        query("SHOW USERS YIELD user, suspended, passwordChangeRequired, roles, requestedDefaultDatabase WHERE user = 'jake'", assertUsersShown(Seq("jake"))) {
           p(
             """In this example we also:
               |
@@ -128,13 +139,24 @@ class SecurityUserAndRoleManagementTest extends DocumentingTest with QueryStatis
       section("Modifying users", "administration-security-users-alter") {
         p("Users can be modified using `ALTER USER`.")
         p("include::user-management-syntax-alter-user.asciidoc[]")
-        p("The `password` can either be a string value or a string parameter, and must not be identical to the old password. " +
-          "The optional `PLAINTEXT` in `SET PLAINTEXT PASSWORD` has the same behaviour as `SET PASSWORD`. " +
-          "The optional `ENCRYPTED` can be used to update a user's password when the plaintext password is unknown but the encrypted password is available (e.g. from a database backup). " +
-          "With `ENCRYPTED`, the password string is expected to be on the format `<encryption-version>,<hash>,<salt>`."
+        p("""
+            | * For `SET PASSWORD`:
+            | ** The `password` can either be a string value or a string parameter, and must not be identical to the old password.
+            | ** The optional `PLAINTEXT` in `SET PLAINTEXT PASSWORD` has the same behaviour as `SET PASSWORD`.
+            | ** The optional `ENCRYPTED` can be used to update a user's password when the plaintext password is unknown but the encrypted password
+            |    is available (e.g. from a database backup).
+            | ** With `ENCRYPTED`, the password string is expected to be on the format `<encryption-version>,<hash>,<salt>`.
+            | * `SET DEFAULT DATABASE` can be used to configure a default database at a user level which takes precedence over the system wide default.
+          """.stripMargin
         )
         p("For example, we can modify the user `jake` with a new password and active status as well as remove the requirement to change his password.")
         query("ALTER USER jake SET PASSWORD 'abc123' CHANGE NOT REQUIRED SET STATUS ACTIVE", ResultAssertions((r) => {
+          assertStats(r, systemUpdates = 1)
+        })) {
+          statsOnlyResultTable()
+        }
+        p("Or we may decide to assign the user `jake` a different default database.")
+        query("ALTER USER jake SET DEFAULT DATABASE anotherDefault", ResultAssertions((r) => {
           assertStats(r, systemUpdates = 1)
         })) {
           statsOnlyResultTable()
@@ -145,7 +167,9 @@ class SecurityUserAndRoleManagementTest extends DocumentingTest with QueryStatis
             |For example, leaving out the `CHANGE [NOT] REQUIRED` part of the query will leave that unchanged.""".stripMargin)
         }
         note {
-          p("[enterprise-edition]#The `SET STATUS {ACTIVE | SUSPENDED}` part of the command is only available in Enterprise Edition.#")
+          p(
+            """[enterprise-edition]#The `SET STATUS {ACTIVE | SUSPENDED}` and `SET DEFAULT DATABASE anotherDefault` parts of these commands are
+              |only available in Enterprise Edition.#""".stripMargin)
         }
         p("The changes to the user will appear on the list provided by `SHOW USERS`.")
         query("SHOW USERS", assertAllNodesShown("User", column = "user")) {


### PR DESCRIPTION
* Documentation for CREATE / ALTER USER SET DEFAULT DATABASE which allows an administrator to set a default database on a per-user basis. Also, document permissions for allowing this.

Depends on: https://github.com/neo-technology/neo4j/pull/7866