### PR TITLE
restore includes and update how toc is hidden

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/execution-plan-groups/operators.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/execution-plan-groups/operators.asciidoc
@@ -1,6 +1,6 @@
 [[execution-plans-operators]]
 = Execution plan operators in detail
-:page-hide-toc: true
+:page-toclevels: -1
 
 [abstract]
 All operators are listed here, grouped by the similarity of their characteristics.

--- a/cypher/cypher-docs/src/docs/dev/execution-plans.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/execution-plans.asciidoc
@@ -78,3 +78,11 @@ In particular, see <<how-do-i-profile-a-query>> for how to view the execution pl
 For a deeper understanding of how each operator works, refer to <<execution-plan-operators-summary>> and the linked sections per operator.
 Please remember that the statistics of the particular database where the queries run will decide the plan used.
 There is no guarantee that a specific query will always be solved with the same plan.
+
+include::execution-plans-operator-summary.asciidoc[leveloffset=+1]
+
+include::execution-plans-db-hits.asciidoc[leveloffset=+1]
+
+include::execution-plan-groups/operators.asciidoc[leveloffset=+1]
+
+include::execution-plan-groups/query-shortestpath-planning.adoc[leveloffset=+1]


### PR DESCRIPTION
Using page-toclevels is the correct Antora way to hide the in-page table of contents. See the [Antora docs](https://docs.antora.org/antora/2.3/whats-new/#on-this-page-widget) for more information.

Include statements are required for PDF output