### PR TITLE
Deprecate BRIEF/VERBOSE for SHOW INDEX/CONSTRAINT

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -40,6 +40,8 @@ Replacement syntax for deprecated and removed features are also indicated.
 | `CREATE CONSTRAINT [name] ON ()-[rel:REL]-() ASSERT exists(rel.property)` | Syntax | Deprecated | Replaced by `CREATE CONSTRAINT [name] ON ()-[rel:REL]-() ASSERT rel.property IS NOT NULL`
 | `exists(prop)` | Syntax | Deprecated | Replaced by `prop IS NOT NULL`
 | `NOT exists(prop)` | Syntax | Deprecated | Replaced by `prop IS NULL`
+| `BRIEF [OUTPUT]` for `SHOW INDEXES` and `SHOW CONSTRAINTS`   | Syntax | Deprecated | Replaced by default output columns
+| `VERBOSE [OUTPUT]` for `SHOW INDEXES` and `SHOW CONSTRAINTS` | Syntax | Deprecated | Replaced by `YIELD *`
 |===
 
 [[cypher-deprecations-additions-removals-4.2]]


### PR DESCRIPTION
Since `YIELD` is not yet implemented for the SHOW schema commands the replacement does not fully exist yet, might hold of on merging this and just add it together with `YIELD`.

Brief/verbose is also mentioned in

- `SchemaIndexTest.scala`
- `ConstraintsTest.scala`
- `refcard/ConstraintTest.scala`

But will not update there since the replacement is not implemented.

Depends on/Should not be merged before: https://github.com/neo-technology/neo4j/pull/8819