### PR TITLE
Add some structure to the list privilege section

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/show-privileges-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/show-privileges-syntax.asciidoc
@@ -1,0 +1,24 @@
+.Show privileges command syntax
+[options="header", width="100%", cols="3a,2"]
+|===
+| Command | Description
+
+| [source, cypher]
+SHOW [ALL] PRIVILEGES
+    [YIELD field1[, field2] [ORDER BY field1 [, field2]] [SKIP n] [LIMIT n]]
+    [WHERE expression]
+| List all privileges.
+
+| [source, cypher]
+SHOW ROLE role PRIVILEGES
+    [YIELD field1[, field2] [ORDER BY field1 [, field2]] [SKIP n] [LIMIT n]]
+    [WHERE expression]
+| List privileges for a specific role.
+
+| [source, cypher]
+SHOW USER [user] PRIVILEGES
+    [YIELD field1[, field2] [ORDER BY field1 [, field2]] [SKIP n] [LIMIT n]]
+    [WHERE expression]
+| List privileges for a specific user, or the current user.
+
+|===

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/show-privileges-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/show-privileges-syntax.asciidoc
@@ -5,19 +5,19 @@
 
 | [source, cypher]
 SHOW [ALL] PRIVILEGES
-    [YIELD field1[, field2] [ORDER BY field1 [, field2]] [SKIP n] [LIMIT n]]
+    [YIELD field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
     [WHERE expression]
 | List all privileges.
 
 | [source, cypher]
 SHOW ROLE role PRIVILEGES
-    [YIELD field1[, field2] [ORDER BY field1 [, field2]] [SKIP n] [LIMIT n]]
+    [YIELD field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
     [WHERE expression]
 | List privileges for a specific role.
 
 | [source, cypher]
 SHOW USER [user] PRIVILEGES
-    [YIELD field1[, field2] [ORDER BY field1 [, field2]] [SKIP n] [LIMIT n]]
+    [YIELD field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
     [WHERE expression]
 | List privileges for a specific user, or the current user.
 

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
@@ -22,6 +22,9 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
       """
         |* <<administration-security-subgraph-introduction, The `GRANT`, `DENY` and `REVOKE` commands>>
         |* <<administration-security-subgraph-show, Listing privileges>>
+        |** <<administration-security-subgraph-show-all, Examples for listing all privileges>>
+        |** <<administration-security-subgraph-show-role, Examples for listing privileges for specific role>>
+        |** <<administration-security-subgraph-show-user, Examples for listing privileges for specific user>>
         |* <<administration-security-subgraph-revoke, The `REVOKE` command>>
         |""".stripMargin)
 
@@ -58,82 +61,88 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
       // image source: https://docs.google.com/drawings/d/1dueKAcaQORul-_Ocb5jK9bUkWgtQfdLdFw4uo7PFjTs/edit
     }
     section("Listing privileges", "administration-security-subgraph-show", "enterprise-edition") {
-      p("Available privileges for all roles can be seen using `SHOW PRIVILEGES`.")
-      p("include::show-all-privileges-syntax.asciidoc[]")
-      query("SHOW PRIVILEGES", assertPrivilegeShown(Seq(
-        Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers"),
-        Map("access" -> "DENIED", "action" -> "access", "role" -> "noAccessUsers")
-      ))) {
-        p(
-          """Lists all privileges for all roles.
-            |The table contains columns describing the privilege:
-            |
-            |* access: whether the privilege is granted or denied (whitelist or blacklist)
-            |* action: which type of privilege this is: traverse, read, match, write, a database privilege, a dbms privilege or admin
-            |* resource: what type of scope this privilege applies to: the entire dbms, a database, a graph or sub-graph access
-            |* graph: the specific database or graph this privilege applies to
-            |* segment: for sub-graph access control, this describes the scope in terms of labels or relationship types
-            |* role: the role the privilege is granted to
-            |""".stripMargin)
-        resultTable()
-      }
+      p("Available privileges for can be seen using the different `SHOW PRIVILEGES` commands.")
+      p("include::show-privileges-syntax.asciidoc[]")
+      section("Examples for listing all privileges", "administration-security-subgraph-show-all") {
+        p("Available privileges for all roles can be seen using `SHOW PRIVILEGES`.")
+        p("include::show-all-privileges-syntax.asciidoc[]")
+        query("SHOW PRIVILEGES", assertPrivilegeShown(Seq(
+          Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers"),
+          Map("access" -> "DENIED", "action" -> "access", "role" -> "noAccessUsers")
+        ))) {
+          p(
+            """Lists all privileges for all roles.
+              |The table contains columns describing the privilege:
+              |
+              |* access: whether the privilege is granted or denied (whitelist or blacklist)
+              |* action: which type of privilege this is: traverse, read, match, write, a database privilege, a dbms privilege or admin
+              |* resource: what type of scope this privilege applies to: the entire dbms, a database, a graph or sub-graph access
+              |* graph: the specific database or graph this privilege applies to
+              |* segment: for sub-graph access control, this describes the scope in terms of labels or relationship types
+              |* role: the role the privilege is granted to
+              |""".stripMargin)
+          resultTable()
+        }
 
-      p("It is also possible to filter and sort the results by using `YIELD`, `ORDER BY` and `WHERE`.")
-      query("SHOW PRIVILEGES YIELD role, access, action ORDER BY action WHERE role = 'admin' ", assertPrivilegeShown(Seq(
-        Map("access" -> "GRANTED", "action" -> "access", "role" -> "admin"),
-        Map("access" -> "GRANTED", "action" -> "write", "role" -> "admin")
-      ))) {
-        p(
-          """In this example:
-            |
-            |* The number of columns returned has been reduced with the `YIELD` clause.
-            |* The order of the returned columns has been changed.
-            |* The results have been filtered to only return the 'admin' role using a `WHERE` clause.
-            |* The results are ordered by the 'action' column using `ORDER BY`.
-            |
-            |`SKIP` and `LIMIT` can also be used to paginate the results.
-            |""".stripMargin)
-        resultTable()
-      }
+        p("It is also possible to filter and sort the results by using `YIELD`, `ORDER BY` and `WHERE`.")
+        query("SHOW PRIVILEGES YIELD role, access, action ORDER BY action WHERE role = 'admin' ", assertPrivilegeShown(Seq(
+          Map("access" -> "GRANTED", "action" -> "access", "role" -> "admin"),
+          Map("access" -> "GRANTED", "action" -> "write", "role" -> "admin")
+        ))) {
+          p(
+            """In this example:
+              |
+              |* The number of columns returned has been reduced with the `YIELD` clause.
+              |* The order of the returned columns has been changed.
+              |* The results have been filtered to only return the 'admin' role using a `WHERE` clause.
+              |* The results are ordered by the 'action' column using `ORDER BY`.
+              |
+              |`SKIP` and `LIMIT` can also be used to paginate the results.
+              |""".stripMargin)
+          resultTable()
+        }
 
-      p("`WHERE` can be used without `YIELD`")
-      query("SHOW PRIVILEGES WHERE graph <> '*' ", assertPrivilegeShown(Seq(
-        Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "graph" -> "neo4j"),
-        Map("access" -> "DENIED", "action" -> "access", "role" -> "noAccessUsers", "graph" -> "neo4j")
-      ))) {
-        p(
-          """In this example the `WHERE` clause is used to filter privileges down to those that target specific graphs only.""".stripMargin)
-        resultTable()
+        p("`WHERE` can be used without `YIELD`")
+        query("SHOW PRIVILEGES WHERE graph <> '*' ", assertPrivilegeShown(Seq(
+          Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "graph" -> "neo4j"),
+          Map("access" -> "DENIED", "action" -> "access", "role" -> "noAccessUsers", "graph" -> "neo4j")
+        ))) {
+          p(
+            """In this example the `WHERE` clause is used to filter privileges down to those that target specific graphs only.""".stripMargin)
+          resultTable()
+        }
       }
-
-      p("Available privileges for a particular role can be seen using `SHOW ROLE name PRIVILEGES`.")
-      p("include::show-role-privileges-syntax.asciidoc[]")
-      query("SHOW ROLE regularUsers PRIVILEGES", assertPrivilegeShown(Seq(
-        Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers")
-      ))) {
-        p("Lists all privileges for role 'regularUsers'")
-        resultTable()
+      section("Examples for listing privileges for specific role", "administration-security-subgraph-show-role") {
+        p("Available privileges for a particular role can be seen using `SHOW ROLE name PRIVILEGES`.")
+        p("include::show-role-privileges-syntax.asciidoc[]")
+        query("SHOW ROLE regularUsers PRIVILEGES", assertPrivilegeShown(Seq(
+          Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers")
+        ))) {
+          p("Lists all privileges for role 'regularUsers'")
+          resultTable()
+        }
       }
+      section("Examples for listing privileges for specific user", "administration-security-subgraph-show-user") {
+        p("Available privileges for a particular user can be seen using `SHOW USER name PRIVILEGES`.")
+        note {
+          p("Please note that if a non-native auth provider like LDAP is in use, `SHOW USER PRIVILEGES` will only work in a limited capacity; " +
+            "It is only possible for a user to show their own privileges. Other users' privileges cannot be listed when using a non-native auth provider.")
+        }
 
-      p("Available privileges for a particular user can be seen using `SHOW USER name PRIVILEGES`.")
-      note {
-        p("Please note that if a non-native auth provider like LDAP is in use, `SHOW USER PRIVILEGES` will only work in a limited capacity; " +
-          "It is only possible for a user to show their own privileges. Other users' privileges cannot be listed when using a non-native auth provider.")
+        p("include::show-user-privileges-syntax.asciidoc[]")
+        query("SHOW USER jake PRIVILEGES", assertPrivilegeShown(Seq(
+          Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "user" -> "jake")
+        ))) {
+          p("Lists all privileges for user 'jake'")
+          resultTable()
+        }
+
+        p("The same command can be used at all times to review available privileges for the current user. " +
+          "For this purpose, a shorter form of the the command also exists: SHOW USER PRIVILEGES.")
+        query("SHOW USER PRIVILEGES", ResultAssertions(r => {
+          assertStats(r)
+        })){}
       }
-
-      p("include::show-user-privileges-syntax.asciidoc[]")
-      query("SHOW USER jake PRIVILEGES", assertPrivilegeShown(Seq(
-        Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "user" -> "jake")
-      ))) {
-        p("Lists all privileges for user 'jake'")
-        resultTable()
-      }
-
-      p("The same command can be used at all times to review available privileges for the current user. " +
-        "For this purpose, a shorter form of the the command also exists: SHOW USER PRIVILEGES.")
-      query("SHOW USER PRIVILEGES", ResultAssertions(r => {
-        assertStats(r)
-      })){}
     }
 
     section("The `REVOKE` command", "administration-security-subgraph-revoke", "enterprise-edition") {

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
@@ -74,12 +74,12 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
             """Lists all privileges for all roles.
               |The table contains columns describing the privilege:
               |
-              |* access: whether the privilege is granted or denied
-              |* action: which type of privilege this is: traverse, read, match, write, a database privilege, a dbms privilege or admin
-              |* resource: what type of scope this privilege applies to: the entire dbms, a database, a graph or sub-graph access
-              |* graph: the specific database or graph this privilege applies to
-              |* segment: for sub-graph access control, this describes the scope in terms of labels or relationship types
-              |* role: the role the privilege is granted to
+              |* `access`: whether the privilege is granted or denied
+              |* `action`: which type of privilege this is: traverse, read, match, write, a database privilege, a dbms privilege or admin
+              |* `resource`: what type of scope this privilege applies to: the entire dbms, a database, a graph or sub-graph access
+              |* `graph`: the specific database or graph this privilege applies to
+              |* `segment`: for sub-graph access control, this describes the scope in terms of labels or relationship types
+              |* `role`: the role the privilege is granted to
               |""".stripMargin)
           resultTable()
         }
