### PR TITLE
DropResult has been removed from the product

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
@@ -598,19 +598,6 @@ class QueryPlanTest extends DocumentingTestBase with SoftReset {
     )
   }
 
-  @Test def dropResult() {
-    profileQuery(
-      title = "Drop Result",
-      text =
-        """The `DropResult` operator produces zero rows.
-          |It is applied when it can be deduced through static analysis that the result of an expression will be empty, such as when a predicate guaranteed to return `false` (e.g. `1 > 5`) is used in a query.""".stripMargin,
-      queryText =
-        """CYPHER runtime=slotted
-          |MATCH (p) WHERE false RETURN p""".stripMargin,
-      assertions = p => assertThat(p.executionPlanDescription().toString, containsString("DropResult"))
-    )
-  }
-
   @Test def produceResults() {
     profileQuery(
       title = "Produce Results",


### PR DESCRIPTION
Now we instead use `LIMIT 0` for this case.