### PR TITLE
Add some structure to the list privilege section

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/show-privileges-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/show-privileges-syntax.asciidoc
@@ -1,0 +1,27 @@
+.Show privileges command syntax
+[options="header", width="100%", cols="3a,2"]
+|===
+| Command | Description
+
+| [source, cypher]
+SHOW [ALL] PRIVILEGE[S] [AS [REVOKE] COMMAND[S]]
+    [YIELD { * \| field1[, ...] } [ORDER BY field1 [, ...]] [SKIP n] [LIMIT n]]
+    [WHERE expression]
+    [RETURN field1[, ...] [ORDER BY field1 [, ...]] [SKIP n] [LIMIT n]]
+| List all privileges.
+
+| [source, cypher]
+SHOW ROLE[S] role[, ...] PRIVILEGE[S] [AS [REVOKE] COMMAND[S]]
+    [YIELD { * \| field1[, ...] } [ORDER BY field1 [, ...]] [SKIP n] [LIMIT n]]
+    [WHERE expression]
+    [RETURN field1[, ...] [ORDER BY field1 [, ...]] [SKIP n] [LIMIT n]]
+| List privileges for a specific role.
+
+| [source, cypher]
+SHOW USER[S] [user[, ...]] PRIVILEGE[S] [AS [REVOKE] COMMAND[S]]
+    [YIELD { * \| field1[, ...] } [ORDER BY field1 [, ...]] [SKIP n] [LIMIT n]]
+    [WHERE expression]
+    [RETURN field1[, ...] [ORDER BY field1 [, ...]] [SKIP n] [LIMIT n]]
+| List privileges for a specific user, or the current user.
+
+|===

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/show-privileges-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/show-privileges-syntax.asciidoc
@@ -5,23 +5,23 @@
 
 | [source, cypher]
 SHOW [ALL] PRIVILEGE[S] [AS [REVOKE] COMMAND[S]]
