### PR TITLE
Deprecation of exists() for property checks

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -38,6 +38,8 @@ Replacement syntax for deprecated and removed features are also indicated.
 | `CREATE CONSTRAINT [name] ON ()-[rel:REL]-() ASSERT rel.property IS NOT NULL` | Syntax | Added | New syntax for creating relationship property existence constraints.
 | `CREATE CONSTRAINT [name] ON (node:Label) ASSERT exists(node.property)`   | Syntax | Deprecated | Replaced by `CREATE CONSTRAINT [name] ON (node:Label) ASSERT node.property IS NOT NULL`
 | `CREATE CONSTRAINT [name] ON ()-[rel:REL]-() ASSERT exists(rel.property)` | Syntax | Deprecated | Replaced by `CREATE CONSTRAINT [name] ON ()-[rel:REL]-() ASSERT rel.property IS NOT NULL`
+| `exists(prop)` | Syntax | Deprecated | Replaced by `prop IS NOT NULL`
+| `NOT exists(prop)` | Syntax | Deprecated | Replaced by `prop IS NULL`
 |===
 
 [[cypher-deprecations-additions-removals-4.2]]

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/indexes-for-search-performance/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/indexes-for-search-performance/index.asciidoc
@@ -162,7 +162,7 @@ WHERE n.prop1 = 'x' AND n.prop2 = 1 AND n.prop3 > 5 AND n.prop4 < 'e' AND n.prop
 will be planned as:
 
 ```
-WHERE n.prop1 = 'x' AND n.prop2 = 1 AND n.prop3 > 5 AND n.prop4IS NOT NULL AND n.prop5 IS NOT NULL AND n.prop6 IS NOT NULL
+WHERE n.prop1 = 'x' AND n.prop2 = 1 AND n.prop3 > 5 AND n.prop4 IS NOT NULL AND n.prop5 IS NOT NULL AND n.prop6 IS NOT NULL
 ```
 
 with filters on `n.prop4 < 'e'` and `n.prop5 = true`, since `n.prop3` has a `range search` predicate.

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/indexes-for-search-performance/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/indexes-for-search-performance/index.asciidoc
@@ -135,7 +135,7 @@ Like single-property indexes, composite indexes support all predicates:
 
 * equality check: `n.prop = value`
 * list membership check: `n.prop IN list`
-* existence check: `exists(n.prop)`
+* existence check: `n.prop IS NOT NULL`
 * range search: `n.prop > value`
 * prefix search: `STARTS WITH`
 * suffix search: `ENDS WITH`
@@ -156,13 +156,13 @@ any predicates following after will therefore also be planned as such.
 For example, an index on `:Label(prop1,prop2,prop3,prop4,prop5,prop6)` and predicates:
 
 ```
-WHERE n.prop1 = 'x' AND n.prop2 = 1 AND n.prop3 > 5 AND n.prop4 < 'e' AND n.prop5 = true AND exists(n.prop6)
+WHERE n.prop1 = 'x' AND n.prop2 = 1 AND n.prop3 > 5 AND n.prop4 < 'e' AND n.prop5 = true AND n.prop6 IS NOT NULL
 ```
 
 will be planned as:
 
 ```
-WHERE n.prop1 = 'x' AND n.prop2 = 1 AND n.prop3 > 5 AND exists(n.prop4) AND exists(n.prop5) AND exists(n.prop6)
+WHERE n.prop1 = 'x' AND n.prop2 = 1 AND n.prop3 > 5 AND n.prop4IS NOT NULL AND n.prop5 IS NOT NULL AND n.prop6 IS NOT NULL
 ```
 
 with filters on `n.prop4 < 'e'` and `n.prop5 = true`, since `n.prop3` has a `range search` predicate.
@@ -176,7 +176,7 @@ WHERE n.prop1 ENDS WITH 'x' AND n.prop2 = false
 will be planned as:
 
 ```
-WHERE exists(n.prop1) AND exists(n.prop2)
+WHERE n.prop1 IS NOT NULL AND n.prop2 IS NOT NULL
 ```
 
 with filters on `n.prop1 ENDS WITH 'x'` and `n.prop2 = false`, since `n.prop1` has a `suffix search` predicate.

--- a/cypher/cypher-docs/src/docs/dev/query-tuning-indexes.adoc
+++ b/cypher/cypher-docs/src/docs/dev/query-tuning-indexes.adoc
@@ -44,9 +44,9 @@ include::ql/administration/indexes/substring-search-using-contains-single-proper
 
 include::ql/administration/indexes/substring-search-using-contains-composite-index.asciidoc[leveloffset=2]
 
