### PR TITLE
Document YIELD and WHERE for SHOW INDEXES

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -41,6 +41,10 @@ Replacement syntax for deprecated and removed features are also indicated.
 | `exists(prop)` | Syntax | Deprecated | Replaced by `prop IS NOT NULL`
 | `NOT exists(prop)` | Syntax | Deprecated | Replaced by `prop IS NULL`
 | `ALTER USER name IF EXISTS ...` | Syntax | Added | Makes altering users idempotent. If no user with the name exists no error will be thrown.
+| `SHOW INDEXES WHERE ...`              | Functionality | Updated    | Now allows filtering for `SHOW INDEXES`
+| `SHOW INDEXES YIELD ... [RETURN ...]` | Functionality | Updated    | Now allows `YIELD` and `RETURN` clauses to `SHOW INDEXES` to change the output.
+| `BRIEF [OUTPUT]` for `SHOW INDEXES`   | Syntax        | Deprecated | Replaced by default output columns
+| `VERBOSE [OUTPUT]` for `SHOW INDEXES` | Syntax        | Deprecated | Replaced by `YIELD *`
 |===
 
 [[cypher-deprecations-additions-removals-4.2]]
@@ -69,9 +73,9 @@ Replacement syntax for deprecated and removed features are also indicated.
 | `SHOW [ALL \| BTREE] INDEX[ES] [BRIEF \| VERBOSE [OUTPUT]]`                                                                        | Functionality | Added | New Cypher commands for listing indexes.
 | `SHOW [ALL \| UNIQUE \| NODE EXIST[S] \| RELATIONSHIP EXIST[S] \| EXIST[S] \| NODE KEY] CONSTRAINT[S] [BRIEF \| VERBOSE [OUTPUT]]` | Functionality | Added | New Cypher commands for listing constraints.
 | `db.indexes`                | Procedure     | Deprecated | Replaced by `SHOW INDEXES`
-| `db.indexDetails`           | Procedure     | Deprecated | Replaced by `SHOW INDEXES VERBOSE`
+| `db.indexDetails`           | Procedure     | Deprecated | Replaced by `SHOW INDEXES YIELD *`
 | `db.constraints`            | Procedure     | Deprecated | Replaced by `SHOW CONSTRAINTS`
-| `db.schemaStatements`       | Procedure     | Deprecated | Replaced by `SHOW INDEXES VERBOSE` and `SHOW CONSTRAINTS VERBOSE`
+| `db.schemaStatements`       | Procedure     | Deprecated | Replaced by `SHOW INDEXES YIELD *` and `SHOW CONSTRAINTS VERBOSE`
 | `SHOW INDEX` privilege      | Functionality | Added      | New Cypher command for administering privilege for listing indexes.
 | `SHOW CONSTRAINT` privilege | Functionality | Added      | New Cypher command for administering privilege for listing constraints.
 |===

--- a/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
@@ -47,7 +47,7 @@ This section comprises a glossary of all the keywords -- grouped by category and
 |<<query-return, RETURN ... [AS]>>                    | Projecting   |  Defines what to include in the query result set.
 |<<query-set, SET>>                          | Writing     |  Update labels on nodes and properties on nodes and relationships.
 |<<administration-constraints-list-constraint, SHOW [ALL\|UNIQUE\|NODE EXIST[S]\|RELATIONSHIP EXIST[S]\|EXIST[S]\|NODE KEY] CONSTRAINT[S] [BRIEF\|VERBOSE [OUTPUT]]>> | Schema | List constraints in the database, either all or filtered on type.
-|<<administration-indexes-list-indexes, SHOW [ALL\|BTREE] INDEX[ES] [BRIEF\|VERBOSE [OUTPUT]]>> | Schema | List indexes in the database, either all or B-tree only.
+|<<administration-indexes-list-indexes, SHOW [ALL\|BTREE] INDEX[ES]>> | Schema | List indexes in the database, either all or B-tree only. Also allows `WHERE` and `YIELD` clauses.
 |<<query-skip, SKIP>>                            | Reading/Writing | A sub-clause defining from which row to start including the rows in the output.
 |<<query-union, UNION>>                      | Set operations   |  Combines the result of multiple queries. Duplicates are removed.
 |<<query-union, UNION ALL>>                      | Set operations   |  Combines the result of multiple queries. Duplicates are retained.

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/indexes-for-search-performance/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/indexes-for-search-performance/index.asciidoc
@@ -103,7 +103,10 @@ With `IF EXISTS`, no error is thrown and nothing happens should the index not ex
 
 | [source, cypher, role=noplay]
 ----
