### PR TITLE
Updates around comma separated lists

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/admin-database-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/admin-database-syntax.asciidoc
@@ -5,79 +5,79 @@
 
 | [source, cypher]
 GRANT ACCESS
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
+    ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}}
     TO role[, ...]
 | Grant the specified roles the privilege to access the default database, specific database(s), or all databases.
 
 | [source, cypher]
 GRANT {START \| STOP}
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
+    ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}}
     TO role[, ...]
 | Grant the specified roles the privilege to start and stop the default database, specific database(s), or all databases.
 
 | [source, cypher]
 GRANT {CREATE \| DROP} INDEX[ES]
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
+    ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}}
     TO role[, ...]
 | Grant the specified roles the privilege to create and delete indexes on the default database, specific database(s), or all databases.
 
 | [source, cypher]
 GRANT INDEX[ES] [MANAGEMENT]
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
+    ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}}
     TO role[, ...]
 | Grant the specified roles the privilege to manage indexes on the default database, specific database(s), or all databases.
 
 | [source, cypher]
 GRANT {CREATE \| DROP} CONSTRAINT[S]
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
+    ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}}
     TO role[, ...]
 | Grant the specified roles the privilege to create and delete constraints on the default database, specific database(s), or all databases.
 
 | [source, cypher]
 GRANT CONSTRAINT[S] [MANAGEMENT]
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
+    ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}}
     TO role[, ...]
 | Grant the specified roles the privilege to manage constraints on the default database, specific database(s), or all databases.
 
 | [source, cypher]
 GRANT CREATE NEW [NODE] LABEL[S]
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
+    ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}}
     TO role[, ...]
 | Grant the specified roles the privilege to create new node labels in the default database, specific database(s), or all databases.
 
 | [source, cypher]
 GRANT CREATE NEW [RELATIONSHIP] TYPE[S]
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
+    ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}}
     TO role[, ...]
 | Grant the specified roles the privilege to create new relationships types in the default database, specific database(s), or all databases.
 
 | [source, cypher]
 GRANT CREATE NEW [PROPERTY] NAME[S]
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
+    ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}}
     TO role[, ...]
 | Grant the specified roles the privilege to create new property names in the default database, specific database(s), or all databases.
 
 | [source, cypher]
 GRANT NAME [MANAGEMENT]
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
+    ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}}
     TO role[, ...]
 | Grant the specified roles the privilege to manage new labels, relationship types, and property names in the default database, specific database(s), or all databases.
 
 | [source, cypher]
 GRANT ALL [[DATABASE] PRIVILEGES]
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
+    ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}}
     TO role[, ...]
 | Grant the specified roles all privileges for the default database, specific database(s), or all databases.
 
 | [source, cypher]
 GRANT {SHOW \| TERMINATE} TRANSACTION[S] [( {* \| user[, ...]} )]
-ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
+ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}}
 TO role[, ...]
 | Grant the specified roles the privilege to list and end the transactions and queries of all users or a particular user(s) in the default database, specific database(s), or all databases.
 
 | [source, cypher]
 GRANT TRANSACTION [MANAGEMENT] [( {* \| user[, ...]} )]
-ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
+ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}}
 TO role[, ...]
 | Grant the specified roles the privilege to manage the transactions and queries of all users or a particular user(s) in the default database, specific database(s), or all databases.
 

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/admin-role-database.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/admin-role-database.asciidoc
@@ -47,23 +47,23 @@ Databases created after this command execution will also be associated with thes
 | Command | Description
 
 | [source, cypher]
-GRANT database-privilege ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}} TO role[, ...]
+GRANT database-privilege ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}} TO role[, ...]
 | Grant a privilege to one or multiple roles.
 
 | [source, cypher]
-DENY database-privilege ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}} TO role[, ...]
+DENY database-privilege ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}} TO role[, ...]
 | Deny a privilege to one or multiple roles.
 
 | [source, cypher]
-REVOKE GRANT database-privilege ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}} FROM role[, ...]
+REVOKE GRANT database-privilege ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}} FROM role[, ...]
 | Revoke a granted privilege from one or multiple roles.
 
 | [source, cypher]
-REVOKE DENY database-privilege ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}} FROM role[, ...]
+REVOKE DENY database-privilege ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}} FROM role[, ...]
 | Revoke a denied privilege from one or multiple roles.
 
 | [source, cypher]