-    [YIELD { * \| field1[, ...] } [ORDER BY field1 [, ...]] [SKIP n] [LIMIT n]]
+    [YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
     [WHERE expression]
-    [RETURN field1[, ...] [ORDER BY field1 [, ...]] [SKIP n] [LIMIT n]]
+    [RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
 | List all privileges.
 
 | [source, cypher]
 SHOW ROLE[S] role[, ...] PRIVILEGE[S] [AS [REVOKE] COMMAND[S]]
-    [YIELD { * \| field1[, ...] } [ORDER BY field1 [, ...]] [SKIP n] [LIMIT n]]
+    [YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
     [WHERE expression]
-    [RETURN field1[, ...] [ORDER BY field1 [, ...]] [SKIP n] [LIMIT n]]
+    [RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
 | List privileges for a specific role.
 
 | [source, cypher]
 SHOW USER[S] [user[, ...]] PRIVILEGE[S] [AS [REVOKE] COMMAND[S]]
-    [YIELD { * \| field1[, ...] } [ORDER BY field1 [, ...]] [SKIP n] [LIMIT n]]
+    [YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
     [WHERE expression]
-    [RETURN field1[, ...] [ORDER BY field1 [, ...]] [SKIP n] [LIMIT n]]
+    [RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
 | List privileges for a specific user, or the current user.
 
 |===

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
@@ -24,6 +24,9 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
       """
         |* <<administration-security-subgraph-introduction, The `GRANT`, `DENY` and `REVOKE` commands>>
         |* <<administration-security-subgraph-show, Listing privileges>>
+        |** <<administration-security-subgraph-show-all, Examples for listing all privileges>>
+        |** <<administration-security-subgraph-show-roles, Examples for listing privileges for specific roles>>
+        |** <<administration-security-subgraph-show-users, Examples for listing privileges for specific users>>
         |* <<administration-security-subgraph-revoke, The `REVOKE` command>>
         |""".stripMargin)
 
@@ -60,167 +63,173 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
       // image source: https://docs.google.com/drawings/d/1dueKAcaQORul-_Ocb5jK9bUkWgtQfdLdFw4uo7PFjTs/edit
     }
     section("Listing privileges", "administration-security-subgraph-show", "enterprise-edition") {
-      p("Available privileges for all roles can be seen using `SHOW PRIVILEGES`.")
-      p("include::show-all-privileges-syntax.asciidoc[]")
-      query("SHOW PRIVILEGES", assertPrivilegeShown(Seq(
-        Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers"),
-        Map("access" -> "DENIED", "action" -> "access", "role" -> "noAccessUsers")
-      ))) {
-        p(
-          """Lists all privileges for all roles.
-            |The table contains columns describing the privilege:
-            |
-            |* access: whether the privilege is granted or denied (whitelist or blacklist)
-            |* action: which type of privilege this is: traverse, read, match, write, a database privilege, a dbms privilege or admin
-            |* resource: what type of scope this privilege applies to: the entire dbms, a database, a graph or sub-graph access
-            |* graph: the specific database or graph this privilege applies to
-            |* segment: for sub-graph access control, this describes the scope in terms of labels or relationship types
-            |* role: the role the privilege is granted to
-            |""".stripMargin)
-        resultTable()
-      }
+      p("Available privileges for can be seen using the different `SHOW PRIVILEGES` commands.")
+      p("include::show-privileges-syntax.asciidoc[]")
+      section("Examples for listing all privileges", "administration-security-subgraph-show-all") {
+        p("Available privileges for all roles can be seen using `SHOW PRIVILEGES`.")
+        p("include::show-all-privileges-syntax.asciidoc[]")
+        query("SHOW PRIVILEGES", assertPrivilegeShown(Seq(
+          Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers"),
+          Map("access" -> "DENIED", "action" -> "access", "role" -> "noAccessUsers")
+        ))) {
+          p(
+            """Lists all privileges for all roles.
+              |The table contains columns describing the privilege:
+              |
+              |* access: whether the privilege is granted or denied (whitelist or blacklist)
+              |* action: which type of privilege this is: traverse, read, match, write, a database privilege, a dbms privilege or admin
+              |* resource: what type of scope this privilege applies to: the entire dbms, a database, a graph or sub-graph access
+              |* graph: the specific database or graph this privilege applies to
+              |* segment: for sub-graph access control, this describes the scope in terms of labels or relationship types
+              |* role: the role the privilege is granted to
+              |""".stripMargin)
+          resultTable()
+        }
 
-      p("It is also possible to filter and sort the results by using `YIELD`, `ORDER BY` and `WHERE`.")
-      query("SHOW PRIVILEGES YIELD role, access, action, segment ORDER BY action WHERE role = 'admin' ", assertPrivilegeShown(Seq(
-        Map("access" -> "GRANTED", "action" -> "access", "role" -> "admin", "segment" -> "database"),
-        Map("access" -> "GRANTED", "action" -> "write", "role" -> "admin", "segment" -> "NODE(*)"),
-        Map("access" -> "GRANTED", "action" -> "write", "role" -> "admin", "segment" -> "RELATIONSHIP(*)")
-      ))) {
-        p(
-          """In this example:
-            |
-            |* The number of columns returned has been reduced with the `YIELD` clause.
-            |* The order of the returned columns has been changed.
-            |* The results have been filtered to only return the 'admin' role using a `WHERE` clause.
-            |* The results are ordered by the 'action' column using `ORDER BY`.
-            |
-            |`SKIP` and `LIMIT` can also be used to paginate the results.
-            |""".stripMargin)
-        resultTable()
-      }
+        p("It is also possible to filter and sort the results by using `YIELD`, `ORDER BY` and `WHERE`.")
+        query("SHOW PRIVILEGES YIELD role, access, action, segment ORDER BY action WHERE role = 'admin' ", assertPrivilegeShown(Seq(
+          Map("access" -> "GRANTED", "action" -> "access", "role" -> "admin", "segment" -> "database"),
+          Map("access" -> "GRANTED", "action" -> "write", "role" -> "admin", "segment" -> "NODE(*)"),
+          Map("access" -> "GRANTED", "action" -> "write", "role" -> "admin", "segment" -> "RELATIONSHIP(*)")
+        ))) {
+          p(
+            """In this example:
+              |
+              |* The number of columns returned has been reduced with the `YIELD` clause.
+              |* The order of the returned columns has been changed.
+              |* The results have been filtered to only return the 'admin' role using a `WHERE` clause.
+              |* The results are ordered by the 'action' column using `ORDER BY`.
+              |
+              |`SKIP` and `LIMIT` can also be used to paginate the results.
+              |""".stripMargin)
+          resultTable()
+        }
 
-      p("`WHERE` can be used without `YIELD`")
-      query("SHOW PRIVILEGES WHERE graph <> '*' ", assertPrivilegeShown(Seq(
-        Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "graph" -> "neo4j"),
-        Map("access" -> "DENIED", "action" -> "access", "role" -> "noAccessUsers", "graph" -> "neo4j")
-      ))) {
-        p(
-          """In this example the `WHERE` clause is used to filter privileges down to those that target specific graphs only.""".stripMargin)
-        resultTable()
-      }
+        p("`WHERE` can be used without `YIELD`")
+        query("SHOW PRIVILEGES WHERE graph <> '*' ", assertPrivilegeShown(Seq(
+          Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "graph" -> "neo4j"),
+          Map("access" -> "DENIED", "action" -> "access", "role" -> "noAccessUsers", "graph" -> "neo4j")
+        ))) {
+          p(
+            """In this example the `WHERE` clause is used to filter privileges down to those that target specific graphs only.""".stripMargin)
+          resultTable()
+        }
 
-      p("Aggregations in the `RETURN` clause can be used to group privileges. In this case, by user and granted / denied.")
-      query("SHOW PRIVILEGES YIELD * RETURN role, access, collect([graph, resource, segment, action]) as privileges", ResultAssertions(r => {
-        assertStats(r)
-      })){
-        resultTable()
-      }
+        p("Aggregations in the `RETURN` clause can be used to group privileges. In this case, by user and granted / denied.")
+        query("SHOW PRIVILEGES YIELD * RETURN role, access, collect([graph, resource, segment, action]) as privileges", ResultAssertions(r => {
+          assertStats(r)
+        })) {
+          resultTable()
+        }
 
-      p("The `RETURN` clause can also be used to order and paginate the results, which is useful when combined with `YIELD` and `WHERE`. In this example the " +
-        "query returns privileges for display five-per-page, and skips the first five to display the second page.")
-      query("SHOW PRIVILEGES YIELD * RETURN * ORDER BY role SKIP 5 LIMIT 5", ResultAssertions(r => {
-        assertStats(r)
-      })){
-        resultTable()
+        p("The `RETURN` clause can also be used to order and paginate the results, which is useful when combined with `YIELD` and `WHERE`. In this example the " +
+          "query returns privileges for display five-per-page, and skips the first five to display the second page.")
+        query("SHOW PRIVILEGES YIELD * RETURN * ORDER BY role SKIP 5 LIMIT 5", ResultAssertions(r => {
+          assertStats(r)
+        })) {
+          resultTable()
+        }
       }
+      section("Examples for listing privileges for specific roles", "administration-security-subgraph-show-roles") {
+        p("Available privileges for specific roles can be seen using `SHOW ROLE name PRIVILEGES`.")
+        p("include::show-role-privileges-syntax.asciidoc[]")
+        query("SHOW ROLE regularUsers PRIVILEGES", assertPrivilegeShown(Seq(
+          Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "graph" -> "neo4j")
+        ))) {
+          p("Lists all privileges for role 'regularUsers'")
+          resultTable()
+        }
+        query("SHOW ROLES regularUsers, noAccessUsers PRIVILEGES", assertPrivilegeShown(Seq(
+          Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "graph" -> "neo4j"),
+          Map("access" -> "DENIED", "action" -> "access", "role" -> "noAccessUsers", "graph" -> "neo4j")
+        ))) {
+          p("Lists all privileges for roles 'regularUsers' and 'noAccessUsers'")
+          resultTable()
+        }
 
-      p("Available privileges for specific roles can be seen using `SHOW ROLE name PRIVILEGES`.")
-      p("include::show-role-privileges-syntax.asciidoc[]")
-      query("SHOW ROLE regularUsers PRIVILEGES", assertPrivilegeShown(Seq(
-        Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "graph" -> "neo4j")
-      ))) {
-        p("Lists all privileges for role 'regularUsers'")
-        resultTable()
-      }
-      query("SHOW ROLES regularUsers, noAccessUsers PRIVILEGES", assertPrivilegeShown(Seq(
-        Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "graph" -> "neo4j"),
-        Map("access" -> "DENIED", "action" -> "access", "role" -> "noAccessUsers", "graph" -> "neo4j")
-      ))) {
-        p("Lists all privileges for roles 'regularUsers' and 'noAccessUsers'")
-        resultTable()
-      }
+        p("Available privileges for roles can also be output as Cypher commands with the optional `AS COMMAND[S]`.")
+        query("SHOW ROLE admin PRIVILEGES AS COMMANDS", assertPrivilegeShown(Seq(
+          Map("command" -> "GRANT ACCESS ON DATABASE * TO `admin`"),
+          Map("command" -> "GRANT ALL DBMS PRIVILEGES ON DBMS TO `admin`"),
+          Map("command" -> "GRANT CONSTRAINT MANAGEMENT ON DATABASE * TO `admin`"),
+          Map("command" -> "GRANT INDEX MANAGEMENT ON DATABASE * TO `admin`"),
+          Map("command" -> "GRANT MATCH {*} ON GRAPH * NODE * TO `admin`"),
+          Map("command" -> "GRANT MATCH {*} ON GRAPH * RELATIONSHIP * TO `admin`"),
+          Map("command" -> "GRANT NAME MANAGEMENT ON DATABASE * TO `admin`"),
+          Map("command" -> "GRANT START ON DATABASE * TO `admin`"),
+          Map("command" -> "GRANT STOP ON DATABASE * TO `admin`"),
+          Map("command" -> "GRANT TRANSACTION MANAGEMENT (*) ON DATABASE * TO `admin`"),
+          Map("command" -> "GRANT WRITE ON GRAPH * TO `admin`"),
+        ))) {
+          resultTable()
+        }
 
-      p("Available privileges for roles can also be output as Cypher commands with the optional `AS COMMAND[S]`.")
-      query("SHOW ROLE admin PRIVILEGES AS COMMANDS", assertPrivilegeShown(Seq(
-        Map("command" -> "GRANT ACCESS ON DATABASE * TO `admin`"),
-        Map("command" -> "GRANT ALL DBMS PRIVILEGES ON DBMS TO `admin`"),
-        Map("command" -> "GRANT CONSTRAINT MANAGEMENT ON DATABASE * TO `admin`"),
-        Map("command" -> "GRANT INDEX MANAGEMENT ON DATABASE * TO `admin`"),
-        Map("command" -> "GRANT MATCH {*} ON GRAPH * NODE * TO `admin`"),
-        Map("command" -> "GRANT MATCH {*} ON GRAPH * RELATIONSHIP * TO `admin`"),
-        Map("command" -> "GRANT NAME MANAGEMENT ON DATABASE * TO `admin`"),
-        Map("command" -> "GRANT START ON DATABASE * TO `admin`"),
-        Map("command" -> "GRANT STOP ON DATABASE * TO `admin`"),
-        Map("command" -> "GRANT TRANSACTION MANAGEMENT (*) ON DATABASE * TO `admin`"),
-        Map("command" -> "GRANT WRITE ON GRAPH * TO `admin`"),
-      ))) {
-        resultTable()
-      }
+        p("Like other `SHOW` commands, the output can also be processed using `YIELD` / `WHERE` / `RETURN`.")
+        query("SHOW ROLE architect PRIVILEGES AS COMMANDS WHERE command CONTAINS 'MATCH'", assertPrivilegeShown(Seq(
+          Map("command" -> "GRANT MATCH {*} ON GRAPH * NODE * TO `architect`"),
+          Map("command" -> "GRANT MATCH {*} ON GRAPH * RELATIONSHIP * TO `architect`"),
+        ))) {
+          resultTable()
+        }
 
-      p("Like other `SHOW` commands, the output can also be processed using `YIELD` / `WHERE` / `RETURN`.")
-      query("SHOW ROLE architect PRIVILEGES AS COMMANDS WHERE command CONTAINS 'MATCH'", assertPrivilegeShown(Seq(
-        Map("command" -> "GRANT MATCH {*} ON GRAPH * NODE * TO `architect`"),
-        Map("command" -> "GRANT MATCH {*} ON GRAPH * RELATIONSHIP * TO `architect`"),
-      ))) {
-        resultTable()
+        p("It is also possible to have privileges output as revoke commands. " +
+          "For more on revoke commands, please see <<administration-security-subgraph-revoke, The REVOKE command>>.")
+        query("SHOW ROLE reader PRIVILEGES AS REVOKE COMMANDS", assertPrivilegeShown(Seq(
+          Map("command" -> "REVOKE GRANT ACCESS ON DATABASE * FROM `reader`"),
+          Map("command" -> "REVOKE GRANT MATCH {*} ON GRAPH * NODE * FROM `reader`"),
+          Map("command" -> "REVOKE GRANT MATCH {*} ON GRAPH * RELATIONSHIP * FROM `reader`"),
+        ))) {
+          resultTable()
+        }
       }
+      section("Examples for listing privileges for specific users", "administration-security-subgraph-show-users") {
+        p("Available privileges for specific users can be seen using `SHOW USER name PRIVILEGES`.")
+        note {
+          p("Please note that if a non-native auth provider like LDAP is in use, `SHOW USER PRIVILEGES` will only work in a limited capacity; " +
+            "It is only possible for a user to show their own privileges. Other users' privileges cannot be listed when using a non-native auth provider.")
+        }
 
-      p("It is also possible to have privileges output as revoke commands. " +
-        "For more on revoke commands, please see <<administration-security-subgraph-revoke, The REVOKE command>>.")
-      query("SHOW ROLE reader PRIVILEGES AS REVOKE COMMANDS", assertPrivilegeShown(Seq(
-        Map("command" -> "REVOKE GRANT ACCESS ON DATABASE * FROM `reader`"),
-        Map("command" -> "REVOKE GRANT MATCH {*} ON GRAPH * NODE * FROM `reader`"),
-        Map("command" -> "REVOKE GRANT MATCH {*} ON GRAPH * RELATIONSHIP * FROM `reader`"),
-      ))) {
-        resultTable()
-      }
+        p("include::show-user-privileges-syntax.asciidoc[]")
+        query("SHOW USER jake PRIVILEGES", assertPrivilegeShown(Seq(
+          Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "user" -> "jake")
+        ))) {
+          p("Lists all privileges for user 'jake'")
+          resultTable()
+        }
+        query("SHOW USERS jake, joe PRIVILEGES", assertPrivilegeShown(Seq(
+          Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "user" -> "jake"),
+          Map("access" -> "DENIED", "action" -> "access", "role" -> "noAccessUsers", "user" -> "joe")
+        ))) {
+          p("Lists all privileges for users 'jake' and 'joe'")
+          resultTable()
+        }
 