-SHOW [ALL\|BTREE] INDEX[ES] [BRIEF\|VERBOSE [OUTPUT]]
+SHOW [ALL\|BTREE] INDEX[ES]
+    [YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
+    [WHERE expression]
+    [RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
 ----
 | List indexes in the database, either all or B-tree only.
 |
@@ -215,8 +218,8 @@ Listing indexes can be done with `SHOW INDEXES`, which will produce a table with
 |===
 | Column
 | Description
-| Brief output
-| Verbose output
+| Default output
+| Full output
 
 | `id`
 | The id of the index.
@@ -284,10 +287,16 @@ Listing indexes can be done with `SHOW INDEXES`, which will produce a table with
 | `+`
 |===
 
+Listing indexes also allows for `WHERE` and `YIELD` clauses to filter the returned rows and columns.
+
 [NOTE]
 The deprecated built-in procedures for listing indexes, such as `db.indexes`, work as before and are not affected by the <<administration-security-administration-database-indexes, `SHOW INDEXES` privilege>>.
 
-include::../indexes/example-of-listing-indexes.asciidoc[leveloffset=+2]
+==== Listing indexes examples
+
+include::../indexes/listing-all-indexes.asciidoc[leveloffset=+2]
+
+include::../indexes/listing-indexes-with-filtering.asciidoc[leveloffset=+2]
 
 [role=deprecated]
 [[administration-indexes-examples-deprecated-syntax]]

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/indexes-for-search-performance/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/indexes-for-search-performance/index.asciidoc
@@ -109,7 +109,7 @@ SHOW [ALL\|BTREE] INDEX[ES]
     [RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
 ----
 | List indexes in the database, either all or B-tree only.
-|
+| When using the `RETURN` clause, the `YIELD` clause is mandatory and may not be omitted.
 
 | [source, cypher, role=noplay]
 ----

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
@@ -19,13 +19,13 @@
  */
 package org.neo4j.cypher.docgen
 
-import java.io.File
-
 import com.neo4j.dbms.api.EnterpriseDatabaseManagementServiceBuilder
 import org.hamcrest.CoreMatchers._
 import org.junit.Assert._
 import org.junit.Test
 import org.neo4j.dbms.api.DatabaseManagementService
+
+import java.io.File
 
 class QueryPlanTest extends DocumentingTestBase with SoftReset {
 
@@ -369,8 +369,8 @@ class QueryPlanTest extends DocumentingTestBase with SoftReset {
     profileQuery(
       title = "List indexes",
       text =
-        """The `ShowIndexes` operator lists indexes. It may include filtering on index type and can have either brief or verbose output.""".stripMargin,
-      queryText = """SHOW INDEXES BRIEF""",
+        """The `ShowIndexes` operator lists indexes. It may include filtering on index type and can have either default or full output.""".stripMargin,
+      queryText = """SHOW INDEXES""",
       assertions = p => {
         val plan = p.executionPlanString()
         assertThat(plan, containsString("ShowIndexes"))

--- a/cypher/cypher-prettifier/src/test/scala/org/neo4j/cypher/docgen/tooling/PrettifierParserTest.scala
+++ b/cypher/cypher-prettifier/src/test/scala/org/neo4j/cypher/docgen/tooling/PrettifierParserTest.scala
@@ -156,9 +156,12 @@ class PrettifierParserTest extends ParserTestBase[Seq[SyntaxToken], Seq[SyntaxTo
     // given
     Seq(
       ("show index", Seq(BreakingKeywords("show index"))),
-      ("show indexes brief", Seq(BreakingKeywords("show indexes"), NonBreakingKeywords("brief"))),
       ("show all indexes", Seq(BreakingKeywords("show all indexes"))),
       ("show btree index", Seq(BreakingKeywords("show btree index"))),
+      ("show index yield *", Seq(BreakingKeywords("show index"), NonBreakingKeywords("yield"), AnyText("*"))),
+      ("show index where type = 'BTREE'", Seq(BreakingKeywords("show index"), BreakingKeywords("where"), AnyText("type"), AnyText("="), EscapedText("BTREE", '\''))),
+      // deprecated
+      ("show indexes brief", Seq(BreakingKeywords("show indexes"), NonBreakingKeywords("brief"))),
       ("show btree index verbose output", Seq(BreakingKeywords("show btree index"), NonBreakingKeywords("verbose output"))),
     ).foreach { case (query, result) =>
       // when then

--- a/cypher/cypher-prettifier/src/test/scala/org/neo4j/cypher/docgen/tooling/PrettifierTest.scala
+++ b/cypher/cypher-prettifier/src/test/scala/org/neo4j/cypher/docgen/tooling/PrettifierTest.scala
@@ -70,8 +70,14 @@ class PrettifierTest extends Suite
 
   test("should not break SHOW INDEXES") {
     actual("show indexes") should equal(expected("SHOW INDEXES"))
+    actual("show btree index yield *") should equal(expected("SHOW BTREE INDEX YIELD *"))
+    // deprecated
     actual("show all indexes brief output") should equal(expected("SHOW ALL INDEXES BRIEF OUTPUT"))
     actual("show btree index verbose") should equal(expected("SHOW BTREE INDEX VERBOSE"))
+  }
+
+  test("may break SHOW INDEXES with WHERE") {
+    actual("show all indexes where type = 'BTREE'") should equal(expected("SHOW ALL INDEXES%nWHERE type = 'BTREE'"))
   }
 
   test("should not break on ASC") {


### PR DESCRIPTION
Also deprecate BRIEF and VERBOSE keywords.

Depends on https://github.com/neo-technology/neo4j/pull/8855 (merged)