### PR TITLE
SHOW USER/ROLE PRIVILEGES allows yield and where

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/role-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/role-management-syntax.asciidoc
@@ -25,6 +25,8 @@ SHOW [ALL\|POPULATED] ROLES WITH USERS
 | [source, cypher, role=noplay]
 ----
 SHOW ROLE name PRIVILEGES
+    [YIELD field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
+    [WHERE expression]
 ----
 | List the privileges granted to a role.
 | <<administration-security-administration-dbms-privileges-role-management, SHOW ROLE PRIVILEGES>>

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/user-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/user-management-syntax.asciidoc
@@ -17,6 +17,8 @@ SHOW USERS
 | [source, cypher, role=noplay]
 ----
 SHOW USER [name] PRIVILEGES
+    [YIELD field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
+    [WHERE expression]
 ----
 | List the privileges granted to a user.
 | <<administration-security-administration-dbms-privileges-privilege-management, SHOW PRIVILEGE>> and


### PR DESCRIPTION
The syntax was correct in the privilege section but missing in the user and role sections.

This is already fixed in later versions but was apparently missed here.