### PR TITLE
Add back `REVOKE ROLE role FROM user` in syntax table and other syntax updates

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/admin-database-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/admin-database-syntax.asciidoc
@@ -70,13 +70,13 @@ GRANT ALL [[DATABASE] PRIVILEGES]
 | Grant the specified roles all privileges for the default database, specific database(s), or all databases.
 
 | [source, cypher]
-GRANT {SHOW \| TERMINATE} TRANSACTION[S] ["(" {* \| user[, ...]} ")"]
+GRANT {SHOW \| TERMINATE} TRANSACTION[S] [( {* \| user[, ...]} )]
 ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
 TO role[, ...]
 | Grant the specified roles the privilege to list and end the transactions and queries of all users or a particular user(s) in the default database, specific database(s), or all databases.
 
 | [source, cypher]
-GRANT TRANSACTION [MANAGEMENT] ["(" {* \| user[, ...]} ")"]
+GRANT TRANSACTION [MANAGEMENT] [( {* \| user[, ...]} )]
 ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
 TO role[, ...]
 | Grant the specified roles the privilege to manage the transactions and queries of all users or a particular user(s) in the default database, specific database(s), or all databases.

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/admin-database-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/admin-database-syntax.asciidoc
@@ -70,13 +70,13 @@ GRANT ALL [[DATABASE] PRIVILEGES]
 | Grant the specified roles all privileges for the default database, specific database(s), or all databases.
 
 | [source, cypher]
-GRANT {SHOW \| TERMINATE} TRANSACTION[S] [(* \| user[, ...])]
+GRANT {SHOW \| TERMINATE} TRANSACTION[S] ["(" {* \| user[, ...]} ")"]
 ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
 TO role[, ...]
 | Grant the specified roles the privilege to list and end the transactions and queries of all users or a particular user(s) in the default database, specific database(s), or all databases.
 
 | [source, cypher]
-GRANT TRANSACTION [MANAGEMENT] [(* \| user[, ...])]
+GRANT TRANSACTION [MANAGEMENT] ["(" {* \| user[, ...]} ")"]
 ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
 TO role[, ...]
 | Grant the specified roles the privilege to manage the transactions and queries of all users or a particular user(s) in the default database, specific database(s), or all databases.

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/admin-role-database.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/admin-role-database.asciidoc
@@ -24,9 +24,9 @@ The components of the database privilege commands are:
 ** `CREATE NEW [PROPERTY] NAME` - allows property names to be created, so that nodes and relationships can have properties with these names assigned.
 ** `NAME [MANAGEMENT]` - allows all of the name management capabilities: node labels, relationship types, and property names.
 ** `ALL [[DATABASE] PRIVILEGES]` - allows access, index, constraint, and name management for the specified database.
-** `SHOW TRANSACTION (* | user[, ...])` -  allows listing transactions and queries for the specified users on the specified database.
-** `TERMINATE TRANSACTION (* | user[, ...])` - allows ending transactions and queries for the specified users on the specified database.
-** `TRANSACTION [MANAGEMENT] (* | user[, ...])` - allows listing and ending transactions and queries for the specified users on the specified database.
+** `SHOW TRANSACTION` -  allows listing transactions and queries for the specified users on the specified database.
+** `TERMINATE TRANSACTION` - allows ending transactions and queries for the specified users on the specified database.
+** `TRANSACTION [MANAGEMENT]` - allows listing and ending transactions and queries for the specified users on the specified database.
 
 * _name_
 ** The database to associate the privilege with.

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/admin-role-database.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/admin-role-database.asciidoc
@@ -24,9 +24,9 @@ The components of the database privilege commands are:
 ** `CREATE NEW [PROPERTY] NAME` - allows property names to be created, so that nodes and relationships can have properties with these names assigned.
 ** `NAME [MANAGEMENT]` - allows all of the name management capabilities: node labels, relationship types, and property names.
 ** `ALL [[DATABASE] PRIVILEGES]` - allows access, index, constraint, and name management for the specified database.