-REVOKE database-privilege ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}} FROM role[, ...]
+REVOKE database-privilege ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}} FROM role[, ...]
 | Revoke a granted or denied privilege from one or multiple roles.
 |===
 

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/all-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/all-management-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 GRANT ALL [[DATABASE] PRIVILEGES]
-    ON {DEFAULT DATABASE | DATABASE[S] {name [, ...] | *}}
+    ON {DEFAULT DATABASE | DATABASE[S] {name[, ...] | *}}
     TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/constraint-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/constraint-management-syntax.asciidoc
@@ -5,14 +5,14 @@
 
 | [source, cypher]
 GRANT {CREATE \| DROP} CONSTRAINT[S]
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
-    TO role [, ...]
+    ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}}
+    TO role[, ...]
 | Enable the specified roles to create or delete constraints on the default database, specific database(s), or all databases.
 
 | [source, cypher]
 GRANT CONSTRAINT[S] [MANAGEMENT]
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
-    TO role [, ...]
+    ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}}
+    TO role[, ...]
 | Enable the specified roles to manage constraints on the default database, specific database(s), or all databases.
 
 |===

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/deny-database-access-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/deny-database-access-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 DENY ACCESS
-    ON {DEFAULT DATABASE | DATABASE[S] {name [, ...] | *}}
-    TO role [, ...]
+    ON {DEFAULT DATABASE | DATABASE[S] {name[, ...] | *}}
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/deny-database-start-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/deny-database-start-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 DENY START
-    ON {DEFAULT DATABASE | DATABASE[S] {name [, ...] | *}}
-    TO role [, ...]
+    ON {DEFAULT DATABASE | DATABASE[S] {name[, ...] | *}}
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/deny-database-stop-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/deny-database-stop-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 DENY STOP
-    ON {DEFAULT DATABASE | DATABASE[S] {name [, ...] | *}}
-    TO role [, ...]
+    ON {DEFAULT DATABASE | DATABASE[S] {name[, ...] | *}}
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/grant-database-access-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/grant-database-access-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 GRANT ACCESS
-    ON {DEFAULT DATABASE | DATABASE[S] {name [, ...] | *}}
-    TO role [, ...]
+    ON {DEFAULT DATABASE | DATABASE[S] {name[, ...] | *}}
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/grant-database-start-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/grant-database-start-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 GRANT START
-    ON {DEFAULT DATABASE | DATABASE[S] {name [, ...] | *}}
-    TO role [, ...]
+    ON {DEFAULT DATABASE | DATABASE[S] {name[, ...] | *}}
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/grant-database-stop-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/grant-database-stop-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 GRANT STOP
-    ON {DEFAULT DATABASE | DATABASE[S] {name [, ...] | *}}
-    TO role [, ...]
+    ON {DEFAULT DATABASE | DATABASE[S] {name[, ...] | *}}
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/index-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/index-management-syntax.asciidoc
@@ -5,14 +5,14 @@
 
 | [source, cypher]
 GRANT {CREATE \| DROP} INDEX[ES]
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
-    TO role [, ...]
+    ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}}
+    TO role[, ...]
 | Enable the specified roles to create or delete indexes in the default database, specific database(s), or all databases.
 
 | [source, cypher]
 GRANT INDEX[ES] [MANAGEMENT]
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
-    TO role [, ...]
+    ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}}
+    TO role[, ...]
 | Enable the specified roles to manage indexes in the default database, specific database(s), or all databases.
 
 |===

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/name-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/name-management-syntax.asciidoc
@@ -5,26 +5,26 @@
 
 | [source, cypher]
 GRANT CREATE NEW [NODE] LABEL[S]
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
-    TO role [, ...]
+    ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}}
+    TO role[, ...]
 | Enable the specified roles to create new node labels in the default database, specific database(s), or all databases.
 
 | [source, cypher]
 GRANT CREATE NEW [RELATIONSHIP] TYPE[S]
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
-    TO role [, ...]
+    ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}}
+    TO role[, ...]
 | Enable the specified roles to create new relationship types in the default database, specific database(s), or all databases.
 
 | [source, cypher]
 GRANT CREATE NEW [PROPERTY] NAME[S]
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
-    TO role [, ...]
+    ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}}
+    TO role[, ...]
 | Enable the specified roles to create new property names in the default database, specific database(s), or all databases.
 
 | [source, cypher]
 GRANT NAME [MANAGEMENT]
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...] \| *}}
-    TO role [, ...]
+    ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...] \| *}}
+    TO role[, ...]
 | Enable the specified roles to create new labels, relationship types, and property names in the default database, specific database(s), or all databases.
 
 |===

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/transaction-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/database/transaction-management-syntax.asciidoc
@@ -5,20 +5,20 @@
 
 | [source, cypher]
 GRANT SHOW TRANSACTION[S] [( {* \| user[, ...]} )]
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...]\| *}}
-    TO role [, ...]
+    ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...]\| *}}
+    TO role[, ...]
 | Enable the specified roles to list transactions and queries for user(s) or all users in the default database, specific database(s), or all databases.
 
 | [source, cypher]
 GRANT TERMINATE TRANSACTION[S] [( {* \| user[, ...]} )]
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...]\| *}}
-    TO role [, ...]
+    ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...]\| *}}
+    TO role[, ...]
 | Enable the specified roles to end running transactions and queries for user(s) or all users in the default database, specific database(s), or all databases.
 
 | [source, cypher]
 GRANT TRANSACTION [MANAGEMENT] [( {* \| user[, ...]} )]
