### PR TITLE
Don't use old create index syntax

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ShortestPathPlanningTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ShortestPathPlanningTest.scala
@@ -48,7 +48,7 @@ class ShortestPathPlanningTest extends DocumentingTest {
         |
         |       (TheDevilsAdvocate:Movie {title: 'The Devil´s Advocate'}),
         |       (Keanu)-[:ACTED_IN {role: 'Kevin Lomax'}]->(TheDevilsAdvocate),
-        |       (Al)-[:ACTED_IN {role: 'John Milton'}]->(TheDevilsAdvocate)""", "CREATE INDEX ON :Person(name)")
+        |       (Al)-[:ACTED_IN {role: 'John Milton'}]->(TheDevilsAdvocate)""", "CREATE INDEX FOR (n:Person) ON (n.name)")
     synopsis("Shortest path finding in Cypher and how it is planned.")
     p(
       """Planning shortest paths in Cypher can lead to different query plans depending on the predicates that need


### PR DESCRIPTION
4.0 introduced new syntax for creating indexes (and dropping both index and constraints) and deprecated the old syntax.