### PR TITLE
Updated read-only example

### DIFF
--- a/embedded-examples/src/test/java/org/neo4j/examples/ReadOnlyDocTest.java
+++ b/embedded-examples/src/test/java/org/neo4j/examples/ReadOnlyDocTest.java
@@ -58,7 +58,7 @@ public class ReadOnlyDocTest
         }
         new DatabaseManagementServiceBuilder( dir ).build().shutdown();
         // tag::createReadOnlyInstance[]
-        managementService = new DatabaseManagementServiceBuilder( dir ).setConfig( GraphDatabaseSettings.read_only, true ).build();
+        managementService = new DatabaseManagementServiceBuilder( dir ).setConfig( GraphDatabaseSettings.read_only_database_default, true ).build();
         graphDb = managementService.database( DEFAULT_DATABASE_NAME );
         // end::createReadOnlyInstance[]
     }

--- a/embedded-examples/src/test/java/org/neo4j/examples/ReadOnlyDocTest.java
+++ b/embedded-examples/src/test/java/org/neo4j/examples/ReadOnlyDocTest.java
@@ -31,9 +31,11 @@ import org.neo4j.dbms.api.DatabaseManagementService;
 import org.neo4j.dbms.api.DatabaseManagementServiceBuilder;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.WriteOperationsNotAllowedException;
+import org.neo4j.internal.helpers.Exceptions;
+import org.neo4j.kernel.api.exceptions.ReadOnlyDbException;
 import org.neo4j.io.fs.FileUtils;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.neo4j.configuration.GraphDatabaseSettings.DEFAULT_DATABASE_NAME;
 
@@ -84,8 +86,9 @@ public class ReadOnlyDocTest
             fail( "expected exception" );
         }
         // then
-        catch ( WriteOperationsNotAllowedException e )
+        catch ( Exception e )
         {
+            assertTrue( "Exception cause should be ReadOnlyDbException!", Exceptions.contains( e, c -> c instanceof ReadOnlyDbException ) );
             // ok
         }
     }


### PR DESCRIPTION
Single line change, needed as the internal `read_only` configuration value is no longer encouraged. In particular, `dbms.read_only` doesn't work with clusters, whilst embedded now **does**. `dbms.databases.default_to_read_only` and friends are the preferred replacements.