### PR TITLE
Overhaul the Cypher hint section.

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/UsingTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/UsingTest.scala
@@ -118,7 +118,7 @@ class UsingTest extends DocumentingTest {
           |the hint might force the planner to pick a _seemingly_ bad starting point, which in reality proves to be a very good one.""")
       section("Hinting a join on a single node") {
         p("""In the example above using multiple index hints, we saw that the planner chose to do a join, but not on the `p` node.
-            |By supplying a join hint in an#ddition to the index hints, we can enforce the join to happen on the `p` node.""")
+            |By supplying a join hint in addition to the index hints, we can enforce the join to happen on the `p` node.""")
         query(s"""$matchString
               |USING INDEX s:Scientist(born)
               |USING INDEX cc:Country(formed)


### PR DESCRIPTION
* Insert better test assertions to make sure plans look the way they are explained to look.
* Use a different more reliable schema.
* Remove sub-section on joining on multiple variables.
* Add sub-section for join hints for OPTIONAL MATCHes.

@Documentation_team:
Please note that I did not build the documentation locally.