### PR TITLE
Add direct dependency on neo4j-kernel.

### DIFF
--- a/cypher/cypher-prettifier/pom.xml
+++ b/cypher/cypher-prettifier/pom.xml
@@ -96,6 +96,12 @@
             <artifactId>neo4j-exceptions</artifactId>
             <version>${neo4j.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j-kernel</artifactId>
+            <version>${neo4j.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
This was a transient dependency from cypher-it before,
but was removed from that module in a product PR.