-    ON {DEFAULT DATABASE \| DATABASE[S] {name [, ...]\| *}}
-    TO role [, ...]
+    ON {DEFAULT DATABASE \| DATABASE[S] {name[, ...]\| *}}
+    TO role[, ...]
 | Enable the specified roles to manage transactions and queries for user(s) or all users in the default database, specific database(s), or all databases.
 
 |===

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-all-graph-privileges-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-all-graph-privileges-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 DENY ALL [ [ GRAPH ] PRIVILEGES ]
-    ON GRAPH[S] {name [, ...] | * }
-    TO role [, ...]
+    ON GRAPH[S] {name[, ...] | * }
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-create-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-create-syntax.asciidoc
@@ -7,5 +7,5 @@ DENY CREATE ON GRAPH[S] { * | graph-name[,...] }
         | NODE[S] { * | label-name[,...] }
         | RELATIONSHIP[S] { * | rel-type-name[,...] }
     ]
-    TO grantee[,...]
+    TO role[,...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-create-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-create-syntax.asciidoc
@@ -1,11 +1,11 @@
 .Command syntax
 [source, cypher]
 -----
-DENY CREATE ON GRAPH[S] { * | graph-name[,...] }
+DENY CREATE ON GRAPH[S] { * | graph-name[, ...] }
     [
-        ELEMENT[S] { * | label-or-rel-type-name[,...] }
-        | NODE[S] { * | label-name[,...] }
-        | RELATIONSHIP[S] { * | rel-type-name[,...] }
+        ELEMENT[S] { * | label-or-rel-type-name[, ...] }
+        | NODE[S] { * | label-name[, ...] }
+        | RELATIONSHIP[S] { * | rel-type-name[, ...] }
     ]
-    TO role[,...]
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-delete-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-delete-syntax.asciidoc
@@ -1,11 +1,11 @@
 .Command syntax
 [source, cypher]
 -----
-DENY DELETE ON GRAPH[S] { * | graph-name[,...] }
+DENY DELETE ON GRAPH[S] { * | graph-name[, ...] }
     [
-        ELEMENT[S] { * | label-or-rel-type-name[,...] }
-        | NODE[S] { * | label-name[,...] }
-        | RELATIONSHIP[S] { * | rel-type-name[,...] }
+        ELEMENT[S] { * | label-or-rel-type-name[, ...] }
+        | NODE[S] { * | label-name[, ...] }
+        | RELATIONSHIP[S] { * | rel-type-name[, ...] }
     ]
-    TO role[,...]
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-delete-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-delete-syntax.asciidoc
@@ -7,5 +7,5 @@ DENY DELETE ON GRAPH[S] { * | graph-name[,...] }
         | NODE[S] { * | label-name[,...] }
         | RELATIONSHIP[S] { * | rel-type-name[,...] }
     ]
