### PR TITLE
Escape the asterisks so they avoid the bold block (in the MATCH privilege section)

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SecurityPrivilegesTest.scala
@@ -153,9 +153,9 @@ class SecurityPrivilegesTest extends DocumentingTest with QueryStatisticsTestSup
       p("include::deny-match-syntax.asciidoc[]")
 
       p(
-        """Please note that the effect of denying a `MATCH` privilege depends on whether concrete property keys are specified or a `*`.
+        """Please note that the effect of denying a `MATCH` privilege depends on whether concrete property keys are specified or a `+*+`.
           |If you specify concrete property keys then `DENY MATCH` will only deny reading those properties. Finding the elements to traverse would still be allowed.
-          |If you specify `*` instead then both traversal of the element and all property reads will be disallowed.
+          |If you specify `+*+` instead then both traversal of the element and all property reads will be disallowed.
           |The following queries will show examples for this.""".stripMargin)
 
       p(


### PR DESCRIPTION
Resolves the unintended bold block here: https://neo4j.com/docs/cypher-manual/4.0/administration/security/subgraph/#administration-security-subgraph-match

@renetapopova assuming the build goes green, let's use this PR to pick the build artefacts and generate the antora output without having to locally compile the `neo4j-documentation` repo.