-      p("Available privileges for specific users can be seen using `SHOW USER name PRIVILEGES`.")
-      note {
-        p("Please note that if a non-native auth provider like LDAP is in use, `SHOW USER PRIVILEGES` will only work in a limited capacity; " +
-          "It is only possible for a user to show their own privileges. Other users' privileges cannot be listed when using a non-native auth provider.")
-      }
+        p("The same command can be used at all times to review available privileges for the current user. " +
+          "For this purpose, a shorter form of the the command also exists: SHOW USER PRIVILEGES.")
+        query("SHOW USER PRIVILEGES", ResultAssertions(r => {
+          assertStats(r)
+        })){}
 
-      p("include::show-user-privileges-syntax.asciidoc[]")
-      query("SHOW USER jake PRIVILEGES", assertPrivilegeShown(Seq(
-        Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "user" -> "jake")
-      ))) {
-        p("Lists all privileges for user 'jake'")
-        resultTable()
-      }
-      query("SHOW USERS jake, joe PRIVILEGES", assertPrivilegeShown(Seq(
-        Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "user" -> "jake"),
-        Map("access" -> "DENIED", "action" -> "access", "role" -> "noAccessUsers", "user" -> "joe")
-      ))) {
-        p("Lists all privileges for users 'jake' and 'joe'")
-        resultTable()
-      }
+        p("Available privileges for users can also be output as Cypher commands with the optional `AS COMMAND[S]`.")
+        note {
+          p("When showing _user_ privileges as commands, the roles in the Cypher commands are replaced with a parameter. " +
+            "This can be used to quickly create new roles based on the privileges of specific users.")
+        }
+        query("SHOW USER jake PRIVILEGES AS COMMANDS", assertPrivilegeShown(Seq(
+          Map("command" -> "GRANT ACCESS ON DATABASE `neo4j` TO $role"),
+          Map("command" -> "GRANT ACCESS ON DEFAULT DATABASE TO $role"),
+          Map("command" -> "GRANT EXECUTE PROCEDURE * ON DBMS TO $role"),
+        ))) {
+          resultTable()
+        }
 
