### PR TITLE
Fix port clashes when running tests in parallel or alongside Neo4J

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ConstraintsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ConstraintsTest.scala
@@ -38,7 +38,8 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
   override def parent: Option[String] = Some("Administration")
   override def section: String = "Constraints"
 
-  override protected def newDatabaseManagementService(directory: File): DatabaseManagementService = new EnterpriseDatabaseManagementServiceBuilder(directory).build()
+  override protected def newDatabaseManagementService(directory: File): DatabaseManagementService = new EnterpriseDatabaseManagementServiceBuilder(directory)
+    .setConfig(databaseConfig()).build()
 
   private val nativeProvider = GenericNativeIndexProvider.DESCRIPTOR.name()
   private val nativeLuceneProvider = NativeLuceneFusionIndexProviderFactory30.DESCRIPTOR.name()

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentingTestBase.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentingTestBase.scala
@@ -21,11 +21,14 @@ package org.neo4j.cypher.docgen
 
 import java.io.{ByteArrayOutputStream, File, PrintWriter, StringWriter}
 import java.nio.charset.StandardCharsets
+import java.util
 import java.util.concurrent.TimeUnit
 
+import com.neo4j.configuration.OnlineBackupSettings
 import org.apache.commons.io.FileUtils
 import org.junit.{After, Before}
 import org.neo4j.configuration.GraphDatabaseSettings.DEFAULT_DATABASE_NAME
+import org.neo4j.configuration.helpers.SocketAddress
 import org.neo4j.cypher.docgen.tooling.{DocsExecutionResult, Prettifier}
 import org.neo4j.cypher.example.JavaExecutionEngineDocTest
 import org.neo4j.cypher.export.{DatabaseSubGraph, SubGraphExporter}
@@ -40,6 +43,7 @@ import org.neo4j.doc.test.GraphDescription
 import org.neo4j.doc.tools.AsciiDocGenerator
 import org.neo4j.exceptions.Neo4jException
 import org.neo4j.graphdb._
+import org.neo4j.graphdb.config.Setting
 import org.neo4j.internal.kernel.api.security.SecurityContext
 import org.neo4j.kernel.api.KernelTransaction.Type
 import org.neo4j.kernel.impl.api.index.IndexingService
@@ -544,7 +548,15 @@ abstract class DocumentingTestBase extends JUnitSuite with DocumentationHelper w
     hardReset()
   }
 