-include::ql/administration/indexes/existence-check-using-exists-single-property-index.asciidoc[leveloffset=2]
+include::ql/administration/indexes/existence-check-using-is-not-null-single-property-index.asciidoc[leveloffset=2]
 
-include::ql/administration/indexes/existence-check-using-exists-composite-index.asciidoc[leveloffset=2]
+include::ql/administration/indexes/existence-check-using-is-not-null-composite-index.asciidoc[leveloffset=2]
 
 include::ql/administration/indexes/spatial-distance-searches-single-property-index.asciidoc[leveloffset=2]
 

--- a/cypher/cypher-docs/src/docs/dev/syntax/expressions.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/syntax/expressions.asciidoc
@@ -32,7 +32,7 @@ An expression in Cypher can be:
 * A path-pattern: `+(a)-->()<--(b)+`.
 * An operator application: `1 + 2` and `3 < 4`.
 * A predicate expression is an expression that returns true or false: `a.prop = 'Hello'`, `length(p) > 10`,
-`exists(a.name)`.
+`a.name IS NOT NULL`.
 * An existential subquery is an expression that returns true or false:
 `EXISTS {
   MATCH (n)-[r]->(p)

--- a/cypher/cypher-docs/src/docs/graphgists/query-tuning/advanced-query-tuning-example.asciidoc
+++ b/cypher/cypher-docs/src/docs/graphgists/query-tuning/advanced-query-tuning-example.asciidoc
@@ -134,7 +134,7 @@ For non-native indexes there will still be a second database access to retrieve 
 
 Predicates that can be used to enable this optimization are:
 
-* Existence (e.g. `WHERE exists(n.name)`)
+* Existence (e.g. `WHERE n.name IS NOT NULL`)
 * Equality (e.g. `WHERE n.name = 'Tom Hanks'`)
 * Range (e.g. `WHERE n.uid > 1000 AND n.uid < 2000`)
 * Prefix (e.g. `WHERE n.name STARTS WITH 'Tom'`)
@@ -225,7 +225,7 @@ The optimization can only work on native indexes.
 It does not work for predicates only querying for the spatial type `Point`.
 Predicates that can be used to enable this optimization are:
 
-* Existence (e.g.`WHERE exists(n.name)`)
+* Existence (e.g.`WHERE n.name IS NOT NULL`)
 * Equality (e.g. `WHERE n.name = 'Tom Hanks'`)
 * Range (e.g. `WHERE n.uid > 1000 AND n.uid < 2000`)
 * Prefix (e.g. `WHERE n.name STARTS WITH 'Tom'`)

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/PredicateFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/PredicateFunctionsTest.scala
@@ -92,6 +92,7 @@ class PredicateFunctionsTest extends DocumentingTest {
     section("exists()", "functions-exists") {
       p("`exists()` returns true if a match for the given pattern exists in the graph, or if the specified property exists in the node, relationship or map." +
         " `null` is returned if the input argument is `null`.")
+      note(p("The `exists()` functions has been deprecated for property checks. Use <<property-existence-checking, `IS NOT NULL`>> instead."))
       function("exists(pattern-or-property)", "A Boolean.", ("pattern-or-property", "A pattern or a property (in the form 'variable.prop')."))
       query(
         """MATCH (n)

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
@@ -736,7 +736,7 @@ class QueryPlanTest extends DocumentingTestBase with SoftReset {
     profileQuery(title = "Node Index Scan",
                  text = """
                           |The `NodeIndexScan` operator examines all values stored in an index, returning all nodes with a particular label having a specified property.""".stripMargin,
-                 queryText = "MATCH (l:Location) WHERE exists(l.name) RETURN l",
+                 queryText = "MATCH (l:Location) WHERE l.name IS NOT NULL RETURN l",
                  assertions = p => assertThat(p.executionPlanDescription().toString, containsString("NodeIndexScan"))
     )
   }

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ShortestPathPlanningTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ShortestPathPlanningTest.scala
@@ -83,7 +83,7 @@ class ShortestPathPlanningTest extends DocumentingTest {
         """MATCH (KevinB:Person {name: 'Kevin Bacon'} ),
           |      (Al:Person {name: 'Al Pacino'}),
           |      p = shortestPath((KevinB)-[:ACTED_IN*]-(Al))
-          |WHERE all(r IN relationships(p) WHERE exists(r.role))
+          |WHERE all(r IN relationships(p) WHERE r.role IS NOT NULL)
           |RETURN p""", assertShortestPathLength) {
         p(
           """This query can be evaluated with the fast algorithm -- there are no predicates that need to see the whole

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
@@ -151,7 +151,7 @@ class WhereTest extends DocumentingTest {
         })) {
           p("The name and belt for the *'Andy'* node are returned because he is the only one with a `belt` property.")
           important {
-            p("The `exists()` function has been deprecated and has been superseded by `IS NOT NULL`.")
+            p("The `exists()` function has been deprecated for property existence checking and has been superseded by `IS NOT NULL`.")
           }
           resultTable()
         }

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
@@ -145,13 +145,13 @@ class WhereTest extends DocumentingTest {
         }
       }
       section("Property existence checking", "property-existence-checking") {
-        p("Use the `exists()` function to only include nodes or relationships in which a property exists.")
-        query("MATCH (n:Person)\nWHERE exists(n.belt)\nRETURN n.name, n.belt", ResultAssertions((r) => {
+        p("Use the `IS NOT NULL` predicate to only include nodes or relationships in which a property exists.")
+        query("MATCH (n:Person)\nWHERE n.belt IS NOT NULL\nRETURN n.name, n.belt", ResultAssertions((r) => {
           r.toList should equal(List(Map("n.name" -> "Andy", "n.belt" -> "white")))
         })) {
           p("The name and belt for the *'Andy'* node are returned because he is the only one with a `belt` property.")
           important {
-            p("The `has()` function has been superseded by `exists()` and has been removed.")
+            p("The `exists()` function has been deprecated and has been superseded by `IS NOT NULL`.")
           }
           resultTable()
         }

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ListPredicatesTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ListPredicatesTest.scala
@@ -51,7 +51,7 @@ WHERE id(n) = %A% AND id(m) = %B%
 WITH nodes(path) AS coll, n, m
 WHERE
 
-all(x IN coll WHERE exists(x.property))
+all(x IN coll WHERE x.property IS NOT NULL)
 
 RETURN n,m###
 
@@ -63,7 +63,7 @@ WHERE id(n) = %A% AND id(m) = %B%
 WITH nodes(path) AS coll, n, m
 WHERE
 
-any(x IN coll WHERE exists(x.property))
+any(x IN coll WHERE x.property IS NOT NULL)
 
 RETURN n, m###
 
@@ -75,7 +75,7 @@ WHERE id(n) = %A% AND id(m) = %B%
 WITH nodes(path) AS coll, n, m
 WHERE
 
-none(x IN coll WHERE exists(x.property))
+none(x IN coll WHERE x.property IS NOT NULL)
 
 RETURN n, m###
 
@@ -87,7 +87,7 @@ WHERE id(n) = %A% AND id(m) = %B%
 WITH nodes(path) AS coll, n, m
 WHERE
 
-single(x IN coll WHERE exists(x.property))
+single(x IN coll WHERE x.property IS NOT NULL)
 
 RETURN n, m###
 

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PredicatesTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PredicatesTest.scala
@@ -79,11 +79,11 @@ RETURN n, m###
 
 Use comparison operators.
 
-###assertion=returns-three
+###assertion=returns-one parameters=anothername
 MATCH (n)
 WHERE
 
-exists(n.property)
+toString(n.property) = $value
 
 RETURN n###
 
@@ -125,17 +125,17 @@ WHERE id(n) = %A% AND id(m) = %B%
 OPTIONAL MATCH (n)-[variable]->(m)
 WHERE
 
-variable IS NULL
+variable IS NOT NULL
 
 RETURN n, m###
 
-Check if something is `null`.
+Check if something is not `null`, e.g. that a property exists.
 
 ###assertion=returns-one parameters=aname
 MATCH (n)
 WHERE
 
-NOT exists(n.property) OR n.property = $value
+n.property IS NULL OR n.property = $value
 
 RETURN n###
 
@@ -175,7 +175,7 @@ String matching.
 
 ###assertion=returns-one parameters=regex
 MATCH (n)
-WHERE exists(n.property) AND
+WHERE n.property IS NOT NULL AND
 
 n.property =~ 'Tim.*'
 
@@ -205,7 +205,7 @@ Exclude matches to `(n)-[:KNOWS]->(m)` from the result.
 
 ###assertion=returns-one parameters=names
 MATCH (n)
-WHERE exists(n.property) AND
+WHERE n.property IS NOT NULL AND
 
 n.property IN [$value1, $value2]
 


### PR DESCRIPTION
`exists(prop)` has been deprecated and replaced by `prop IS NOT NULL`, while `NOT exists(prop)` has been replaced by `prop IS NULL`


Should go in together with https://github.com/neo-technology/neo4j/pull/7893. It also needs to be build locally together with that branch, since it makes changes to the plan descriptions which docs assert on.