-      p("The same command can be used at all times to review available privileges for the current user. " +
-        "For this purpose, a shorter form of the the command also exists: SHOW USER PRIVILEGES.")
-      query("SHOW USER PRIVILEGES", ResultAssertions(r => {
-        assertStats(r)
-      })){}
-
-      p("Available privileges for users can also be output as Cypher commands with the optional `AS COMMAND[S]`.")
-      note {
-        p("When showing _user_ privileges as commands, the roles in the Cypher commands are replaced with a parameter. " +
-          "This can be used to quickly create new roles based on the privileges of specific users.")
-      }
-      query("SHOW USER jake PRIVILEGES AS COMMANDS", assertPrivilegeShown(Seq(
-        Map("command" -> "GRANT ACCESS ON DATABASE `neo4j` TO $role"),
-        Map("command" -> "GRANT ACCESS ON DEFAULT DATABASE TO $role"),
-        Map("command" -> "GRANT EXECUTE PROCEDURE * ON DBMS TO $role"),
-      ))) {
-        resultTable()
-      }
-
-      p("Like other `SHOW` commands, the output can also be processed using `YIELD` / `WHERE` / `RETURN`. " +
-        "Additionally, just as with role privileges, it is also possible to show user privileges as revoke commands.")
-      query("SHOW USER jake PRIVILEGES AS REVOKE COMMANDS WHERE command CONTAINS 'EXECUTE'", assertPrivilegeShown(Seq(
-        Map("command" -> "REVOKE GRANT EXECUTE PROCEDURE * ON DBMS FROM $role"),
-      ))) {
-        resultTable()
+        p("Like other `SHOW` commands, the output can also be processed using `YIELD` / `WHERE` / `RETURN`. " +
+          "Additionally, just as with role privileges, it is also possible to show user privileges as revoke commands.")
+        query("SHOW USER jake PRIVILEGES AS REVOKE COMMANDS WHERE command CONTAINS 'EXECUTE'", assertPrivilegeShown(Seq(
+          Map("command" -> "REVOKE GRANT EXECUTE PROCEDURE * ON DBMS FROM $role"),
+        ))) {
+          resultTable()
+        }
       }
     }
 

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
@@ -63,10 +63,10 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
       // image source: https://docs.google.com/drawings/d/1dueKAcaQORul-_Ocb5jK9bUkWgtQfdLdFw4uo7PFjTs/edit
     }
     section("Listing privileges", "administration-security-subgraph-show", "enterprise-edition") {
-      p("Available privileges for can be seen using the different `SHOW PRIVILEGES` commands.")
+      p("Available privileges can be displayed using the different `SHOW PRIVILEGES` commands.")
       p("include::show-privileges-syntax.asciidoc[]")
       section("Examples for listing all privileges", "administration-security-subgraph-show-all") {
-        p("Available privileges for all roles can be seen using `SHOW PRIVILEGES`.")
+        p("Available privileges for all roles can be displayed using `SHOW PRIVILEGES`.")
         p("include::show-all-privileges-syntax.asciidoc[]")
         query("SHOW PRIVILEGES", assertPrivilegeShown(Seq(
           Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers"),
@@ -76,7 +76,7 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
             """Lists all privileges for all roles.
               |The table contains columns describing the privilege:
               |
-              |* access: whether the privilege is granted or denied (whitelist or blacklist)
+              |* access: whether the privilege is granted or denied
               |* action: which type of privilege this is: traverse, read, match, write, a database privilege, a dbms privilege or admin
               |* resource: what type of scope this privilege applies to: the entire dbms, a database, a graph or sub-graph access
               |* graph: the specific database or graph this privilege applies to
@@ -97,7 +97,7 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
               |
               |* The number of columns returned has been reduced with the `YIELD` clause.
               |* The order of the returned columns has been changed.
-              |* The results have been filtered to only return the 'admin' role using a `WHERE` clause.
+              |* The results have been filtered to only return the `admin` role using a `WHERE` clause.
               |* The results are ordered by the 'action' column using `ORDER BY`.
               |
               |`SKIP` and `LIMIT` can also be used to paginate the results.
@@ -111,7 +111,7 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
           Map("access" -> "DENIED", "action" -> "access", "role" -> "noAccessUsers", "graph" -> "neo4j")
         ))) {
           p(
-            """In this example the `WHERE` clause is used to filter privileges down to those that target specific graphs only.""".stripMargin)
+            """In this example, the `WHERE` clause is used to filter privileges down to those that target specific graphs only.""".stripMargin)
           resultTable()
         }
 
@@ -131,19 +131,19 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
         }
       }
       section("Examples for listing privileges for specific roles", "administration-security-subgraph-show-roles") {
-        p("Available privileges for specific roles can be seen using `SHOW ROLE name PRIVILEGES`.")
+        p("Available privileges for specific roles can be displayed using `SHOW ROLE name PRIVILEGES`.")
         p("include::show-role-privileges-syntax.asciidoc[]")
         query("SHOW ROLE regularUsers PRIVILEGES", assertPrivilegeShown(Seq(
           Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "graph" -> "neo4j")
         ))) {
-          p("Lists all privileges for role 'regularUsers'.")
+          p("Lists all privileges for role `regularUsers`.")
           resultTable()
         }
         query("SHOW ROLES regularUsers, noAccessUsers PRIVILEGES", assertPrivilegeShown(Seq(
           Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "graph" -> "neo4j"),
           Map("access" -> "DENIED", "action" -> "access", "role" -> "noAccessUsers", "graph" -> "neo4j")
         ))) {
-          p("Lists all privileges for roles 'regularUsers' and 'noAccessUsers'.")
+          p("Lists all privileges for roles `regularUsers` and `noAccessUsers`.")
           resultTable()
         }
 
@@ -183,7 +183,7 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
         }
       }
       section("Examples for listing privileges for specific users", "administration-security-subgraph-show-users") {
-        p("Available privileges for specific users can be seen using `SHOW USER name PRIVILEGES`.")
+        p("Available privileges for specific users can be displayed using `SHOW USER name PRIVILEGES`.")
         note {
           p("Please note that if a non-native auth provider like LDAP is in use, `SHOW USER PRIVILEGES` will only work in a limited capacity; " +
             "It is only possible for a user to show their own privileges. Other users' privileges cannot be listed when using a non-native auth provider.")
@@ -193,14 +193,14 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
         query("SHOW USER jake PRIVILEGES", assertPrivilegeShown(Seq(
           Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "user" -> "jake")
         ))) {
-          p("Lists all privileges for user 'jake'.")
+          p("Lists all privileges for user `jake`.")
           resultTable()
         }
         query("SHOW USERS jake, joe PRIVILEGES", assertPrivilegeShown(Seq(
           Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "user" -> "jake"),
           Map("access" -> "DENIED", "action" -> "access", "role" -> "noAccessUsers", "user" -> "joe")
         ))) {
-          p("Lists all privileges for users 'jake' and 'joe'.")
+          p("Lists all privileges for users `jake` and `joe`.")
           resultTable()
         }
 

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
@@ -76,12 +76,12 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
             """Lists all privileges for all roles.
               |The table contains columns describing the privilege:
               |
-              |* access: whether the privilege is granted or denied
-              |* action: which type of privilege this is: traverse, read, match, write, a database privilege, a dbms privilege or admin
-              |* resource: what type of scope this privilege applies to: the entire dbms, a database, a graph or sub-graph access
-              |* graph: the specific database or graph this privilege applies to
-              |* segment: for sub-graph access control, this describes the scope in terms of labels or relationship types
-              |* role: the role the privilege is granted to
+              |* `access`: whether the privilege is granted or denied
+              |* `action`: which type of privilege this is: traverse, read, match, write, a database privilege, a dbms privilege or admin
+              |* `resource`: what type of scope this privilege applies to: the entire dbms, a database, a graph or sub-graph access
+              |* `graph`: the specific database or graph this privilege applies to
+              |* `segment`: for sub-graph access control, this describes the scope in terms of labels or relationship types
+              |* `role`: the role the privilege is granted to
               |""".stripMargin)
           resultTable()
         }
@@ -98,7 +98,7 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
               |* The number of columns returned has been reduced with the `YIELD` clause.
               |* The order of the returned columns has been changed.
               |* The results have been filtered to only return the `admin` role using a `WHERE` clause.
-              |* The results are ordered by the 'action' column using `ORDER BY`.
+              |* The results are ordered by the `action` column using `ORDER BY`.
               |
               |`SKIP` and `LIMIT` can also be used to paginate the results.
               |""".stripMargin)

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
@@ -136,14 +136,14 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
         query("SHOW ROLE regularUsers PRIVILEGES", assertPrivilegeShown(Seq(
           Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "graph" -> "neo4j")
         ))) {
-          p("Lists all privileges for role 'regularUsers'")
+          p("Lists all privileges for role 'regularUsers'.")
           resultTable()
         }
         query("SHOW ROLES regularUsers, noAccessUsers PRIVILEGES", assertPrivilegeShown(Seq(
           Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "graph" -> "neo4j"),
           Map("access" -> "DENIED", "action" -> "access", "role" -> "noAccessUsers", "graph" -> "neo4j")
         ))) {
-          p("Lists all privileges for roles 'regularUsers' and 'noAccessUsers'")
+          p("Lists all privileges for roles 'regularUsers' and 'noAccessUsers'.")
           resultTable()
         }
 
@@ -193,14 +193,14 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
         query("SHOW USER jake PRIVILEGES", assertPrivilegeShown(Seq(
           Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "user" -> "jake")
         ))) {
-          p("Lists all privileges for user 'jake'")
+          p("Lists all privileges for user 'jake'.")
           resultTable()
         }
         query("SHOW USERS jake, joe PRIVILEGES", assertPrivilegeShown(Seq(
           Map("access" -> "GRANTED", "action" -> "access", "role" -> "regularUsers", "user" -> "jake"),
           Map("access" -> "DENIED", "action" -> "access", "role" -> "noAccessUsers", "user" -> "joe")
         ))) {
-          p("Lists all privileges for users 'jake' and 'joe'")
+          p("Lists all privileges for users 'jake' and 'joe'.")
           resultTable()
         }
 


### PR DESCRIPTION
Since we now have more than one example for each version of the `SHOW PRIVILEGES` commands it got a bit hard to see what versions were available