-** `SHOW TRANSACTION {* | user[, ...]}` -  allows listing transactions and queries for the specified users on the specified database.
-** `TERMINATE TRANSACTION {* | user[, ...]}` - allows ending transactions and queries for the specified users on the specified database.
-** `TRANSACTION [MANAGEMENT] {* | user[, ...]}` - allows listing and ending transactions and queries for the specified users on the specified database.
+** `SHOW TRANSACTION (* | user[, ...])` -  allows listing transactions and queries for the specified users on the specified database.
+** `TERMINATE TRANSACTION (* | user[, ...])` - allows ending transactions and queries for the specified users on the specified database.
+** `TRANSACTION [MANAGEMENT] (* | user[, ...])` - allows listing and ending transactions and queries for the specified users on the specified database.
 
 * _name_
 ** The database to associate the privilege with.

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/all-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/all-management-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 GRANT ALL [[DATABASE] PRIVILEGES]
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
+    ON {DEFAULT DATABASE | DATABASE[S] {name [, ...] | *}}
     TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/deny-database-access-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/deny-database-access-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 DENY ACCESS
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
+    ON {DEFAULT DATABASE | DATABASE[S] {name [, ...] | *}}
     TO role [, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/deny-database-start-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/deny-database-start-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 DENY START
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
+    ON {DEFAULT DATABASE | DATABASE[S] {name [, ...] | *}}
     TO role [, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/deny-database-stop-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/deny-database-stop-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 DENY STOP
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
+    ON {DEFAULT DATABASE | DATABASE[S] {name [, ...] | *}}
     TO role [, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/grant-database-access-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/grant-database-access-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 GRANT ACCESS
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
+    ON {DEFAULT DATABASE | DATABASE[S] {name [, ...] | *}}
     TO role [, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/grant-database-start-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/grant-database-start-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 GRANT START
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
+    ON {DEFAULT DATABASE | DATABASE[S] {name [, ...] | *}}
     TO role [, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/grant-database-stop-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/grant-database-stop-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 GRANT STOP
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
+    ON {DEFAULT DATABASE | DATABASE[S] {name [, ...] | *}}
     TO role [, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/transaction-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/transaction-management-syntax.asciidoc
@@ -4,19 +4,19 @@
 | Command | Description
 
 | [source, cypher]
-GRANT SHOW TRANSACTION[S] [(* \| user[, ...])]
+GRANT SHOW TRANSACTION[S] ["(" {* \| user[, ...]} ")"]
     ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...]\| *}}
     TO role [, ...]
 | Enable the specified roles to list transactions and queries for user(s) or all users in the default database, specific database(s), or all databases.
 
 | [source, cypher]
-GRANT TERMINATE TRANSACTION[S] [(* \| user[, ...])]
+GRANT TERMINATE TRANSACTION[S] ["(" {* \| user[, ...]} ")"]
     ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...]\| *}}
     TO role [, ...]
 | Enable the specified roles to end running transactions and queries for user(s) or all users in the default database, specific database(s), or all databases.
 
 | [source, cypher]
-GRANT TRANSACTION [MANAGEMENT] [(* \| user[, ...])]
+GRANT TRANSACTION [MANAGEMENT] ["(" {* \| user[, ...]} ")"]
     ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...]\| *}}
     TO role [, ...]
 | Enable the specified roles to manage transactions and queries for user(s) or all users in the default database, specific database(s), or all databases.

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/transaction-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/transaction-management-syntax.asciidoc
@@ -4,19 +4,19 @@
 | Command | Description
 
 | [source, cypher]
-GRANT SHOW TRANSACTION[S] ["(" {* \| user[, ...]} ")"]
+GRANT SHOW TRANSACTION[S] [( {* \| user[, ...]} )]
     ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...]\| *}}
     TO role [, ...]
 | Enable the specified roles to list transactions and queries for user(s) or all users in the default database, specific database(s), or all databases.
 
 | [source, cypher]
-GRANT TERMINATE TRANSACTION[S] ["(" {* \| user[, ...]} ")"]
+GRANT TERMINATE TRANSACTION[S] [( {* \| user[, ...]} )]
     ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...]\| *}}
     TO role [, ...]
 | Enable the specified roles to end running transactions and queries for user(s) or all users in the default database, specific database(s), or all databases.
 
 | [source, cypher]
-GRANT TRANSACTION [MANAGEMENT] ["(" {* \| user[, ...]} ")"]
+GRANT TRANSACTION [MANAGEMENT] [( {* \| user[, ...]} )]
     ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...]\| *}}
     TO role [, ...]
 | Enable the specified roles to manage transactions and queries for user(s) or all users in the default database, specific database(s), or all databases.

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-deny-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-deny-syntax.asciidoc
@@ -11,7 +11,7 @@ The components of the graph privilege commands are:
 
 * _name_
 ** The graph or graphs to associate the privilege with.