@@ -95,7 +95,7 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
               |* The number of columns returned has been reduced with the `YIELD` clause.
               |* The order of the returned columns has been changed.
               |* The results have been filtered to only return the `admin` role using a `WHERE` clause.
-              |* The results are ordered by the 'action' column using `ORDER BY`.
+              |* The results are ordered by the `action` column using `ORDER BY`.
               |
               |`SKIP` and `LIMIT` can also be used to paginate the results.
               |""".stripMargin)

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
@@ -61,10 +61,10 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
       // image source: https://docs.google.com/drawings/d/1dueKAcaQORul-_Ocb5jK9bUkWgtQfdLdFw4uo7PFjTs/edit
     }
     section("Listing privileges", "administration-security-subgraph-show", "enterprise-edition") {
-      p("Available privileges for can be seen using the different `SHOW PRIVILEGES` commands.")
+      p("Available privileges can be displayed using the different `SHOW PRIVILEGES` commands.")
       p("include::show-privileges-syntax.asciidoc[]")
       section("Examples for listing all privileges", "administration-security-subgraph-show-all") {
-        p("Available privileges for all roles can be seen using `SHOW PRIVILEGES`.")
+        p("Available privileges for all roles can be displayed using `SHOW PRIVILEGES`.")
         p("include::show-all-privileges-syntax.asciidoc[]")
         query("SHOW PRIVILEGES", assertPrivilegeShown(Seq(
           Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers"),
@@ -74,7 +74,7 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
             """Lists all privileges for all roles.
               |The table contains columns describing the privilege:
               |