-    TO grantee[,...]
+    TO role[,...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-match-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-match-syntax.asciidoc
@@ -5,9 +5,9 @@ DENY MATCH
     "{" { * | property[, ...] } "}"
     ON GRAPH[S] {name[, ...] | *}
         [
-            ELEMENT[S] { * | label-or-rel-type-name[,...] }
-            | NODE[S] { * | label-name[,...] }
-            | RELATIONSHIP[S] { * | rel-type-name[,...] }
+            ELEMENT[S] { * | label-or-rel-type-name[, ...] }
+            | NODE[S] { * | label-name[, ...] }
+            | RELATIONSHIP[S] { * | rel-type-name[, ...] }
         ]
     TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-match-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-match-syntax.asciidoc
@@ -2,12 +2,12 @@
 [source, cypher]
 -----
 DENY MATCH
-    "{" { * | properties } "}"
-    ON GRAPH[S] {name [, ...] | *}
+    "{" { * | property[, ...] } "}"
+    ON GRAPH[S] {name[, ...] | *}
         [
             ELEMENT[S] { * | label-or-rel-type-name[,...] }
             | NODE[S] { * | label-name[,...] }
             | RELATIONSHIP[S] { * | rel-type-name[,...] }
         ]
-    TO role [, ...]
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-read-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-read-syntax.asciidoc
@@ -2,12 +2,12 @@
 [source, cypher]
 -----
 DENY READ
-    "{" { * | properties } "}"
-    ON GRAPH[S] {name [, ...] | *}
+    "{" { * | property[, ...] } "}"
+    ON GRAPH[S] {name[, ...] | *}
         [
             ELEMENT[S] { * | label-or-rel-type-name[,...] }
             | NODE[S] { * | label-name[,...] }
             | RELATIONSHIP[S] { * | rel-type-name[,...] }
         ]
-    TO role [, ...]
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-read-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-read-syntax.asciidoc
@@ -5,9 +5,9 @@ DENY READ
     "{" { * | property[, ...] } "}"
     ON GRAPH[S] {name[, ...] | *}
         [
-            ELEMENT[S] { * | label-or-rel-type-name[,...] }
-            | NODE[S] { * | label-name[,...] }
-            | RELATIONSHIP[S] { * | rel-type-name[,...] }
+            ELEMENT[S] { * | label-or-rel-type-name[, ...] }
+            | NODE[S] { * | label-name[, ...] }
+            | RELATIONSHIP[S] { * | rel-type-name[, ...] }
         ]
     TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-remove-label-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-remove-label-syntax.asciidoc
@@ -1,7 +1,7 @@
 .Command syntax
 [source, cypher]
 -----
-DENY REMOVE LABEL {label [, ...] | *}
-    ON GRAPH[S] {name [, ...] | *}
-    TO role [, ...]
+DENY REMOVE LABEL {label[, ...] | *}
+    ON GRAPH[S] {name[, ...] | *}
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-set-label-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-set-label-syntax.asciidoc
@@ -1,7 +1,7 @@
 .Command syntax
 [source, cypher]
 -----
-DENY SET LABEL {label [, ...] | *}
-    ON GRAPH[S] {name [, ...] | *}
-    TO role [, ...]
+DENY SET LABEL {label[, ...] | *}
+    ON GRAPH[S] {name[, ...] | *}
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-set-property-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-set-property-syntax.asciidoc
@@ -1,12 +1,12 @@
 .Command syntax
 [source, cypher]
 -----
-DENY SET PROPERTY "{" { * | property-name[,...] } "}"
-    ON GRAPH[S] { * | graph-name[,...] }
+DENY SET PROPERTY "{" { * | property-name[, ...] } "}"
+    ON GRAPH[S] { * | graph-name[, ...] }
         [
-            ELEMENT[S] { * | label-or-rel-type-name[,...] }
-            | NODE[S] { * | label-name[,...] }
-            | RELATIONSHIP[S] { * | rel-type-name[,...] }
+            ELEMENT[S] { * | label-or-rel-type-name[, ...] }
+            | NODE[S] { * | label-name[, ...] }
+            | RELATIONSHIP[S] { * | rel-type-name[, ...] }
         ]
-    TO role[,...]
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-set-property-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-set-property-syntax.asciidoc
@@ -8,5 +8,5 @@ DENY SET PROPERTY "{" { * | property-name[,...] } "}"
             | NODE[S] { * | label-name[,...] }
             | RELATIONSHIP[S] { * | rel-type-name[,...] }
         ]
