### PR TITLE
The label/type list of entity is not optional and other small syntax updates

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-match-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-match-syntax.asciidoc
@@ -2,11 +2,12 @@
 [source, cypher]
 -----
 DENY MATCH
-    { * | properties }
+    "{" { * | properties } "}"
     ON GRAPH[S] {name | *}
         [
-            { NODE[S] | RELATIONSHIP[S] | ELEMENT[S] }
-            [ { * | labels } ]
+            ELEMENT[S] { * | label-or-rel-type-name[,...] }
+            | NODE[S] { * | label-name[,...] }
+            | RELATIONSHIP[S] { * | rel-type-name[,...] }
         ]
     TO roles
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-read-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-read-syntax.asciidoc
@@ -2,11 +2,12 @@
 [source, cypher]
 -----
 DENY READ
-    { * | properties }
+    "{" { * | properties } "}"
     ON GRAPH[S] {name | *}
         [
-            { NODE[S] | RELATIONSHIP[S] | ELEMENT[S] }
-            [ { * | labels } ]
+            ELEMENT[S] { * | label-or-rel-type-name[,...] }
+            | NODE[S] { * | label-name[,...] }
+            | RELATIONSHIP[S] { * | rel-type-name[,...] }
         ]
     TO roles
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-traverse-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-traverse-syntax.asciidoc
@@ -4,8 +4,9 @@
 DENY TRAVERSE
     ON GRAPH[S] {name | *}
         [
-           { NODE[S] | RELATIONSHIP[S] | ELEMENT[S] }
-           [ { * | labels } ]
+            ELEMENT[S] { * | label-or-rel-type-name[,...] }
+            | NODE[S] { * | label-name[,...] }
+            | RELATIONSHIP[S] { * | rel-type-name[,...] }
         ]
     TO roles
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-match-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-match-syntax.asciidoc
@@ -2,11 +2,12 @@
 [source, cypher]
 -----
 GRANT MATCH
-    { * | properties }
+    "{" { * | properties } "}"
     ON GRAPH[S] {name | *}
         [
-            { NODE[S] | RELATIONSHIP[S] | ELEMENT[S] }
-            [ { * | labels } ]
+            ELEMENT[S] { * | label-or-rel-type-name[,...] }
+            | NODE[S] { * | label-name[,...] }
+            | RELATIONSHIP[S] { * | rel-type-name[,...] }
         ]
     TO roles
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-read-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-read-syntax.asciidoc
@@ -2,11 +2,12 @@
 [source, cypher]
 -----
 GRANT READ
-    { * | properties }
+    "{" { * | properties } "}"
     ON GRAPH[S] {name | *}
         [
-            { NODE[S] | RELATIONSHIP[S] | ELEMENT[S] }
-            [ { * | labels } ]
+            ELEMENT[S] { * | label-or-rel-type-name[,...] }
+            | NODE[S] { * | label-name[,...] }
+            | RELATIONSHIP[S] { * | rel-type-name[,...] }
         ]
     TO roles
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-traverse-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-traverse-syntax.asciidoc
@@ -4,8 +4,9 @@
 GRANT TRAVERSE
     ON GRAPH[S] {name | *}
         [
-           { NODE[S] | RELATIONSHIP[S] | ELEMENT[S] }
-           [ { * | labels } ]
+            ELEMENT[S] { * | label-or-rel-type-name[,...] }
+            | NODE[S] { * | label-name[,...] }
+            | RELATIONSHIP[S] { * | rel-type-name[,...] }
         ]
     TO roles
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/revoke-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/revoke-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 REVOKE
-    [ { GRANT | DENY } ] privilege
+    [ GRANT | DENY ] privilege
     FROM roles
 -----


### PR DESCRIPTION
* Backported 4.1 version of read/traverse/match syntax since it was correct there
* Also backported `"{"` for the property list in read/match to show that is part of the syntax
* For revoke commands, don't need both `[] `and `{}` to group optional parts