-              |* access: whether the privilege is granted or denied (whitelist or blacklist)
+              |* access: whether the privilege is granted or denied
               |* action: which type of privilege this is: traverse, read, match, write, a database privilege, a dbms privilege or admin
               |* resource: what type of scope this privilege applies to: the entire dbms, a database, a graph or sub-graph access
               |* graph: the specific database or graph this privilege applies to
@@ -94,7 +94,7 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
               |
               |* The number of columns returned has been reduced with the `YIELD` clause.
               |* The order of the returned columns has been changed.
-              |* The results have been filtered to only return the 'admin' role using a `WHERE` clause.
+              |* The results have been filtered to only return the `admin` role using a `WHERE` clause.
               |* The results are ordered by the 'action' column using `ORDER BY`.
               |
               |`SKIP` and `LIMIT` can also be used to paginate the results.
@@ -108,22 +108,22 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
           Map("access" -> "DENIED", "action" -> "access", "role" -> "noAccessUsers", "graph" -> "neo4j")
         ))) {
           p(
-            """In this example the `WHERE` clause is used to filter privileges down to those that target specific graphs only.""".stripMargin)
+            """In this example, the `WHERE` clause is used to filter privileges down to those that target specific graphs only.""".stripMargin)
           resultTable()
         }
       }
       section("Examples for listing privileges for specific role", "administration-security-subgraph-show-role") {
-        p("Available privileges for a particular role can be seen using `SHOW ROLE name PRIVILEGES`.")
+        p("Available privileges for a particular role can be displayed using `SHOW ROLE name PRIVILEGES`.")
         p("include::show-role-privileges-syntax.asciidoc[]")
         query("SHOW ROLE regularUsers PRIVILEGES", assertPrivilegeShown(Seq(
           Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers")
         ))) {
-          p("Lists all privileges for role 'regularUsers'.")
+          p("Lists all privileges for role `regularUsers`.")
           resultTable()
         }
       }
       section("Examples for listing privileges for specific user", "administration-security-subgraph-show-user") {
-        p("Available privileges for a particular user can be seen using `SHOW USER name PRIVILEGES`.")
+        p("Available privileges for a particular user can be displayed using `SHOW USER name PRIVILEGES`.")
         note {
           p("Please note that if a non-native auth provider like LDAP is in use, `SHOW USER PRIVILEGES` will only work in a limited capacity; " +
             "It is only possible for a user to show their own privileges. Other users' privileges cannot be listed when using a non-native auth provider.")
@@ -133,7 +133,7 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
         query("SHOW USER jake PRIVILEGES", assertPrivilegeShown(Seq(
           Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "user" -> "jake")
         ))) {
-          p("Lists all privileges for user 'jake'.")
+          p("Lists all privileges for user `jake`.")
           resultTable()
         }
 

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
@@ -118,7 +118,7 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
         query("SHOW ROLE regularUsers PRIVILEGES", assertPrivilegeShown(Seq(
           Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers")
         ))) {
-          p("Lists all privileges for role 'regularUsers'")
+          p("Lists all privileges for role 'regularUsers'.")
           resultTable()
         }
       }
@@ -133,7 +133,7 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
         query("SHOW USER jake PRIVILEGES", assertPrivilegeShown(Seq(
           Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "user" -> "jake")
         ))) {
-          p("Lists all privileges for user 'jake'")
+          p("Lists all privileges for user 'jake'.")
           resultTable()
         }
 


### PR DESCRIPTION
Since we now have more than one example for each version of the `SHOW PRIVILEGES` commands it got a bit hard to see what versions were available