-    TO grantee[,...]
+    TO role[,...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-traverse-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-traverse-syntax.asciidoc
@@ -4,9 +4,9 @@
 DENY TRAVERSE
     ON GRAPH[S] {name[, ...] | *}
         [
-            ELEMENT[S] { * | label-or-rel-type-name[,...] }
-            | NODE[S] { * | label-name[,...] }
-            | RELATIONSHIP[S] { * | rel-type-name[,...] }
+            ELEMENT[S] { * | label-or-rel-type-name[, ...] }
+            | NODE[S] { * | label-name[, ...] }
+            | RELATIONSHIP[S] { * | rel-type-name[, ...] }
         ]
     TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-traverse-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-traverse-syntax.asciidoc
@@ -2,11 +2,11 @@
 [source, cypher]
 -----
 DENY TRAVERSE
-    ON GRAPH[S] {name [, ...] | *}
+    ON GRAPH[S] {name[, ...] | *}
         [
             ELEMENT[S] { * | label-or-rel-type-name[,...] }
             | NODE[S] { * | label-name[,...] }
             | RELATIONSHIP[S] { * | rel-type-name[,...] }
         ]
-    TO role [, ...]
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-write-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/deny-write-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 DENY WRITE
-    ON GRAPH[S] {name [, ...] | *}
-    TO role [, ...]
+    ON GRAPH[S] {name[, ...] | *}
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-all-graph-privileges-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-all-graph-privileges-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 GRANT ALL [ [ GRAPH ] PRIVILEGES ]
-    ON GRAPH[S] {name [, ...] | * }
-    TO role [, ...]
+    ON GRAPH[S] {name[, ...] | * }
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-create-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-create-syntax.asciidoc
@@ -7,5 +7,5 @@ GRANT CREATE ON GRAPH[S] { * | graph-name[,...] }
         | NODE[S] { * | label-name[,...] }
         | RELATIONSHIP[S] { * | rel-type-name[,...] }
     ]
-    TO grantee[,...]
+    TO role[,...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-create-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-create-syntax.asciidoc
@@ -1,11 +1,11 @@
 .Command syntax
 [source, cypher]
 -----
-GRANT CREATE ON GRAPH[S] { * | graph-name[,...] }
+GRANT CREATE ON GRAPH[S] { * | graph-name[, ...] }
     [
-        ELEMENT[S] { * | label-or-rel-type-name[,...] }
-        | NODE[S] { * | label-name[,...] }
-        | RELATIONSHIP[S] { * | rel-type-name[,...] }
+        ELEMENT[S] { * | label-or-rel-type-name[, ...] }
+        | NODE[S] { * | label-name[, ...] }
+        | RELATIONSHIP[S] { * | rel-type-name[, ...] }
     ]
-    TO role[,...]
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-delete-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-delete-syntax.asciidoc
@@ -7,5 +7,5 @@ GRANT DELETE ON GRAPH[S] { * | graph-name[,...] }
         | NODE[S] { * | label-name[,...] }
         | RELATIONSHIP[S] { * | rel-type-name[,...] }
     ]