-  protected def newDatabaseManagementService(directory: File): DatabaseManagementService = new DatabaseManagementServiceBuilder(directory).build()
+  protected def databaseConfig(): util.Map[Setting[_], Object] =
+    Map[Setting[_], Object](
+      OnlineBackupSettings.online_backup_listen_address -> new SocketAddress("127.0.0.1", 0),
+      OnlineBackupSettings.online_backup_enabled -> java.lang.Boolean.FALSE
+    ).asJava
+
+  protected def newDatabaseManagementService(directory: File): DatabaseManagementService = {
+    new DatabaseManagementServiceBuilder(directory).setConfig(databaseConfig()).build()
+  }
 
   override def hardReset() {
     tearDown()

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
@@ -29,7 +29,8 @@ import org.neo4j.dbms.api.DatabaseManagementService
 
 class QueryPlanTest extends DocumentingTestBase with SoftReset {
 
-  override protected def newDatabaseManagementService(directory: File): DatabaseManagementService = new EnterpriseDatabaseManagementServiceBuilder(directory).build()
+  override protected def newDatabaseManagementService(directory: File): DatabaseManagementService =
+    new EnterpriseDatabaseManagementServiceBuilder(directory).setConfig(databaseConfig()).build()
 
   override val setupQueries = List(
     """CREATE (me:Person {name: 'me'})

--- a/cypher/pom.xml
+++ b/cypher/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <license-text.header>../build/GPL-3-header.txt</license-text.header>
-        <scala.version>2.12.7</scala.version>
+        <scala.version>2.12.10</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <hsqldb.version>2.3.2</hsqldb.version>
     </properties>

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/RefcardTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/RefcardTest.scala
@@ -22,11 +22,13 @@ package org.neo4j.cypher.docgen
 import java.io._
 import java.nio.charset.StandardCharsets
 
+import com.neo4j.configuration.OnlineBackupSettings
 import com.neo4j.dbms.api.EnterpriseDatabaseManagementServiceBuilder
 import org.apache.commons.io.FileUtils
 import org.apache.maven.artifact.versioning.ComparableVersion
 import org.junit.{After, Before, Test}
 import org.neo4j.configuration.GraphDatabaseSettings.DEFAULT_DATABASE_NAME
+import org.neo4j.configuration.helpers.SocketAddress
 import org.neo4j.cypher.GraphIcing
 import org.neo4j.cypher.docgen.tooling.{DocsExecutionResult, Prettifier}
 import org.neo4j.cypher.internal.ExecutionEngine
@@ -36,6 +38,7 @@ import org.neo4j.dbms.api.DatabaseManagementService
 import org.neo4j.doc.test.{GraphDatabaseServiceCleaner, GraphDescription}
 import org.neo4j.exceptions.{InternalException, Neo4jException}
 import org.neo4j.graphdb._
+import org.neo4j.graphdb.config.Setting
 import org.neo4j.kernel.api.KernelTransaction
 import org.neo4j.kernel.impl.coreapi.InternalTransaction
 import org.neo4j.kernel.impl.query.Neo4jTransactionalContextFactory
@@ -286,7 +289,13 @@ abstract class RefcardTest extends Assertions with DocumentationHelper with Grap
 
   protected def cleanGraph: Unit = GraphDatabaseServiceCleaner.cleanDatabaseContent(db.getGraphDatabaseService)
 
-  protected def newDatabaseManagementService(directory: File): DatabaseManagementService = new EnterpriseDatabaseManagementServiceBuilder(directory).build()
+  protected def newDatabaseManagementService(directory: File): DatabaseManagementService =
+    new EnterpriseDatabaseManagementServiceBuilder(directory)
+      .setConfig(Map[Setting[_], Object](
+        OnlineBackupSettings.online_backup_listen_address -> new SocketAddress("127.0.0.1", 0),
+        OnlineBackupSettings.online_backup_enabled -> java.lang.Boolean.FALSE
+      ).asJava)
+      .build()
 
 }
 

--- a/procedures/src/main/java/org/neo4j/doc/Neo4jInstance.java
+++ b/procedures/src/main/java/org/neo4j/doc/Neo4jInstance.java
@@ -22,14 +22,17 @@
  */
 package org.neo4j.doc;
 
+import com.neo4j.configuration.OnlineBackupSettings;
 import com.neo4j.dbms.api.EnterpriseDatabaseManagementServiceBuilder;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Map;
 
 import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.configuration.helpers.SocketAddress;
 import org.neo4j.dbms.api.DatabaseManagementService;
 import org.neo4j.dbms.api.DatabaseManagementServiceBuilder;
 
@@ -40,7 +43,11 @@ public class Neo4jInstance {
     public DatabaseManagementService newEnterpriseInstance() throws IOException {
         Files.createDirectories( baseDatabaseDirectory );
         DatabaseManagementService managementService =
-                new EnterpriseDatabaseManagementServiceBuilder( databaseDirectory() ).setConfig( GraphDatabaseSettings.auth_enabled, true ).build();
+                new EnterpriseDatabaseManagementServiceBuilder( databaseDirectory() ).setConfig(
+                        Map.of( OnlineBackupSettings.online_backup_listen_address, new SocketAddress( "127.0.0.1", 0 ),
+                                OnlineBackupSettings.online_backup_enabled, java.lang.Boolean.FALSE,
+                                GraphDatabaseSettings.auth_enabled, true
+                        ) ).build();
         registerShutdownHook(managementService);
         return managementService;
     }

--- a/procedures/src/main/java/org/neo4j/doc/ProcedureReferenceGenerator.java
+++ b/procedures/src/main/java/org/neo4j/doc/ProcedureReferenceGenerator.java
@@ -157,7 +157,7 @@ public class ProcedureReferenceGenerator {
             this.signature = (String) row.get("signature");
             this.description = (String) row.get("description");
             this.mode = (String) row.get("mode");
-            this.roles = (List<String>) row.get("roles");
+            this.roles = (List<String>) row.get("defaultBuiltInRoles");
             this.enterpriseOnly = false;
         }
 

--- a/server-docs/src/test/java/org/neo4j/doc/server/NeoServerJAXRSDocIT.java
+++ b/server-docs/src/test/java/org/neo4j/doc/server/NeoServerJAXRSDocIT.java
@@ -79,6 +79,7 @@ public class NeoServerJAXRSDocIT extends ExclusiveWebContainerTestBase
                 .withThirdPartyJaxRsPackage( "org.dummy.doc.web.service",
                         DummyThirdPartyWebService.DUMMY_WEB_SERVICE_MOUNT_POINT )
                 .usingDataDir( new File( folder, name.getMethodName() ).getAbsolutePath() )
+                .onRandomPorts()
                 .build();
 
         URI thirdPartyServiceUri = new URI( webContainer.getBaseUri()

--- a/server-docs/src/test/java/org/neo4j/doc/server/TransactionTimeoutDocIT.java
+++ b/server-docs/src/test/java/org/neo4j/doc/server/TransactionTimeoutDocIT.java
@@ -52,7 +52,10 @@ public class TransactionTimeoutDocIT extends ExclusiveWebContainerTestBase
     public void shouldHonorReallyLowSessionTimeout() throws Exception
     {
         // Given
-        webContainer = builder().withProperty( ServerSettings.transaction_idle_timeout.name(), "1" ).usingDataDir( folder.getAbsolutePath() ).build();
+        webContainer = builder()
+                .withProperty( ServerSettings.transaction_idle_timeout.name(), "1" )
+                .onRandomPorts()
+                .usingDataDir( folder.getAbsolutePath() ).build();
 
         String tx = HTTP.POST( txURI(), Collections.singletonList(map("statement", "CREATE (n)"))).location();
 

--- a/server-docs/src/test/java/org/neo4j/doc/server/rest/security/CommunityServerTestBase.java
+++ b/server-docs/src/test/java/org/neo4j/doc/server/rest/security/CommunityServerTestBase.java
@@ -59,6 +59,7 @@ public class CommunityServerTestBase extends ExclusiveWebContainerTestBase
         webContainer = builder()
                 .usingDataDir( folder.getAbsolutePath() )
                 .withProperty( GraphDatabaseSettings.auth_enabled.name(), Boolean.toString( authEnabled ) )
+                .onRandomPorts()
                 .build();
     }
 

--- a/server-test-utils/src/main/java/org/neo4j/doc/server/WebContainerHolder.java
+++ b/server-test-utils/src/main/java/org/neo4j/doc/server/WebContainerHolder.java
@@ -106,7 +106,7 @@ public final class WebContainerHolder extends Thread
     {
         if ( builder == null )
         {
-            builder = CommunityWebContainerBuilder.builder();
+            builder = CommunityWebContainerBuilder.serverOnRandomPorts();
         }
     }
 

--- a/server-test-utils/src/main/java/org/neo4j/doc/server/helpers/CommunityWebContainerBuilder.java
+++ b/server-test-utils/src/main/java/org/neo4j/doc/server/helpers/CommunityWebContainerBuilder.java
@@ -31,6 +31,7 @@ import org.neo4j.common.DependencyResolver;
 import org.neo4j.configuration.Config;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.configuration.SettingValueParsers;
+import org.neo4j.configuration.connectors.BoltConnector;
 import org.neo4j.configuration.connectors.HttpConnector;
 import org.neo4j.configuration.connectors.HttpsConnector;
 import org.neo4j.configuration.helpers.SocketAddress;
@@ -62,6 +63,7 @@ public class CommunityWebContainerBuilder
     private final LogProvider logProvider;
     private SocketAddress address = new SocketAddress( "localhost", HttpConnector.DEFAULT_PORT );
     private SocketAddress httpsAddress = new SocketAddress( "localhost", HttpsConnector.DEFAULT_PORT );
+    private SocketAddress boltAddress = new SocketAddress( "localhost", BoltConnector.DEFAULT_PORT );
     private String maxThreads;
     private String dataDir;
     private String dbUri = "/db";
@@ -166,6 +168,8 @@ public class CommunityWebContainerBuilder
         properties.put( HttpsConnector.enabled.name(), String.valueOf( httpsEnabled ) );
         properties.put( HttpsConnector.listen_address.name(), httpsAddress.toString() );
 
+        properties.put( BoltConnector.listen_address.name(), boltAddress.toString() );
+
         properties.put( GraphDatabaseSettings.neo4j_home.name(), temporaryFolder.toAbsolutePath().toString() );
 
         properties.put( GraphDatabaseSettings.auth_enabled.name(), FALSE );
@@ -251,6 +255,7 @@ public class CommunityWebContainerBuilder
     {
         this.onHttpsAddress( ANY_ADDRESS );
         this.onAddress( ANY_ADDRESS );
+        this.onBoltAddress( ANY_ADDRESS );
         return this;
     }
 
@@ -263,6 +268,12 @@ public class CommunityWebContainerBuilder
     public CommunityWebContainerBuilder onHttpsAddress( SocketAddress address )
     {
         this.httpsAddress = address;
+        return this;
+    }
+
+    public CommunityWebContainerBuilder onBoltAddress( SocketAddress address )
+    {
+        this.boltAddress = address;
         return this;
     }
 


### PR DESCRIPTION
* Fix port clashes on online backup and rest server to allow tests to run alongside a neo4j server
* Update Scala version to match product