### PR TITLE
4.0 cypher query syntax fix part 8 (#961)

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/OptionalMatchTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/OptionalMatchTest.scala
@@ -28,79 +28,76 @@ class OptionalMatchTest extends DocumentingTest {
   override def doc = new DocBuilder {
     doc("OPTIONAL MATCH", "query-optional-match")
     initQueries(
-      """CREATE (charlie:Person {name: 'Charlie Sheen'}),
-        |       (martin:Person {name: 'Martin Sheen'}),
-        |       (michael:Person {name: 'Michael Douglas'}),
-        |       (oliver:Person {name: 'Oliver Stone'}),
-        |       (rob:Person {name: 'Rob Reiner'}),
-        |
-        |       (wallStreet:Movie {title: 'Wall Street'}),
-        |
-        |       (charlie)-[:ACTED_IN]->(wallStreet),
-        |       (martin)-[:ACTED_IN]->(wallStreet),
-        |       (michael)-[:ACTED_IN]->(wallStreet),
-        |       (oliver)-[:DIRECTED]->(wallStreet),
-        |
-        |       (thePresident:Movie {title: 'The American President'}),
-        |
-        |       (martin)-[:ACTED_IN]->(thePresident),
-        |       (michael)-[:ACTED_IN]->(thePresident),
-        |       (rob)-[:DIRECTED]->(thePresident),
-        |
-        |       (charlie)-[:FATHER]->(martin)
-      """.stripMargin)
+      """CREATE
+        #  (charlie:Person {name: 'Charlie Sheen'}),
+        #  (martin:Person {name: 'Martin Sheen'}),
+        #  (michael:Person {name: 'Michael Douglas'}),
+        #  (oliver:Person {name: 'Oliver Stone'}),
+        #  (rob:Person {name: 'Rob Reiner'}),
+        #  (wallStreet:Movie {title: 'Wall Street'}),
+        #  (charlie)-[:ACTED_IN]->(wallStreet),
+        #  (martin)-[:ACTED_IN]->(wallStreet),
+        #  (michael)-[:ACTED_IN]->(wallStreet),
+        #  (oliver)-[:DIRECTED]->(wallStreet),
+        #  (thePresident:Movie {title: 'The American President'}),
+        #  (martin)-[:ACTED_IN]->(thePresident),
+        #  (michael)-[:ACTED_IN]->(thePresident),
+        #  (rob)-[:DIRECTED]->(thePresident),
+        #  (charlie)-[:FATHER]->(martin)""".stripMargin('#'))
     synopsis("The `OPTIONAL MATCH` clause is used to search for the pattern described in it, while using nulls for missing parts of the pattern.")
-    p(
-      """
-        |* <<optional-match-introduction, Introduction>>
-        |* <<optional-relationships, Optional relationships>>
-        |* <<properties-on-optional-elements, Properties on optional elements>>
-        |* <<optional-typed-named-relationship, Optional typed and named relationship>>
-      """.stripMargin)
+    p("""* <<optional-match-introduction, Introduction>>
+        #* <<optional-relationships, Optional relationships>>
+        #* <<properties-on-optional-elements, Properties on optional elements>>
+        #* <<optional-typed-named-relationship, Optional typed and named relationship>>""".stripMargin('#'))
     section("Introduction", "optional-match-introduction") {
-      p(
-        """`OPTIONAL MATCH` matches patterns against your graph database, just like `MATCH` does.
-          |The difference is that if no matches are found, `OPTIONAL MATCH` will use a `null` for missing parts of the pattern.
-          |`OPTIONAL MATCH` could be considered the Cypher equivalent of the outer join in SQL.
-        """)
-      p(
-        """Either the whole pattern is matched, or nothing is matched.
-          |Remember that `WHERE` is part of the pattern description, and the predicates will be considered while looking for matches, not after.
-          |This matters especially in the case of multiple (`OPTIONAL`) `MATCH` clauses, where it is crucial to put `WHERE` together with the `MATCH` it belongs to.""")
+      p("""`OPTIONAL MATCH` matches patterns against your graph database, just like `MATCH` does.
+          #The difference is that if no matches are found, `OPTIONAL MATCH` will use a `null` for missing parts of the pattern.
+          #`OPTIONAL MATCH` could be considered the Cypher equivalent of the outer join in SQL.""".stripMargin('#'))
+      p("""Either the whole pattern is matched, or nothing is matched.
+          #Remember that `WHERE` is part of the pattern description, and the predicates will be considered while looking for matches, not after.
+          #This matters especially in the case of multiple (`OPTIONAL`) `MATCH` clauses, where it is crucial to put `WHERE` together with the `MATCH` it belongs to.""".stripMargin('#'))
       tip {
-        p("To understand the patterns used in the `OPTIONAL MATCH` clause, read <<cypher-patterns>>.")
+        p("""To understand the patterns used in the `OPTIONAL MATCH` clause, read <<cypher-patterns>>.""")
       }
-      p("The following graph is used for the examples below:")
+      p("""The following graph is used for the examples below:""")
       graphViz()
     }
     section("Optional relationships", "optional-relationships") {
-      p(
-        """If a relationship is optional, use the `OPTIONAL MATCH` clause.
-          |This is similar to how a SQL outer join works.
-          |If the relationship is there, it is returned.
-          |If it's not, `null` is returned in its place.""".stripMargin)
-      query("MATCH (a:Movie {title: 'Wall Street'})\nOPTIONAL MATCH (a)-->(x)\nRETURN x", ResultAssertions((r) => {
+      p("""If a relationship is optional, use the `OPTIONAL MATCH` clause.
+          #This is similar to how a SQL outer join works.
+          #If the relationship is there, it is returned.
+          #If it's not, `null` is returned in its place.""".stripMargin('#'))
+      query("""MATCH (a:Movie {title: 'Wall Street'})
+              #OPTIONAL MATCH (a)-->(x)
+              #RETURN x""".stripMargin('#'),
+      ResultAssertions((r) => {
         r.toList should equal(List(Map("x" -> null)))
       })) {
-        p("Returns `null`, since the node has no outgoing relationships.")
+        p("""Returns `null`, since the node has no outgoing relationships.""")
         resultTable()
       }
     }
     section("Properties on optional elements", "properties-on-optional-elements") {
-      p("Returning a property from an optional element that is `null` will also return `null`.")
-      query("MATCH (a:Movie { title: 'Wall Street' })\nOPTIONAL MATCH (a)-->(x)\nRETURN x, x.name", ResultAssertions((r) => {
+      p("""Returning a property from an optional element that is `null` will also return `null`.""")
+      query("""MATCH (a:Movie {title: 'Wall Street'})
+              #OPTIONAL MATCH (a)-->(x)
+              #RETURN x, x.name""".stripMargin('#'),
+      ResultAssertions((r) => {
         r.toList should equal(List(Map("x" -> null, "x.name" -> null)))
       })) {
-        p("Returns the element x (`null` in this query), and `null` as its name.")
+        p("""Returns the element x (`null` in this query), and `null` as its name.""")
         resultTable()
       }
     }
     section("Optional typed and named relationship", "optional-typed-named-relationship") {
       p("Just as with a normal relationship, you can decide which variable it goes into, and what relationship type you need.")
-      query("MATCH (a:Movie {title: 'Wall Street'})\nOPTIONAL MATCH (a)-[r:ACTS_IN]->()\nRETURN a.title, r", ResultAssertions((r) => {
+      query("""MATCH (a:Movie {title: 'Wall Street'})
+              #OPTIONAL MATCH (a)-[r:ACTS_IN]->()
+              #RETURN a.title, r""".stripMargin('#'),
+      ResultAssertions((r) => {
         r.toList should equal(List(Map("a.title" -> "Wall Street", "r" -> null)))
       })) {
-        p("This returns the title of the node, *'Wall Street'*, and, since the node has no outgoing `ACTS_IN` relationships, `null` is returned for the relationship denoted by `r`.")
+        p("""This returns the title of the node, *'Wall Street'*, and, since the node has no outgoing `ACTS_IN` relationships, `null` is returned for the relationship denoted by `r`.""")
         resultTable()
       }
     }

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ReturnTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ReturnTest.scala
@@ -28,88 +28,77 @@ class ReturnTest extends DocumentingTest {
   override def doc = new DocBuilder {
     doc("RETURN", "query-return")
     initQueries(
-      """
-        |CREATE (a {name: 'A', happy: 'Yes!', age: 55}),
-        |       (b {name: 'B'}),
-        |
-        |       (a)-[:KNOWS]->(b),
-        |       (a)-[:BLOCKS]->(b)
-      """.stripMargin)
+      """CREATE
+        #  (a {name: 'A', happy: 'Yes!', age: 55}),
+        #  (b {name: 'B'}),
+        #  (a)-[:KNOWS]->(b),
+        #  (a)-[:BLOCKS]->(b)""".stripMargin('#'))
     synopsis("The `RETURN` clause defines what to include in the query result set.")
-    p(
-      """* <<return-introduction, Introduction>>
-        |* <<return-nodes, Return nodes>>
-        |* <<return-relationships, Return relationships>>
-        |* <<return-property, Return property>>
-        |* <<return-all-elements, Return all elements>>
-        |* <<return-variable-with-uncommon-characters, Variable with uncommon characters>>
-        |* <<return-column-alias, Column alias>>
-        |* <<return-optional-properties, Optional properties>>
-        |* <<return-other-expressions, Other expressions>>
-        |* <<return-unique-results, Unique results>>
-      """.stripMargin)
+    p("""* <<return-introduction, Introduction>>
+        #* <<return-nodes, Return nodes>>
+        #* <<return-relationships, Return relationships>>
+        #* <<return-property, Return property>>
+        #* <<return-all-elements, Return all elements>>
+        #* <<return-variable-with-uncommon-characters, Variable with uncommon characters>>
+        #* <<return-column-alias, Column alias>>
+        #* <<return-optional-properties, Optional properties>>
+        #* <<return-other-expressions, Other expressions>>
+        #* <<return-unique-results, Unique results>>""".stripMargin('#'))
     section("Introduction", "return-introduction") {
-      p(
-        """In the `RETURN` part of your query, you define which parts of the pattern you are interested in.
-          |It can be nodes, relationships, or properties on these.""".stripMargin)
+      p("""In the `RETURN` part of your query, you define which parts of the pattern you are interested in.
+          #It can be nodes, relationships, or properties on these.""".stripMargin('#'))
       tip {
-        p(
-          """If what you actually want is the value of a property, make sure to not return the full node/relationship.
-            |This will improve performance.""".stripMargin)
+        p("""If what you actually want is the value of a property, make sure to not return the full node/relationship.
+            #This will improve performance.""".stripMargin('#'))
       }
       graphViz()
     }
     section("Return nodes", "return-nodes") {
-      p(
-        """To return a node, list it in the `RETURN` statement.""".stripMargin)
-      query(
-        """MATCH (n {name: 'B'})
-          |RETURN n""".stripMargin, assertHasNodes(1)) {
+      p("""To return a node, list it in the `RETURN` statement.""")
+      query("""MATCH (n {name: 'B'})
+              #RETURN n""".stripMargin('#'),
+      assertHasNodes(1)) {
         p("The example will return the node.")
         resultTable()
       }
     }
     section("Return relationships", "return-relationships") {
-      p(
-        """To return a relationship, just include it in the `RETURN` list.""".stripMargin)
-      query(
-        """MATCH (n {name: 'A'})-[r:KNOWS]->(c)
-          |RETURN r""".stripMargin, assertHasRelationships(0)) {
+      p("""To return a relationship, just include it in the `RETURN` list.""")
+      query("""MATCH (n {name: 'A'})-[r:KNOWS]->(c)
+              #RETURN r""".stripMargin('#'),
+      assertHasRelationships(0)) {
         p("The relationship is returned by the example.")
         resultTable()
       }
     }
     section("Return property", "return-property") {
-      p(
-        """To return a property, use the dot separator, like this:""".stripMargin)
-      query(
-        """MATCH (n {name: 'A'})
-          |RETURN n.name""".stripMargin, ResultAssertions((r) => {
+      p("""To return a property, use the dot separator, like this:""")
+      query("""MATCH (n {name: 'A'})
+              #RETURN n.name""".stripMargin('#'),
+      ResultAssertions((r) => {
           r.toList should equal(List(Map("n.name" -> "A")))
         })) {
-        p("The value of the property `name` gets returned.")
+        p("""The value of the property `name` gets returned.""")
         resultTable()
       }
     }
     section("Return all elements", "return-all-elements") {
-      p(
-        """When you want to return all nodes, relationships and paths found in a query, you can use the `*` symbol.""".stripMargin)
-      query(
-        """MATCH p = (a {name: 'A'})-[r]->(b)
-          |RETURN *""".stripMargin, ResultAssertions((r) => {
+      p("""When you want to return all nodes, relationships and paths found in a query, you can use the `*` symbol.""")
+      query("""MATCH p = (a {name: 'A'})-[r]->(b)
+              #RETURN *""".stripMargin('#'),
+      ResultAssertions((r) => {
           r.toList.head.keys should equal(Set("a", "b", "r", "p"))
         })) {
-        p("This returns the two nodes, the relationship and the path used in the query.")
+        p("""This returns the two nodes, the relationship and the path used in the query.""")
         resultTable()
       }
     }
     section("Variable with uncommon characters", "return-variable-with-uncommon-characters") {
-      p(
-        """To introduce a placeholder that is made up of characters that are not contained in the English alphabet, you can use the ``` to enclose the variable, like this:""".stripMargin)
-      query(
-        """MATCH (`This isn\'t a common variable`)
-         WHERE `This isn\'t a common variable`.name = 'A'
-         RETURN `This isn\'t a common variable`.happy""", ResultAssertions((r) => {
+      p("""To introduce a placeholder that is made up of characters that are not contained in the English alphabet, you can use the ``` to enclose the variable, like this:""")
+      query("""MATCH (`This isn\'t a common variable`)
+              #WHERE `This isn\'t a common variable`.name = 'A'
+              #RETURN `This isn\'t a common variable`.happy""".stripMargin('#'),
+      ResultAssertions((r) => {
           r.toList should equal(List(Map("`This isn\\'t a common variable`.happy" -> "Yes!")))
         })) {
         p("The node with name \"A\" is returned.")
@@ -117,11 +106,10 @@ class ReturnTest extends DocumentingTest {
       }
     }
     section("Column alias", "return-column-alias") {
-      p(
-        """If the name of the column should be different from the expression used, you can rename it by using `AS` <new name>.""".stripMargin)
-      query(
-        """MATCH (a {name: 'A'})
-          |RETURN a.age AS SomethingTotallyDifferent""".stripMargin, ResultAssertions((r) => {
+      p("""If the name of the column should be different from the expression used, you can rename it by using `AS` <new name>.""")
+      query("""MATCH (a {name: 'A'})
+              #RETURN a.age AS SomethingTotallyDifferent""".stripMargin('#'),
+      ResultAssertions((r) => {
           r.toList should equal(List(Map("SomethingTotallyDifferent" -> 55l)))
         })) {
         p("Returns the age property of a node, but renames the column.")
@@ -129,38 +117,35 @@ class ReturnTest extends DocumentingTest {
       }
     }
     section("Optional properties", "return-optional-properties") {
-      p(
-        """If a property might or might not be there, you can still select it as usual.
-          |It will be treated as `null` if it is missing.""".stripMargin)
-      query(
-        """MATCH (n)
-          |RETURN n.age""".stripMargin, ResultAssertions((r) => {
+      p("""If a property might or might not be there, you can still select it as usual.
+          #It will be treated as `null` if it is missing.""".stripMargin('#'))
+      query("""MATCH (n)
+              #RETURN n.age""".stripMargin('#'),
+      ResultAssertions((r) => {
           r.toList should equal(List(Map("n.age" -> 55l), Map("n.age" -> null)))
         })) {
-        p("This example returns the age when the node has that property, or `null` if the property is not there.")
+        p("""This example returns the age when the node has that property, or `null` if the property is not there.""")
         resultTable()
       }
     }
     section("Other expressions", "return-other-expressions") {
-      p(
-        """Any expression can be used as a return item -- literals, predicates, properties, functions, and everything else.""".stripMargin)
-      query(
-        """MATCH (a {name: 'A'})
-          |RETURN a.age > 30, "I'm a literal", (a)-->()""".stripMargin, ResultAssertions(r => {
+      p("""Any expression can be used as a return item -- literals, predicates, properties, functions, and everything else.""")
+      query("""MATCH (a {name: 'A'})
+              #RETURN a.age > 30, "I'm a literal", (a)-->()""".stripMargin('#'),
+      ResultAssertions(r => {
           r.toList.head("a.age > 30") shouldBe true
           r.toList.head("\"I'm a literal\"") shouldBe "I'm a literal"
           r.toList.head("(a)-->()").asInstanceOf[Seq[Path]].size shouldBe 2
         })) {
-        p("Returns a predicate, a literal and function call with a pattern expression parameter.")
+        p("""Returns a predicate, a literal and function call with a pattern expression parameter.""")
         resultTable()
       }
     }
     section("Unique results", "return-unique-results") {
-      p(
-        """`DISTINCT` retrieves only unique rows depending on the columns that have been selected to output.""".stripMargin)
-      query(
-        """MATCH (a {name: 'A'})-->(b)
-          |RETURN DISTINCT b""".stripMargin, assertHasNodes(1)) {
+      p("""`DISTINCT` retrieves only unique rows depending on the columns that have been selected to output.""")
+      query("""MATCH (a {name: 'A'})-->(b)
+              #RETURN DISTINCT b""".stripMargin('#'),
+      assertHasNodes(1)) {
         p("The node named \"B\" is returned by the query, but only once.")
         resultTable()
       }


### PR DESCRIPTION
Fixed syntax for optional match clause
Fixed syntax for return clause