-    TO grantee[,...]
+    TO role[,...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-delete-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-delete-syntax.asciidoc
@@ -1,11 +1,11 @@
 .Command syntax
 [source, cypher]
 -----
-GRANT DELETE ON GRAPH[S] { * | graph-name[,...] }
+GRANT DELETE ON GRAPH[S] { * | graph-name[, ...] }
     [
-        ELEMENT[S] { * | label-or-rel-type-name[,...] }
-        | NODE[S] { * | label-name[,...] }
-        | RELATIONSHIP[S] { * | rel-type-name[,...] }
+        ELEMENT[S] { * | label-or-rel-type-name[, ...] }
+        | NODE[S] { * | label-name[, ...] }
+        | RELATIONSHIP[S] { * | rel-type-name[, ...] }
     ]
-    TO role[,...]
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-deny-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-deny-syntax.asciidoc
@@ -39,23 +39,23 @@ Graphs created after this command execution will also be associated with these p
 | Command | Description
 
 | [source, cypher]
-GRANT graph-privilege ON GRAPH[S] {name [, ...] \| *} [entity] TO role [, ...]
+GRANT graph-privilege ON GRAPH[S] {name[, ...] \| *} [entity] TO role[, ...]
 | Grant a privilege to one or multiple roles.
 
 | [source, cypher]
-DENY graph-privilege ON GRAPH[S] {name [, ...] \| *} [entity] TO role [, ...]
+DENY graph-privilege ON GRAPH[S] {name[, ...] \| *} [entity] TO role[, ...]
 | Deny a privilege to one or multiple roles.
 
 | [source, cypher]
-REVOKE GRANT graph-privilege ON GRAPH[S] {name [, ...] \| *} [entity] FROM role [, ...]
+REVOKE GRANT graph-privilege ON GRAPH[S] {name[, ...] \| *} [entity] FROM role[, ...]
 | Revoke a granted privilege from one or multiple roles.
 
 | [source, cypher]
-REVOKE DENY graph-privilege ON GRAPH[S] {name [, ...] \| *} [entity] FROM role [, ...]
+REVOKE DENY graph-privilege ON GRAPH[S] {name[, ...] \| *} [entity] FROM role[, ...]
 | Revoke a denied privilege from one or multiple roles.
 
 | [source, cypher]
-REVOKE graph-privilege ON GRAPH[S] {name [, ...] \| *} [entity] FROM role [, ...]
+REVOKE graph-privilege ON GRAPH[S] {name[, ...] \| *} [entity] FROM role[, ...]
 | Revoke a granted or denied privilege from one or multiple roles.
 |===
 

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-match-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-match-syntax.asciidoc
@@ -2,12 +2,12 @@
 [source, cypher]
 -----
 GRANT MATCH
-    "{" { * | properties } "}"
-    ON GRAPH[S] {name [, ...] | *}
+    "{" { * | property[, ...] } "}"
+    ON GRAPH[S] {name[, ...] | *}
         [
             ELEMENT[S] { * | label-or-rel-type-name[,...] }
             | NODE[S] { * | label-name[,...] }
             | RELATIONSHIP[S] { * | rel-type-name[,...] }
         ]
-    TO role [, ...]
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-match-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-match-syntax.asciidoc
@@ -5,9 +5,9 @@ GRANT MATCH
     "{" { * | property[, ...] } "}"
     ON GRAPH[S] {name[, ...] | *}
         [
-            ELEMENT[S] { * | label-or-rel-type-name[,...] }
-            | NODE[S] { * | label-name[,...] }
-            | RELATIONSHIP[S] { * | rel-type-name[,...] }
+            ELEMENT[S] { * | label-or-rel-type-name[, ...] }
+            | NODE[S] { * | label-name[, ...] }
+            | RELATIONSHIP[S] { * | rel-type-name[, ...] }
         ]
     TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-merge-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-merge-syntax.asciidoc
@@ -1,12 +1,12 @@
 .Command syntax
 [source, cypher]
 -----
-GRANT MERGE "{" { * | property-name[,...] } "}"
-    ON GRAPH[S] { * | graph-name[,...] }
+GRANT MERGE "{" { * | property-name[, ...] } "}"
+    ON GRAPH[S] { * | graph-name[, ...] }
         [
-            ELEMENT[S] { * | label-or-rel-type-name[,...] }
-            | NODE[S] { * | label-name[,...] }
-            | RELATIONSHIP[S] { * | rel-type-name[,...] }
+            ELEMENT[S] { * | label-or-rel-type-name[, ...] }
+            | NODE[S] { * | label-name[, ...] }
+            | RELATIONSHIP[S] { * | rel-type-name[, ...] }
         ]
-    TO role[,...]
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-merge-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-merge-syntax.asciidoc
@@ -8,5 +8,5 @@ GRANT MERGE "{" { * | property-name[,...] } "}"
             | NODE[S] { * | label-name[,...] }
             | RELATIONSHIP[S] { * | rel-type-name[,...] }
         ]
