### PR TITLE
Missed update to be consistent with Index section

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/ql/administration/constraints/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/constraints/index.asciidoc
@@ -255,7 +255,7 @@ include::drop-a-non-existing-constraint.asciidoc[leveloffset=+2]
 [[administration-constraints-list-constraint]]
 === List constraints
 
-Listing all constraints can be done with `SHOW CONSTRAINTS`, which will produce a table with the following columns:
+Listing constraints can be done with `SHOW CONSTRAINTS`, which will produce a table with the following columns:
 
 .List constraints output
 [options="header", width="100%", cols="1a,4,^.^,^"]


### PR DESCRIPTION
When cherry-picking https://github.com/neo4j/neo4j-documentation/pull/734 to 4.3, I found one place that was missed updating in the 4.2 PR. Fixed it in the [4.3 version](https://github.com/neo4j/neo4j-documentation/pull/779) and now cherry-pick it back to 4.2.