### PR TITLE
Fix operators comparison docs (#840)

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/syntax/comparison.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/syntax/comparison.asciidoc
@@ -104,5 +104,3 @@ Is equivalent to:
 ----
 a < b AND b = c AND c <= d AND d <> e
 ----
-
-For other comparison operators, see <<query-operators-comparison>>.

--- a/cypher/cypher-docs/src/docs/dev/syntax/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/syntax/index.asciidoc
@@ -28,16 +28,14 @@ This section describes the syntax of the Cypher query language.
 * <<query-operators, Operators>>
  ** <<query-operators-summary, Operators at a glance>>
  ** <<query-operators-aggregation, Aggregation operators>>
+ ** <<query-operators-property, Property operators>>
  ** <<query-operators-mathematical, Mathematical operators>>
  ** <<query-operators-comparison, Comparison operators>>
  ** <<query-operators-boolean, Boolean operators>>
  ** <<query-operators-string, String operators>>
  ** <<query-operators-temporal, Temporal operators>>
+ ** <<query-operators-map, Map operators>>
  ** <<query-operators-list, List operators>>
- ** <<query-operators-property, Property operators>>
- ** <<cypher-comparison, Equality and comparison of values>>
- ** <<cypher-ordering, Ordering and comparison of values>>
- ** <<cypher-operations-chaining, Chaining comparison operations>>
 * <<cypher-comments, Comments>>
 * <<cypher-patterns, Patterns>>
  ** <<cypher-pattern-node, Patterns for nodes>>
@@ -100,19 +98,17 @@ include::parameters.asciidoc[leveloffset=+1]
 
 include::../ql/query-operators.adoc[leveloffset=+1]
 
-include::comparison.asciidoc[leveloffset=+1]
-
 include::comments.asciidoc[leveloffset=+1]
 
 include::../ql/cypher-patterns.adoc[leveloffset=+1]
 
 include::../ql/cypher-temporal.adoc[leveloffset=+1]
 
+include::../ql/cypher-spatial.adoc[leveloffset=+1]
+
 include::../ql/cypher-lists.adoc[leveloffset=+1]
 
 include::../ql/cypher-maps.adoc[leveloffset=+1]
-
-include::../ql/cypher-spatial.adoc[leveloffset=+1]
 
 include::working-with-null.asciidoc[leveloffset=+1]
 

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/OperatorsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/OperatorsTest.scala
@@ -43,6 +43,9 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
         |* <<query-operators-comparison, Comparison operators>>
         | ** <<syntax-comparing-two-numbers, Comparing two numbers>>
         | ** <<syntax-using-starts-with-to-filter-names, Using `STARTS WITH` to filter names>>
+        | ** <<cypher-comparison, Equality and comparison of values>>
+        | ** <<cypher-ordering, Ordering and comparison of values>>
+        | ** <<cypher-operations-chaining, Chaining comparison operations>>
         |* <<query-operators-boolean, Boolean operators>>
         | ** <<syntax-using-boolean-operators-to-filter-numbers, Using boolean operators to filter numbers>>
         |* <<query-operators-string, String operators>>
@@ -54,16 +57,13 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
         |* <<query-operators-map, Map operators>>
         | ** <<syntax-accessing-the-value-of-a-nested-map, Statically accessing the value of a nested map by key using the `.` operator">>
         | ** <<syntax-accessing-dynamic-map-parameter, Dynamically accessing the value of a map by key using the `[]` operator and a parameter>>
-        | ** <<syntax-using-in-with-nested-list-subscripting, Using `IN` with `[]` on a nested list>>
         |* <<query-operators-list, List operators>>
         | ** <<syntax-concatenating-two-lists, Concatenating two lists using `+`>>
         | ** <<syntax-using-in-to-check-if-a-number-is-in-a-list, Using `IN` to check if a number is in a list>>
         | ** <<syntax-using-in-for-more-complex-list-membership-operations, Using `IN` for more complex list membership operations>>
         | ** <<syntax-accessing-elements-in-a-list, Accessing elements in a list using the `[]` operator>>
         | ** <<syntax-accessing-element-in-a-list-parameter, Dynamically accessing an element in a list using the `[]` operator and a parameter>>
-        |* <<cypher-comparison, Equality and comparison of values>>
-        |* <<cypher-ordering, Ordering and comparison of values>>
-        |* <<cypher-operations-chaining, Chaining comparison operations>>
+        | ** <<syntax-using-in-with-nested-list-subscripting, Using `IN` with `[]` on a nested list>>
       """.stripMargin)
     section("Operators at a glance", "query-operators-summary") {
       p(
@@ -245,6 +245,7 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
         }
       }
       p("""<<query-where-string>> contains more information regarding the string-specific comparison operators as well as additional examples illustrating the usage thereof.""")
+      p("include::../syntax/comparison.asciidoc[leveloffset=+1]")
     }
     section("Boolean operators", "query-operators-boolean") {
       p(


### PR DESCRIPTION
* move include statement to OperatorsTest

* fix path to operators comparison

* combine comparison operators sections

* update menu in syntax index

* fix some menu ordering

(cherry picked from commit 5519bafa59ea2115d1b43dc180414872386a22ab)