-    TO grantee[,...]
+    TO role[,...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-read-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-read-syntax.asciidoc
@@ -5,9 +5,9 @@ GRANT READ
     "{" { * | property[, ...] } "}"
     ON GRAPH[S] {name[, ...] | *}
         [
-            ELEMENT[S] { * | label-or-rel-type-name[,...] }
-            | NODE[S] { * | label-name[,...] }
-            | RELATIONSHIP[S] { * | rel-type-name[,...] }
+            ELEMENT[S] { * | label-or-rel-type-name[, ...] }
+            | NODE[S] { * | label-name[, ...] }
+            | RELATIONSHIP[S] { * | rel-type-name[, ...] }
         ]
     TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-read-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-read-syntax.asciidoc
@@ -2,12 +2,12 @@
 [source, cypher]
 -----
 GRANT READ
-    "{" { * | properties } "}"
-    ON GRAPH[S] {name [, ...] | *}
+    "{" { * | property[, ...] } "}"
+    ON GRAPH[S] {name[, ...] | *}
         [
             ELEMENT[S] { * | label-or-rel-type-name[,...] }
             | NODE[S] { * | label-name[,...] }
             | RELATIONSHIP[S] { * | rel-type-name[,...] }
         ]
-    TO role [, ...]
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-remove-label-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-remove-label-syntax.asciidoc
@@ -1,7 +1,7 @@
 .Command syntax
 [source, cypher]
 -----
-GRANT REMOVE LABEL {label [, ...] | *}
-    ON GRAPH[S] {name [, ...] | *}
-    TO role [, ...]
+GRANT REMOVE LABEL {label[, ...] | *}
+    ON GRAPH[S] {name[, ...] | *}
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-set-label-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-set-label-syntax.asciidoc
@@ -1,7 +1,7 @@
 .Command syntax
 [source, cypher]
 -----
-GRANT SET LABEL {label [, ...] | *}
-    ON GRAPH[S] {name [, ...] | *}
-    TO role [, ...]
+GRANT SET LABEL {label[, ...] | *}
+    ON GRAPH[S] {name[, ...] | *}
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-set-property-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-set-property-syntax.asciidoc
@@ -1,12 +1,12 @@
 .Command syntax
 [source, cypher]
 -----
-GRANT SET PROPERTY "{" { * | property-name[,...] } "}"
-    ON GRAPH[S] { * | graph-name[,...] }
+GRANT SET PROPERTY "{" { * | property-name[, ...] } "}"
+    ON GRAPH[S] { * | graph-name[, ...] }
         [
-            ELEMENT[S] { * | label-or-rel-type-name[,...] }
-            | NODE[S] { * | label-name[,...] }
-            | RELATIONSHIP[S] { * | rel-type-name[,...] }
+            ELEMENT[S] { * | label-or-rel-type-name[, ...] }
+            | NODE[S] { * | label-name[, ...] }
+            | RELATIONSHIP[S] { * | rel-type-name[, ...] }
         ]
-    TO role[,...]
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-set-property-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-set-property-syntax.asciidoc
@@ -8,5 +8,5 @@ GRANT SET PROPERTY "{" { * | property-name[,...] } "}"
             | NODE[S] { * | label-name[,...] }
             | RELATIONSHIP[S] { * | rel-type-name[,...] }
         ]