-Because in ${neo4j.version} you can have only one graph per database, this command uses the database name to refer to that graph.
+Because in Neo4j {neo4j-version} you can have only one graph per database, this command uses the database name to refer to that graph.
 +
 [NOTE]
 ====

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/revoke-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/revoke-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 REVOKE
-    [ { GRANT | DENY } ] graph-privilege
+    [ GRANT | DENY ] graph-privilege
     FROM role [, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/role-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/role-management-syntax.asciidoc
@@ -45,7 +45,7 @@ CREATE ROLE name [IF NOT EXISTS] [AS COPY OF name]
 ----
 CREATE OR REPLACE ROLE name [AS COPY OF name]
 ----
-| Create a new role.
+| Recreate a role, or create a new role if no such role exists.
 | <<administration-security-administration-dbms-privileges-role-management, CREATE ROLE>> and
 <<administration-security-administration-dbms-privileges-role-management, DROP ROLE>>
 
@@ -68,4 +68,5 @@ GRANT ROLE name[, ...] TO user[, ...]
 REVOKE ROLE name[, ...] FROM user[, ...]
 ----
 | Remove roles from users.
+| <<administration-security-administration-dbms-privileges-role-management, REMOVE ROLE>>
 |===

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/role-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/role-management-syntax.asciidoc
@@ -26,7 +26,7 @@ SHOW [ALL\|POPULATED] ROLES WITH USERS
 
 | [source, cypher]
 ----
-SHOW ROLE[S] name1[, name2] PRIVILEGE[S] [AS [REVOKE] COMMAND[S]]
+SHOW ROLE[S] name[, ...] PRIVILEGE[S] [AS [REVOKE] COMMAND[S]]
     [YIELD { * \| field1[, ...] } [ORDER BY field1 [, ...]] [SKIP n] [LIMIT n]]
     [WHERE expression]
     [RETURN field1[, ...] [ORDER BY field1 [, ...]] [SKIP n] [LIMIT n]]

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/role-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/role-management-syntax.asciidoc
@@ -45,7 +45,7 @@ CREATE ROLE name [IF NOT EXISTS] [AS COPY OF name]
 ----
 CREATE OR REPLACE ROLE name [AS COPY OF name]
 ----
-| Create a new role, replacing an existing role if one exists with the same name.
+| Create a new role, or if a role with the same name exists, replace it.
 | <<administration-security-administration-dbms-privileges-role-management, CREATE ROLE>> and
 <<administration-security-administration-dbms-privileges-role-management, DROP ROLE>>
 

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/role-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/role-management-syntax.asciidoc
@@ -45,7 +45,7 @@ CREATE ROLE name [IF NOT EXISTS] [AS COPY OF name]
 ----
 CREATE OR REPLACE ROLE name [AS COPY OF name]
 ----
-| Recreate a role, or create a new role if no such role exists.
+| Create a new role, replacing an existing role if one exists with the same name.
 | <<administration-security-administration-dbms-privileges-role-management, CREATE ROLE>> and
 <<administration-security-administration-dbms-privileges-role-management, DROP ROLE>>
 

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/show-role-privileges-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/show-role-privileges-syntax.asciidoc
@@ -1,7 +1,7 @@
 .Command syntax
 [source, cypher]
 -----
-SHOW ROLE[S] role1[, role2] PRIVILEGE[S] [AS [REVOKE] COMMAND[S]]
+SHOW ROLE[S] role[, ...] PRIVILEGE[S] [AS [REVOKE] COMMAND[S]]
     [YIELD { * | field1[, ...] } [ORDER BY field1 [, ...]] [SKIP n] [LIMIT n]]
     [WHERE expression]
     [RETURN field1[, ...] [ORDER BY field1 [, ...]] [SKIP n] [LIMIT n]]

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/show-user-privileges-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/show-user-privileges-syntax.asciidoc
@@ -1,7 +1,7 @@
 .Command syntax
 [source, cypher]
 -----
-SHOW USER[S] [user1[, user2]] PRIVILEGE[S] [AS [REVOKE] COMMAND[S]]
+SHOW USER[S] [user[, ...]] PRIVILEGE[S] [AS [REVOKE] COMMAND[S]]
     [YIELD { * | field1[, ...] } [ORDER BY field1 [, ...]] [SKIP n] [LIMIT n]]
     [WHERE expression]
     [RETURN field1[, ...] [ORDER BY field1 [, ...]] [SKIP n] [LIMIT n]]

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/user-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/user-management-syntax.asciidoc
@@ -59,7 +59,7 @@ CREATE OR REPLACE USER name
   [[SET PASSWORD] CHANGE [NOT] REQUIRED]
   [SET STATUS {ACTIVE \| SUSPENDED}]
 ----
-| Create a new user.
+| Recreate a user, or create a new user if no such user exists.
 | <<administration-security-administration-dbms-privileges-user-management, CREATE USER>> and
 <<administration-security-administration-dbms-privileges-user-management, DROP USER>>
 | `+`

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/user-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/user-management-syntax.asciidoc
@@ -59,7 +59,7 @@ CREATE OR REPLACE USER name
   [[SET PASSWORD] CHANGE [NOT] REQUIRED]
   [SET STATUS {ACTIVE \| SUSPENDED}]
 ----
-| Create a new user, replacing an existing user if one exists with the same name.
+| Create a new user, or if a user with the same name exists, replace it.
 | <<administration-security-administration-dbms-privileges-user-management, CREATE USER>> and
 <<administration-security-administration-dbms-privileges-user-management, DROP USER>>
 | `+`

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/user-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/user-management-syntax.asciidoc
@@ -59,7 +59,7 @@ CREATE OR REPLACE USER name
   [[SET PASSWORD] CHANGE [NOT] REQUIRED]
   [SET STATUS {ACTIVE \| SUSPENDED}]
 ----
-| Recreate a user, or create a new user if no such user exists.
+| Create a new user, replacing an existing user if one exists with the same name.
 | <<administration-security-administration-dbms-privileges-user-management, CREATE USER>> and
 <<administration-security-administration-dbms-privileges-user-management, DROP USER>>
 | `+`

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/user-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/user-management-syntax.asciidoc
@@ -29,7 +29,7 @@ SHOW USERS
 
 | [source, cypher]
 ----
-SHOW USER[S] [name1[, name2]] PRIVILEGE[S] [AS [REVOKE] COMMAND[S]]
+SHOW USER[S] [name[, ...]] PRIVILEGE[S] [AS [REVOKE] COMMAND[S]]
     [YIELD { * \| field1[, ...] } [ORDER BY field1 [, ...]] [SKIP n] [LIMIT n]]
     [WHERE expression]
     [RETURN field1[, ...] [ORDER BY field1 [, ...]] [SKIP n] [LIMIT n]]

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/BuiltInRolesAdministrationTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/BuiltInRolesAdministrationTest.scala
@@ -39,7 +39,7 @@ class BuiltInRolesAdministrationTest extends DocumentingTest with QueryStatistic
         )
         p(
           """The `PUBLIC` role can not be dropped and thus there is no need to recreate the role itself.
-            |To restore the role to its original capabilities, two steps are needed. First, all `GRANT` or `DENY` privileges on this role should be revoked (see output of `SHOW ROLE PUBLIC PRIVILEGES` on what to revoke).
+            |To restore the role to its original capabilities, two steps are needed. First, all `GRANT` or `DENY` privileges on this role should be revoked (see output of `SHOW ROLE PUBLIC PRIVILEGES AS REVOKE COMMANDS` on what to revoke).
             |Secondly, the following queries must be run:""".stripMargin)
         query("GRANT ACCESS ON DEFAULT DATABASE TO PUBLIC", ResultAssertions(r => {
           assertStats(r, systemUpdates = 1)

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityAdministrationTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityAdministrationTest.scala
@@ -943,7 +943,8 @@ class SecurityAdministrationTest extends DocumentingTest with QueryStatisticsTes
             |* show privileges
             |* assign privileges
             |* remove privileges
-            |* execute all procedures with elevated privileges""".stripMargin)
+            |* execute all procedures with elevated privileges
+            |* execute all user defined functions with elevated privileges""".stripMargin)
         p("include::dbms/all-management-syntax.asciidoc[]")
 
         p(


### PR DESCRIPTION
Cherry-picked from 4.1:
* When privileges was added to the list it was missed from REVOKE ROLE which lead to that table entry not being rendered
* Fix so we print the neo4j version instead of printing `${neo4j.version}`
* Update transaction privileges in database privilege list to use correct `()` instead of `{}`
* Fix syntax for transaction privileges to show what is part of syntax and what is just grouping
* For revoke commands, don't need both `[]` and `{}` to group optional parts
* Don't print `\|` in syntax examples when it should just be `|`
* Update so `CREATE OR REPLACE` says replacing instead of just creating

Additional updates:
* Update syntax in recreate PUBLIC role example. We now have `AS REVOKE COMMANDS` on the `SHOW PRIVILEGE` commands, might use that to see what privileges to revoke from `PUBLIC`
* Correct the list of privileges included in `ALL DBMS PRIVILEGES`
* Update to use `name[, ...]` instead of `name1[, name2]` in the `SHOW ROLE/USER PRIVILEGES`, to be consistent with other such places (and you can list more then 2)