### PR TITLE
4.0 cypher query syntax fix part 2 (#933)

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CaseExpressionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CaseExpressionsTest.scala
@@ -28,59 +28,67 @@ class CaseExpressionsTest extends DocumentingTest {
   override def doc = new DocBuilder {
     doc("`CASE` expressions", "query-syntax-case")
     runtime("interpreted")
-    initQueries(
-      """CREATE (alice:A {name:'Alice', age: 38, eyes: 'brown'}),
-        |       (bob:B {name: 'Bob', age: 25, eyes: 'blue'}),
-        |       (charlie:C {name: 'Charlie', age: 53, eyes: 'green'}),
-        |       (daniel:D {name: 'Daniel', eyes: 'brown'}),
-        |       (eskil:E {name: 'Eskil', age: 41, eyes: 'blue', array: ['one', 'two', 'three']}),
-        |
-        |       (alice)-[:KNOWS]->(bob),
-        |       (alice)-[:KNOWS]->(charlie),
-        |       (bob)-[:KNOWS]->(daniel),
-        |       (charlie)-[:KNOWS]->(daniel),
-        |       (bob)-[:MARRIED]->(eskil)""")
-    p(
-      """Generic conditional expressions may be expressed using the well-known `CASE` construct.
-        |Two variants of `CASE` exist within Cypher: the simple form, which allows an expression to be compared against multiple values, and the generic form, which allows multiple conditional statements to be expressed.
-      """.stripMargin)
+    initQueries("""CREATE
+                  #  (alice:A {name:'Alice', age: 38, eyes: 'brown'}),
+                  #  (bob:B {name: 'Bob', age: 25, eyes: 'blue'}),
+                  #  (charlie:C {name: 'Charlie', age: 53, eyes: 'green'}),
+                  #  (daniel:D {name: 'Daniel', eyes: 'brown'}),
+                  #  (eskil:E {name: 'Eskil', age: 41, eyes: 'blue', array: ['one', 'two', 'three']}),
+                  #  (alice)-[:KNOWS]->(bob),
+                  #  (alice)-[:KNOWS]->(charlie),
+                  #  (bob)-[:KNOWS]->(daniel),
+                  #  (charlie)-[:KNOWS]->(daniel),
+                  #  (bob)-[:MARRIED]->(eskil)""".stripMargin('#'))
+    p("""Generic conditional expressions may be expressed using the well-known `CASE` construct.
+        #Two variants of `CASE` exist within Cypher: the simple form, which allows an expression to be compared against multiple values, and the generic form, which allows multiple conditional statements to be expressed.""".stripMargin('#'))
     p("The following graph is used for the examples below:")
     graphViz()
     section("Simple `CASE` form: comparing an expression against multiple values", "syntax-simple-case") {
-      p(
-        """The expression is calculated, and compared in order with the `WHEN` clauses until a match is found.
-          |If no match is found, the expression in the `ELSE` clause is returned.
-          |However, if there is no `ELSE` case and no match is found, `null` will be returned.""".stripMargin)
-      functionWithCypherStyleFormatting(
-        "CASE test \n WHEN value THEN result \n  [WHEN ...] \n  [ELSE default] \nEND", ("test", "A valid expression."), ("value", "An expression whose result will be compared to `test`."), ("result", "This is the expression returned as output if `value` matches `test`."), ("default", "If no match is found, `default` is returned."))
-      query(
-        """MATCH (n)
-          |RETURN
-          |CASE n.eyes
-          |WHEN 'blue'  THEN 1
-          |WHEN 'brown' THEN 2
-          |ELSE 3
-          |END AS result""".stripMargin, ResultAssertions((r) => {
+      p("""The expression is calculated, and compared in order with the `WHEN` clauses until a match is found.
+          #If no match is found, the expression in the `ELSE` clause is returned.
+          #However, if there is no `ELSE` case and no match is found, `null` will be returned.""".stripMargin('#'))
+      functionWithCypherStyleFormatting("""CASE test
+                                          #  WHEN value THEN result
+                                          #  [WHEN ...]
+                                          #  [ELSE default]
+                                          #END""".stripMargin('#'),
+      ("test", "A valid expression."),
+      ("value", "An expression whose result will be compared to `test`."),
+      ("result", "This is the expression returned as output if `value` matches `test`."),
+      ("default", "If no match is found, `default` is returned."))
+      query("""MATCH (n)
+              #RETURN
+              #CASE n.eyes
+              #  WHEN 'blue'  THEN 1
+              #  WHEN 'brown' THEN 2
+              #  ELSE 3
+              #END AS result""".stripMargin('#'),
+      ResultAssertions((r) => {
           r.toList should equal(List(Map("result" -> 2), Map("result" -> 1), Map("result" -> 3), Map("result" -> 2), Map("result" -> 1)))
-        })) {
+      })) {
         resultTable()
       }
     }
     section("Generic `CASE` form: allowing for multiple conditionals to be expressed", "syntax-generic-case") {
-      p(
-        """The predicates are evaluated in order until a `true` value is found, and the result value is used.
-          |If no match is found, the expression in the `ELSE` clause is returned.
-          |However, if there is no `ELSE` case and no match is found, `null` will be returned.""".stripMargin)
-      functionWithCypherStyleFormatting(
-        "CASE \nWHEN predicate THEN result \n  [WHEN ...] \n  [ELSE default] \nEND", ("predicate", "A predicate that is tested to find a valid alternative."), ("result", "This is the expression returned as output if `predicate` evaluates to `true`."), ("default", "If no match is found, `default` is returned."))
-      query(
-        """MATCH (n)
-          |RETURN
-          |CASE
-          |WHEN n.eyes = 'blue'  THEN 1
-          |WHEN n.age < 40       THEN 2
-          |ELSE 3
-          |END AS result""".stripMargin, ResultAssertions((r) => {
+      p("""The predicates are evaluated in order until a `true` value is found, and the result value is used.
+          #If no match is found, the expression in the `ELSE` clause is returned.
+          #However, if there is no `ELSE` case and no match is found, `null` will be returned.""".stripMargin('#'))
+      functionWithCypherStyleFormatting("""CASE
+                                          #  WHEN predicate THEN result
+                                          #  [WHEN ...]
+                                          #  [ELSE default]
+                                          #END""".stripMargin('#'),
+      ("predicate", "A predicate that is tested to find a valid alternative."),
+      ("result", "This is the expression returned as output if `predicate` evaluates to `true`."),
+      ("default", "If no match is found, `default` is returned."))
+      query("""MATCH (n)
+              #RETURN
+              #CASE
+              #  WHEN n.eyes = 'blue' THEN 1
+              #  WHEN n.age < 40      THEN 2
+              #  ELSE 3
+              #END AS result""".stripMargin('#'),
+      ResultAssertions((r) => {
           r.toList should equal(List(Map("result" -> 2), Map("result" -> 1), Map("result" -> 3), Map("result" -> 3), Map("result" -> 1)))
         })) {
         resultTable()
@@ -89,31 +97,31 @@ class CaseExpressionsTest extends DocumentingTest {
     section("Distinguishing between when to use the simple and generic `CASE` forms", "syntax-distinguish-case") {
       p(
         """Owing to the close similarity between the syntax of the two forms, sometimes it may not be clear at the outset as to which form to use.
-          |We illustrate this scenario by means of the following query, in which there is an expectation that `age_10_years_ago` is `-1` if `n.age` is `null`:
-        """.stripMargin)
-      query(
-        """MATCH (n)
-          |RETURN n.name,
-          |CASE n.age
-          |WHEN n.age IS NULL THEN -1
-          |ELSE n.age - 10
-          |END AS age_10_years_ago""".stripMargin, ResultAssertions((r) => {
+          #We illustrate this scenario by means of the following query, in which there is an expectation that `age_10_years_ago` is `-1` if `n.age` is `null`:
+        """.stripMargin('#'))
+      query("""MATCH (n)
+              #RETURN n.name,
+              #CASE n.age
+              #  WHEN n.age IS NULL THEN -1
+              #  ELSE n.age - 10
+              #END AS age_10_years_ago""".stripMargin('#'),
+      ResultAssertions((r) => {
           r.toList should equal(List(Map("age_10_years_ago" -> 28, "n.name" -> "Alice"), Map("age_10_years_ago" -> 15, "n.name" -> "Bob"), Map("age_10_years_ago" -> 43, "n.name" -> "Charlie"), Map("age_10_years_ago" -> null, "n.name" -> "Daniel"), Map("age_10_years_ago" -> 31, "n.name" -> "Eskil")))
         })) {
         p("""However, as this query is written using the simple `CASE` form, instead of `age_10_years_ago` being `-1` for the node named `Daniel`, it is `null`.
-          |This is because a comparison is made between `n.age` and `n.age IS NULL`.
-          |As `n.age IS NULL` is a boolean value, and `n.age` is an integer value, the `WHEN n.age IS NULL THEN -1` branch is never taken.
-          |This results in the `ELSE n.age - 10` branch being taken instead, returning `null`.""".stripMargin)
+            #This is because a comparison is made between `n.age` and `n.age IS NULL`.
+            #As `n.age IS NULL` is a boolean value, and `n.age` is an integer value, the `WHEN n.age IS NULL THEN -1` branch is never taken.
+            #This results in the `ELSE n.age - 10` branch being taken instead, returning `null`.""".stripMargin('#'))
         resultTable()
       }
       p("""The corrected query, behaving as expected, is given by the following generic `CASE` form:""")
-      query(
-        """MATCH (n)
-          |RETURN n.name,
-          |CASE
-          |WHEN n.age IS NULL THEN -1
-          |ELSE n.age - 10
-          |END AS age_10_years_ago""".stripMargin, ResultAssertions((r) => {
+      query("""MATCH (n)
+              #RETURN n.name,
+              #CASE
+              #  WHEN n.age IS NULL THEN -1
+              #  ELSE n.age - 10
+              #END AS age_10_years_ago""".stripMargin('#'),
+      ResultAssertions((r) => {
           r.toList should equal(List(Map("age_10_years_ago" -> 28, "n.name" -> "Alice"), Map("age_10_years_ago" -> 15, "n.name" -> "Bob"), Map("age_10_years_ago" -> 43, "n.name" -> "Charlie"), Map("age_10_years_ago" -> -1, "n.name" -> "Daniel"), Map("age_10_years_ago" -> 31, "n.name" -> "Eskil")))
         })) {
         p("""We now see that the `age_10_years_ago` correctly returns `-1` for the node named `Daniel`.""".stripMargin)

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/OperatorsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/OperatorsTest.scala
@@ -90,13 +90,14 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
           |* remove duplicates values: `DISTINCT`""".stripMargin)
       section("Using the `DISTINCT` operator", "syntax-using-the-distinct-operator") {
         p("Retrieve the unique eye colors from `Person` nodes.")
-        query(
-          """CREATE (a:Person {name: 'Anne', eyeColor: 'blue'}),
-                        (b:Person {name: 'Bill', eyeColor: 'brown'}),
-                        (c:Person {name: 'Carol', eyeColor: 'blue'})
-                        WITH [a, b, c] AS ps
-                  UNWIND ps AS p
-                  RETURN DISTINCT p.eyeColor""", ResultAssertions((r) => {
+        query("""CREATE
+                #  (a:Person {name: 'Anne', eyeColor: 'blue'}),
+                #  (b:Person {name: 'Bill', eyeColor: 'brown'}),
+                #  (c:Person {name: 'Carol', eyeColor: 'blue'})
+                #WITH [a, b, c] AS ps
+                #UNWIND ps AS p
+                #RETURN DISTINCT p.eyeColor""".stripMargin('#'),
+        ResultAssertions((r) => {
             r.toList should equal(List(Map("p.eyeColor" -> "blue"), Map("p.eyeColor" -> "brown")))
           })) {
           p("Even though both *'Anne'* and *'Carol'* have blue eyes, *'blue'* is only returned once.")
@@ -114,12 +115,13 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
           |* property replacement `=` for replacing all properties of a node or relationship
           |* property mutation operator `+=` for setting specific properties of a node or relationship""".stripMargin)
       section("Statically accessing a property of a node or relationship using the `.` operator", "syntax-accessing-the-property-of-a-node-or-relationship") {
-        query(
-          """CREATE (a:Person {name: 'Jane', livesIn: 'London'}),
-            | (b:Person {name: 'Tom', livesIn: 'Copenhagen'})
-            |WITH a, b
-            |MATCH (p:Person)
-            |RETURN  p.name""".stripMargin, ResultAssertions((r) => {
+        query("""CREATE
+                #  (a:Person {name: 'Jane', livesIn: 'London'}),
+                #  (b:Person {name: 'Tom', livesIn: 'Copenhagen'})
+                #WITH a, b
+                #MATCH (p:Person)
+                #RETURN  p.name""".stripMargin('#'),
+        ResultAssertions((r) => {
             r.toList should equal(List(Map("p.name" -> "Jane"), Map("p.name" -> "Tom")))
           })) {
           resultTable()
@@ -127,14 +129,16 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
       }
       section("Filtering on a dynamically-computed property key using the `[]` operator", "syntax-filtering-on-a-dynamically-computed-property-key") {
         query(
-          """CREATE (a:Restaurant {name: 'Hungry Jo', rating_hygiene: 10, rating_food: 7}),
-            |(b:Restaurant {name: 'Buttercup Tea Rooms', rating_hygiene: 5, rating_food: 6}),
-            |(c1:Category {name: 'hygiene'}),
-            |(c2:Category {name: 'food'})
-            |WITH a, b, c1, c2
-            |MATCH (restaurant:Restaurant), (category:Category)
-            |WHERE restaurant["rating_" + category.name] > 6
-            |RETURN DISTINCT restaurant.name""".stripMargin, ResultAssertions((r) => {
+          """CREATE
+            #  (a:Restaurant {name: 'Hungry Jo', rating_hygiene: 10, rating_food: 7}),
+            #  (b:Restaurant {name: 'Buttercup Tea Rooms', rating_hygiene: 5, rating_food: 6}),
+            #  (c1:Category {name: 'hygiene'}),
+            #  (c2:Category {name: 'food'})
+            #WITH a, b, c1, c2
+            #MATCH (restaurant:Restaurant), (category:Category)
+            #WHERE restaurant["rating_" + category.name] > 6
+            #RETURN DISTINCT restaurant.name""".stripMargin('#'),
+        ResultAssertions((r) => {
             r.toList should equal(List(Map("restaurant.name" -> "Hungry Jo")))
           })) {
           resultTable()
@@ -147,10 +151,11 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
       section("Replacing all properties of a node or relationship using the `=` operator", "syntax-property-replacement-operator") {
         query(
           """CREATE (a:Person {name: 'Jane', age: 20})
-            |WITH a
-            |MATCH (p:Person {name: 'Jane'})
-            |SET p = {name: 'Ellen', livesIn: 'London'}
-            |RETURN p.name, p.age, p.livesIn""".stripMargin, ResultAssertions((r) => {
+            #WITH a
+            #MATCH (p:Person {name: 'Jane'})
+            #SET p = {name: 'Ellen', livesIn: 'London'}
+            #RETURN p.name, p.age, p.livesIn""".stripMargin('#'),
+        ResultAssertions((r) => {
             r.toList should equal(List(Map("p.name" -> "Ellen", "p.age" -> null, "p.livesIn" -> "London")))
             assertStats(r, propertiesWritten = 5, nodesCreated = 1, labelsAdded = 1)
           })) {
@@ -160,12 +165,12 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
         p("See <<set-replace-properties-using-map>> for more details on using the property replacement operator `=`.")
       }
       section("Mutating specific properties of a node or relationship using the `+=` operator", "syntax-property-mutation-operator") {
-        query(
-          """CREATE (a:Person {name: 'Jane', age: 20})
-            |WITH a
-            |MATCH (p:Person {name: 'Jane'})
-            |SET p += {name: 'Ellen', livesIn: 'London'}
-            |RETURN p.name, p.age, p.livesIn""".stripMargin, ResultAssertions((r) => {
+        query("""CREATE (a:Person {name: 'Jane', age: 20})
+                #WITH a
+                #MATCH (p:Person {name: 'Jane'})
+                #SET p += {name: 'Ellen', livesIn: 'London'}
+                #RETURN p.name, p.age, p.livesIn""".stripMargin('#'),
+        ResultAssertions((r) => {
             r.toList should equal(List(Map("p.name" -> "Ellen", "p.age" -> 20, "p.livesIn" -> "London")))
             assertStats(r, propertiesWritten = 4, nodesCreated = 1, labelsAdded = 1)
           })) {
@@ -188,16 +193,17 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
       section("Using the exponentiation operator `^`", "syntax-using-the-exponentiation-operator") {
         query(
           """WITH 2 AS number, 3 AS exponent
-            |RETURN number ^ exponent AS result""".stripMargin, ResultAssertions((r) => {
+            #RETURN number ^ exponent AS result""".stripMargin('#'),
+        ResultAssertions((r) => {
             r.toList should equal(List(Map("result" -> 8l)))
           })) {
           resultTable()
         }
       }
       section("Using the unary minus operator `-`", "syntax-using-the-unary-minus-operator") {
-        query(
-          """WITH -3 AS a, 4 AS b
-            |RETURN b - a AS result""".stripMargin, ResultAssertions((r) => {
+        query("""WITH -3 AS a, 4 AS b
+                #RETURN b - a AS result""".stripMargin('#'),
+        ResultAssertions((r) => {
             r.toList should equal(List(Map("result" -> 7l)))
           })) {
           resultTable()
@@ -220,12 +226,12 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
         p(
           """* `STARTS WITH`: perform case-sensitive prefix searching on strings
             |* `ENDS WITH`: perform case-sensitive suffix searching on strings
-            |* `CONTAINS`: perform case-sensitive inclusion searching in strings""")
+            |* `CONTAINS`: perform case-sensitive inclusion searching in strings""".stripMargin)
       }
       section("Comparing two numbers", "syntax-comparing-two-numbers") {
-        query(
-          """WITH 4 AS one, 3 AS two
-            |RETURN one > two AS result""".stripMargin, ResultAssertions((r) => {
+        query("""WITH 4 AS one, 3 AS two
+                #RETURN one > two AS result""".stripMargin('#'),
+        ResultAssertions((r) => {
             r.toList should equal(List(Map("result" -> true)))
           })) {
           resultTable()
@@ -233,12 +239,12 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
       }
       p("""See <<cypher-comparison>> for more details on the behavior of comparison operators, and <<query-where-ranges>> for more examples showing how these may be used.""")
       section("Using `STARTS WITH` to filter names", "syntax-using-starts-with-to-filter-names") {
-        query(
-          """WITH ['John', 'Mark', 'Jonathan', 'Bill'] AS somenames
-         UNWIND somenames AS names
-         WITH names AS candidate
-         WHERE candidate STARTS WITH 'Jo'
-         RETURN candidate""", ResultAssertions((r) => {
+        query("""WITH ['John', 'Mark', 'Jonathan', 'Bill'] AS somenames
+                #UNWIND somenames AS names
+                #WITH names AS candidate
+                #WHERE candidate STARTS WITH 'Jo'
+                #RETURN candidate""".stripMargin('#'),
+        ResultAssertions((r) => {
             r.toList should equal(List(Map("candidate" -> "John"), Map("candidate" -> "Jonathan")))
           })) {
           resultTable()
@@ -274,12 +280,12 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
           |
           |""")
       section("Using boolean operators to filter numbers", "syntax-using-boolean-operators-to-filter-numbers") {
-        query(
-          """WITH [2, 4, 7, 9, 12] AS numberlist
-            |UNWIND numberlist AS number
-            |WITH number
-            |WHERE number = 4 OR (number > 6 AND number < 10)
-            |RETURN number""".stripMargin, ResultAssertions((r) => {
+        query("""WITH [2, 4, 7, 9, 12] AS numberlist
+                #UNWIND numberlist AS number
+                #WITH number
+                #WHERE number = 4 OR (number > 6 AND number < 10)
+                #RETURN number""".stripMargin('#'),
+        ResultAssertions((r) => {
             r.toList should equal(List(Map("number" -> 4l), Map("number" -> 7l), Map("number" -> 9l)))
           })) {
           resultTable()
@@ -293,20 +299,19 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
           |* concatenating strings: `+`
           |* matching a regular expression: `=~`""".stripMargin)
       section("Using a regular expression with `=~` to filter words", "syntax-using-a-regular-expression-to-filter-words") {
-        query(
-          """WITH ['mouse', 'chair', 'door', 'house'] AS wordlist
-            |UNWIND wordlist AS word
-            |WITH word
-            |WHERE word =~ '.*ous.*'
-            |RETURN word""".stripMargin, ResultAssertions((r) => {
+        query("""WITH ['mouse', 'chair', 'door', 'house'] AS wordlist
+                #UNWIND wordlist AS word
+                #WITH word
+                #WHERE word =~ '.*ous.*'
+                #RETURN word""".stripMargin('#'),
+        ResultAssertions((r) => {
             r.toList should equal(List(Map("word" -> "mouse"), Map("word" -> "house")))
           })) {
           resultTable()
         }
       }
-      p(
-        """Further information and examples regarding the use of regular expressions in filtering can be found in <<query-where-regex>>.
-          |In addition, refer to <<query-operator-comparison-string-specific>> for details on string-specific comparison operators.""")
+      p("""Further information and examples regarding the use of regular expressions in filtering can be found in <<query-where-regex>>.
+          #In addition, refer to <<query-operator-comparison-string-specific>> for details on string-specific comparison operators.""".stripMargin('#'))
     }
     section("Temporal operators", "query-operators-temporal") {
       p(
@@ -334,10 +339,11 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
           |
         """)
       section("Adding and subtracting a _Duration_ to or from a temporal instant", "syntax-add-subtract-duration-to-temporal-instant") {
-        query(
-          """WITH localdatetime({year:1984, month:10, day:11, hour:12, minute:31, second:14}) AS aDateTime,
-            |     duration({years: 12, nanoseconds: 2}) AS aDuration
-            |RETURN aDateTime + aDuration, aDateTime - aDuration""".stripMargin, ResultAssertions((r) => {
+        query("""WITH
+                #  localdatetime({year:1984, month:10, day:11, hour:12, minute:31, second:14}) AS aDateTime,
+                #  duration({years: 12, nanoseconds: 2}) AS aDuration
+                #RETURN aDateTime + aDuration, aDateTime - aDuration""".stripMargin('#'),
+        ResultAssertions((r) => {
             r.toList should equal(List(
               Map(
                 "aDateTime - aDuration" -> LocalDateTimeValue.parse("1972-10-11T12:31:13.999999998").asObjectCopy(),
@@ -350,10 +356,11 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
           """<<cypher-temporal-duration-component, Components of a _Duration_>> that do not apply to the temporal instant are ignored.
             |For example, when adding a _Duration_ to a _Date_, the _hours_, _minutes_, _seconds_ and _nanoseconds_ of the _Duration_ are ignored (_Time_ behaves in an analogous manner):
           """.stripMargin)
-        query(
-          """WITH date({year:1984, month:10, day:11}) AS aDate,
-            |     duration({years: 12, nanoseconds: 2}) AS aDuration
-            |RETURN aDate + aDuration, aDate - aDuration""".stripMargin, ResultAssertions((r) => {
+        query("""WITH
+                #  date({year:1984, month:10, day:11}) AS aDate,
+                #  duration({years: 12, nanoseconds: 2}) AS aDuration
+                #RETURN aDate + aDuration, aDate - aDuration""".stripMargin('#'),
+        ResultAssertions((r) => {
             r.toList should equal(List(
               Map(
                 "aDate - aDuration" -> DateValue.parse("1972-10-11").asObjectCopy(),
@@ -366,9 +373,10 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
           """Adding two durations to a temporal instant is not an associative operation.
             |This is because non-existing dates are truncated to the nearest existing date:""".stripMargin)
         query(
-          """RETURN (date("2011-01-31") + duration("P1M")) + duration("P12M") AS date1,
-            |   date("2011-01-31") + (duration("P1M") + duration("P12M")) AS date2
-          """.stripMargin, ResultAssertions((r) => {
+          """RETURN
+            #  (date("2011-01-31") + duration("P1M")) + duration("P12M") AS date1,
+            #  date("2011-01-31") + (duration("P1M") + duration("P12M")) AS date2""".stripMargin('#'),
+        ResultAssertions((r) => {
             r.toList should equal(List(
               Map(
                 "date1" -> DateValue.parse("2012-02-28").asObjectCopy(),
@@ -379,10 +387,11 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
         }
       }
       section("Adding and subtracting a _Duration_ to or from another _Duration_", "syntax-add-subtract-duration-to-duration") {
-        query(
-          """WITH duration({years: 12, months: 5, days: 14, hours: 16, minutes: 12, seconds: 70, nanoseconds: 1}) as duration1,
-            |     duration({months:1, days: -14, hours: 16, minutes: -12, seconds: 70}) AS duration2
-            |RETURN duration1, duration2, duration1 + duration2, duration1 - duration2""".stripMargin, ResultAssertions((r) => {
+        query("""WITH
+                #  duration({years: 12, months: 5, days: 14, hours: 16, minutes: 12, seconds: 70, nanoseconds: 1}) as duration1,
+                #  duration({months:1, days: -14, hours: 16, minutes: -12, seconds: 70}) AS duration2
+                #RETURN duration1, duration2, duration1 + duration2, duration1 - duration2""".stripMargin('#'),
+        ResultAssertions((r) => {
             r.toList should equal(List(
               Map(
                 "duration1" -> DurationValue.parse("P12Y5M14DT16H13M10.000000001S"),
@@ -396,9 +405,9 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
       }
       section("Multiplying and dividing a _Duration_ with or by a number", "syntax-multiply-divide-duration-number") {
         p("""These operations are interpreted simply as component-wise operations with overflow to smaller units based on an average length of units in the case of division (and multiplication with fractions).""".stripMargin)
-        query(
-          """WITH duration({days: 14, minutes: 12, seconds: 70, nanoseconds: 1}) AS aDuration
-            |RETURN aDuration, aDuration * 2, aDuration / 3""".stripMargin, ResultAssertions((r) => {
+        query("""WITH duration({days: 14, minutes: 12, seconds: 70, nanoseconds: 1}) AS aDuration
+                #RETURN aDuration, aDuration * 2, aDuration / 3""".stripMargin('#'),
+        ResultAssertions((r) => {
             r.toList should equal(List(
               Map(
                 "aDuration" -> DurationValue.parse("P14DT13M10.000000001S"),
@@ -421,9 +430,9 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
         p("""The behavior of the `[]` operator with respect to `null` is detailed in <<cypher-null-bracket-operator>>.""")
       }
       section("Statically accessing the value of a nested map by key using the `.` operator", "syntax-accessing-the-value-of-a-nested-map") {
-        query(
-          """WITH {person: {name: 'Anne', age: 25}} AS p
-            |RETURN  p.person.name""".stripMargin, ResultAssertions((r) => {
+        query("""WITH {person: {name: 'Anne', age: 25}} AS p
+                #RETURN  p.person.name""".stripMargin('#'),
+        ResultAssertions((r) => {
             r.toList should equal(List(Map("p.person.name" -> "Anne")))
           })) {
           resultTable()
@@ -432,9 +441,9 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
       section("Dynamically accessing the value of a map by key using the `[]` operator and a parameter", "syntax-accessing-dynamic-map-parameter") {
         p(
           """A parameter may be used to specify the key of the value to access:""".stripMargin)
-        query(
-          """WITH {name: 'Anne', age: 25} AS a
-            |RETURN a[$myKey] AS result""".stripMargin, ResultAssertions((r) => {
+        query("""WITH {name: 'Anne', age: 25} AS a
+                #RETURN a[$myKey] AS result""".stripMargin('#'),
+        ResultAssertions((r) => {
             r.toList should equal(List(Map("result" -> "Anne")))
           }),
           ("myKey", "name")) {
@@ -454,20 +463,20 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
         p("""The behavior of the `IN` and `[]` operators with respect to `null` is detailed <<cypher-working-with-null, here>>.""")
       }
       section("Concatenating two lists using `+`", "syntax-concatenating-two-lists") {
-        query(
-          """RETURN [1,2,3,4,5] + [6,7] AS myList""".stripMargin, ResultAssertions((r) => {
+        query("""RETURN [1,2,3,4,5] + [6,7] AS myList""",
+        ResultAssertions((r) => {
             r.toList should equal(List(Map("myList" -> List(1L, 2L, 3L, 4L, 5L, 6L, 7L))))
           })) {
           resultTable()
         }
       }
       section("Using `IN` to check if a number is in a list", "syntax-using-in-to-check-if-a-number-is-in-a-list") {
-        query(
-          """WITH [2, 3, 4, 5] AS numberlist
-            |UNWIND numberlist AS number
-            |WITH number
-            |WHERE number IN [2, 3, 8]
-            |RETURN number""".stripMargin, ResultAssertions((r) => {
+        query("""WITH [2, 3, 4, 5] AS numberlist
+                #UNWIND numberlist AS number
+                #WITH number
+                #WHERE number IN [2, 3, 8]
+                #RETURN number""".stripMargin('#'),
+        ResultAssertions((r) => {
             r.toList should equal(List(Map("number" -> 2l), Map("number" -> 3l)))
           })) {
           resultTable()
@@ -478,8 +487,8 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
           """The general rule is that the `IN` operator will evaluate to `true` if the list given as the right-hand operand contains an element which has the same _type and contents (or value)_ as the left-hand operand.
             |Lists are only comparable to other lists, and elements of a list `innerList` are compared pairwise in ascending order from the first element in `innerList` to the last element in `innerList`.""".stripMargin)
         p("""The following query checks whether or not the list `[2, 1]` is an element of the list `[1, [2, 1], 3]`:""".stripMargin)
-        query(
-          """RETURN [2, 1] IN [1, [2, 1], 3] AS inList""".stripMargin, ResultAssertions((r) => {
+        query("""RETURN [2, 1] IN [1, [2, 1], 3] AS inList""",
+        ResultAssertions((r) => {
             r.toList should equal(List(Map("inList" -> true)))
           })) {
           p(
@@ -490,8 +499,8 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
         }
         p(
           """At first glance, the contents of the left-hand operand and the right-hand operand _appear_ to be the same in the following query:""".stripMargin)
-        query(
-          """RETURN [1, 2] IN [1, 2] AS inList""".stripMargin, ResultAssertions((r) => {
+        query("""RETURN [1, 2] IN [1, 2] AS inList""",
+        ResultAssertions((r) => {
             r.toList should equal(List(Map("inList" -> false)))
           })) {
           p("""However, `IN` evaluates to `false` as the right-hand operand does not contain an element that is of the same _type_ -- i.e. a _list_ -- as the left-hand-operand.""")
@@ -509,9 +518,9 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
         p("""As long as `labels(n)` returns either `Person` or `Employee` (or both), the query will return a value greater than zero.""")
       }
       section("Accessing elements in a list using the `[]` operator", "syntax-accessing-elements-in-a-list") {
-        query(
-          """WITH ['Anne', 'John', 'Bill', 'Diane', 'Eve'] AS names
-            |RETURN names[1..3] AS result""".stripMargin, ResultAssertions((r) => {
+        query("""WITH ['Anne', 'John', 'Bill', 'Diane', 'Eve'] AS names
+                #RETURN names[1..3] AS result""".stripMargin('#'),
+        ResultAssertions((r) => {
             r.toList should equal(List(Map("result" -> List("John", "Bill"))))
           })) {
           p("""The square brackets will extract the elements from the start index `1`, and up to (but excluding) the end index `3`.""")
@@ -521,9 +530,9 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
       section("Dynamically accessing an element in a list using the `[]` operator and a parameter", "syntax-accessing-element-in-a-list-parameter") {
         p(
           """A parameter may be used to specify the index of the element to access:""".stripMargin)
-        query(
-          """WITH ['Anne', 'John', 'Bill', 'Diane', 'Eve'] AS names
-            |RETURN names[$myIndex] AS result""".stripMargin, ResultAssertions((r) => {
+        query("""WITH ['Anne', 'John', 'Bill', 'Diane', 'Eve'] AS names
+                #RETURN names[$myIndex] AS result""".stripMargin('#'),
+        ResultAssertions((r) => {
             r.toList should equal(List(Map("result" -> "John")))
           }),
           ("myIndex", 1L)) {
@@ -533,9 +542,9 @@ class OperatorsTest extends DocumentingTest with QueryStatisticsTestSupport {
       section("Using `IN` with `[]` on a nested list", "syntax-using-in-with-nested-list-subscripting") {
         p(
           """`IN` can be used in conjunction with `[]` to test whether an element exists in a nested list:""".stripMargin)
-        query(
-          """WITH [[1, 2, 3]] AS l
-            |RETURN 3 IN l[0] AS result""".stripMargin, ResultAssertions((r) => {
+        query("""WITH [[1, 2, 3]] AS l
+                #RETURN 3 IN l[0] AS result""".stripMargin('#'),
+        ResultAssertions((r) => {
             r.toList should equal(List(Map("result" -> true)))
           }),
           ("myIndex", 1L)) {


### PR DESCRIPTION
Fixed indentation for Case Expressions.
Fixed Cypher style for Operators.
Indent on create with several nodes and relationships.