-    TO grantee[,...]
+    TO role[,...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-traverse-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-traverse-syntax.asciidoc
@@ -2,11 +2,11 @@
 [source, cypher]
 -----
 GRANT TRAVERSE
-    ON GRAPH[S] {name [, ...] | *}
+    ON GRAPH[S] {name[, ...] | *}
         [
             ELEMENT[S] { * | label-or-rel-type-name[,...] }
             | NODE[S] { * | label-name[,...] }
             | RELATIONSHIP[S] { * | rel-type-name[,...] }
         ]
-    TO role [, ...]
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-traverse-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-traverse-syntax.asciidoc
@@ -4,9 +4,9 @@
 GRANT TRAVERSE
     ON GRAPH[S] {name[, ...] | *}
         [
-            ELEMENT[S] { * | label-or-rel-type-name[,...] }
-            | NODE[S] { * | label-name[,...] }
-            | RELATIONSHIP[S] { * | rel-type-name[,...] }
+            ELEMENT[S] { * | label-or-rel-type-name[, ...] }
+            | NODE[S] { * | label-name[, ...] }
+            | RELATIONSHIP[S] { * | rel-type-name[, ...] }
         ]
     TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-write-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/grant-write-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 GRANT WRITE
-    ON GRAPH[S] {name [, ...] | *}
-    TO role [, ...]
+    ON GRAPH[S] {name[, ...] | *}
+    TO role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/revoke-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/revoke-syntax.asciidoc
@@ -3,5 +3,5 @@
 -----
 REVOKE
     [ GRANT | DENY ] graph-privilege
-    FROM role [, ...]
+    FROM role[, ...]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/role-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/role-management-syntax.asciidoc
@@ -6,7 +6,7 @@
 | [source, cypher]
 ----
 SHOW [ALL\|POPULATED] ROLES
-    [YIELD field1[, field2] [ORDER BY field1 [, field2]] [SKIP n] [LIMIT n]]
+    [YIELD field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
     [WHERE expression]
 ----
 | List roles.
@@ -15,7 +15,7 @@ SHOW [ALL\|POPULATED] ROLES
 | [source, cypher]
 ----
 SHOW [ALL\|POPULATED] ROLES WITH USERS
-    [YIELD field1[, field2] [ORDER BY field1 [, field2]] [SKIP n] [LIMIT n]]
+    [YIELD field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
     [WHERE expression]
 ----
 | List roles and users assigned to them.

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/show-all-privileges-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/show-all-privileges-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 SHOW [ALL] PRIVILEGES
-    [YIELD field1[, field2] [ORDER BY field1 [, field2]] [SKIP n] [LIMIT n]]
+    [YIELD field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
     [WHERE expression]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/show-role-privileges-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/show-role-privileges-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 SHOW ROLE role PRIVILEGES
-    [YIELD field1[, field2] [ORDER BY field1 [, field2]] [SKIP n] [LIMIT n]]
+    [YIELD field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
     [WHERE expression]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/show-user-privileges-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/show-user-privileges-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 SHOW USER [user] PRIVILEGES
-    [YIELD field1[, field2] [ORDER BY field1 [, field2]] [SKIP n] [LIMIT n]]
+    [YIELD field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
     [WHERE expression]
 -----

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/user-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/user-management-syntax.asciidoc
@@ -6,7 +6,7 @@
 | [source, cypher]
 ----
 SHOW USERS
-    [YIELD field1[, field2] [ORDER BY field1 [, field2]] [SKIP n] [LIMIT n]]
+    [YIELD field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
     [WHERE expression]
 ----
 | List all users.

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/show-databases-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/show-databases-syntax.asciidoc
@@ -2,6 +2,6 @@
 [source, cypher]
 -----
 SHOW { DATABASE db | DATABASES | DEFAULT DATABASE }
-    [YIELD field1[, field2] [ORDER BY field1 [, field2]] [SKIP n] [LIMIT n]]
+    [YIELD field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
     [WHERE expression]
 -----

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityReadPrivilegesTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityReadPrivilegesTest.scala
@@ -28,8 +28,8 @@ class SecurityReadPrivilegesTest extends DocumentingTest with QueryStatisticsTes
         |There are three separate read privileges:
         |
         |* `TRAVERSE` - enables the specified entities to be found.
-        |* `READ +{props}+` - enables the specified properties on the found entities to be read.
-        |* `MATCH +{props}+` - combines both `TRAVERSE` and `READ`, enabling an entity to be found and its properties read.
+        |* `READ` - enables the specified properties on the found entities to be read.
+        |* `MATCH` - combines both `TRAVERSE` and `READ`, enabling an entity to be found and its properties read.
         |""".stripMargin)
 
     section("The `TRAVERSE` privilege", "administration-security-reads-traverse", "enterprise-edition") {

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityWritePrivilegesTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityWritePrivilegesTest.scala
@@ -34,9 +34,9 @@ class SecurityWritePrivilegesTest extends DocumentingTest with QueryStatisticsTe
         |
         |* `CREATE` - allows creating nodes and relationships.
         |* `DELETE` - allows deleting nodes and relationships.
-        |* `SET LABEL labels` - allows setting the specified node labels using the `SET` clause.
-        |* `REMOVE LABEL labels` - allows removing the specified node labels using the `REMOVE` clause.
-        |* `SET PROPERTY +{props}+` - allows setting properties on nodes and relationships.
+        |* `SET LABEL` - allows setting the specified node labels using the `SET` clause.
+        |* `REMOVE LABEL` - allows removing the specified node labels using the `REMOVE` clause.
+        |* `SET PROPERTY` - allows setting properties on nodes and relationships.
         |
         |There are also compound privileges which combine the above specific privileges:
         |


### PR DESCRIPTION
* `[, ...]` instead of plural name
* no space before `[, ...]`, ex. `name[, ...]` not `name [, ...]`
* update `grantee` to `role` to be consistent
* change `field1[, field2]` to `field[, ...]` to show you can have more than 2 in the list