### PR TITLE
4.1 cypher query syntax fix part 11 (#976) (#978)

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/OrderByTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/OrderByTest.scala
@@ -27,57 +27,48 @@ class OrderByTest extends DocumentingTest {
   override def doc = new DocBuilder {
     doc("ORDER BY", "query-order")
     initQueries(
-      """
-        |CREATE (a {name: 'A', age: 34, length: 170}),
-        |       (b {name: 'B', age: 36}),
-        |       (c {name: 'C', age: 32, length: 185}),
-        |
-        |       (a)-[:KNOWS]->(b),
-        |       (b)-[:KNOWS]->(c)
-      """.stripMargin
+      """CREATE
+        #  (a {name: 'A', age: 34, length: 170}),
+        #  (b {name: 'B', age: 36}),
+        #  (c {name: 'C', age: 32, length: 185}),
+        #  (a)-[:KNOWS]->(b),
+        #  (b)-[:KNOWS]->(c)""".stripMargin('#')
     )
     synopsis("`ORDER BY` is a sub-clause following `RETURN` or `WITH`, and it specifies that the output should be sorted and how.")
-    p(
-      """* <<order-introduction, Introduction>>
-        |* <<order-nodes-by-property, Order nodes by property>>
-        |* <<order-nodes-by-multiple-properties, Order nodes by multiple properties>>
-        |* <<order-nodes-in-descending-order, Order nodes in descending order>>
-        |* <<order-null, Ordering `null`>>
-        |* <<order-with, Ordering in a `WITH` clause>>
-      """.stripMargin)
+    p("""* <<order-introduction, Introduction>>
+        #* <<order-nodes-by-property, Order nodes by property>>
+        #* <<order-nodes-by-multiple-properties, Order nodes by multiple properties>>
+        #* <<order-nodes-in-descending-order, Order nodes in descending order>>
+        #* <<order-null, Ordering `null`>>
+        #* <<order-with, Ordering in a `WITH` clause>>""".stripMargin('#'))
     section("Introduction", "order-introduction") {
       p(
         """Note that you cannot sort on nodes or relationships, just on properties on these.
-          |`ORDER BY` relies on comparisons to sort the output, see <<cypher-ordering>>.""".stripMargin)
-      p(
-        """In terms of scope of variables, `ORDER BY` follows special rules, depending on if the projecting `RETURN` or `WITH` clause is either aggregating or `DISTINCT`.
-           If it is an aggregating or `DISTINCT` projection, only the variables available in the projection are available.
-           If the projection does not alter the output cardinality (which aggregation and `DISTINCT` do), variables available from before the projecting clause are also available.
-           When the projection clause shadows already existing variables, only the new variables are available.
-        """.stripMargin)
-      p(
-        """Lastly, it is not allowed to use aggregating expressions in the `ORDER BY` sub-clause if they are not also listed in the projecting clause.
-           This last rule is to make sure that `ORDER BY` does not change the results, only the order of them.
-        """.stripMargin)
-      p(
-        """The performance of Cypher queries using `ORDER BY` on node properties can be influenced by the existence and use of an index for finding the nodes.
-          | If the index can provide the nodes in the order requested in the query, Cypher can avoid the use of an expensive `Sort` operation.
-          | Read more about this capability in <<query-tuning-indexes>>.
-        """.stripMargin
-      )
+          #`ORDER BY` relies on comparisons to sort the output, see <<cypher-ordering, Ordering and comparison of values>>.""".stripMargin('#'))
+      p("""In terms of scope of variables, `ORDER BY` follows special rules, depending on if the projecting `RETURN` or `WITH` clause is either aggregating or `DISTINCT`.
+           #If it is an aggregating or `DISTINCT` projection, only the variables available in the projection are available.
+           #If the projection does not alter the output cardinality (which aggregation and `DISTINCT` do), variables available from before the projecting clause are also available.
+           #When the projection clause shadows already existing variables, only the new variables are available.""".stripMargin('#'))
+      p("""Lastly, it is not allowed to use aggregating expressions in the `ORDER BY` sub-clause if they are not also listed in the projecting clause.
+           #This last rule is to make sure that `ORDER BY` does not change the results, only the order of them.""".stripMargin('#'))
+      p("""The performance of Cypher queries using `ORDER BY` on node properties can be influenced by the existence and use of an index for finding the nodes.
+          #If the index can provide the nodes in the order requested in the query, Cypher can avoid the use of an expensive `Sort` operation.
+          #Read more about this capability in <<query-tuning-indexes>>.""".stripMargin('#'))
       p("The following graph is used for the examples below:")
       graphViz()
     }
     
-    note(p("Strings that contain special characters can have inconsistent or non-deterministic ordering in Neo4j. For details, see <<property-types-sip-note>>."))
+    note(
+      p("""Strings that contain special characters can have inconsistent or non-deterministic ordering in Neo4j.
+          #For details, see <<property-types-sip-note>>.""".stripMargin('#'))
+    )
 
     section("Order nodes by property", "order-nodes-by-property") {
-      p(
-        """`ORDER BY` is used to sort the output.""".stripMargin)
-      query(
-        """MATCH (n)
-          |RETURN n.name, n.age
-          |ORDER BY n.name""".stripMargin, ResultAssertions((r) => {
+      p("""`ORDER BY` is used to sort the output.""")
+      query("""MATCH (n)
+              #RETURN n.name, n.age
+              #ORDER BY n.name""".stripMargin('#'),
+      ResultAssertions((r) => {
         r.toList should equal(List(Map("n.name" -> "A", "n.age" -> 34), Map("n.name" -> "B", "n.age" -> 36), Map("n.name" -> "C", "n.age" -> 32)))
       })) {
         p("The nodes are returned, sorted by their name.")
@@ -85,13 +76,12 @@ class OrderByTest extends DocumentingTest {
       }
     }
     section("Order nodes by multiple properties", "order-nodes-by-multiple-properties") {
-      p(
-        """You can order by multiple properties by stating each variable in the `ORDER BY` clause.
-          |Cypher will sort the result by the first variable listed, and for equals values, go to the next property in the `ORDER BY` clause, and so on.""".stripMargin)
-      query(
-        """MATCH (n)
-          |RETURN n.name, n.age
-          |ORDER BY n.age, n.name""".stripMargin, ResultAssertions((r) => {
+      p("""You can order by multiple properties by stating each variable in the `ORDER BY` clause.
+          #Cypher will sort the result by the first variable listed, and for equals values, go to the next property in the `ORDER BY` clause, and so on.""".stripMargin('#'))
+      query("""MATCH (n)
+              #RETURN n.name, n.age
+              #ORDER BY n.age, n.name""".stripMargin('#'),
+      ResultAssertions((r) => {
           r.toList should equal(List(Map("n.age" -> 32, "n.name" -> "C"), Map("n.age" -> 34, "n.name" -> "A"), Map("n.age" -> 36, "n.name" -> "B")))
         })) {
         p("This returns the nodes, sorted first by their age, and then by their name.")
@@ -99,12 +89,11 @@ class OrderByTest extends DocumentingTest {
       }
     }
     section("Order nodes in descending order", "order-nodes-in-descending-order") {
-      p(
-        """By adding `DESC[ENDING]` after the variable to sort on, the sort will be done in reverse order.""".stripMargin)
-      query(
-        """MATCH (n)
-          |RETURN n.name, n.age
-          |ORDER BY n.name DESC""".stripMargin, ResultAssertions((r) => {
+      p("""By adding `DESC[ENDING]` after the variable to sort on, the sort will be done in reverse order.""")
+      query("""MATCH (n)
+              #RETURN n.name, n.age
+              #ORDER BY n.name DESC""".stripMargin('#'),
+      ResultAssertions((r) => {
           r.toList should equal(List(Map("n.age" -> 32, "n.name" -> "C"), Map("n.age" -> 36, "n.name" -> "B"), Map("n.age" -> 34, "n.name" -> "A")))
         })) {
         p("The example returns the nodes, sorted by their name in reverse order.")
@@ -112,12 +101,11 @@ class OrderByTest extends DocumentingTest {
       }
     }
     section("Ordering `null`", "order-null") {
-      p(
-        """When sorting the result set, `null` will always come at the end of the result set for ascending sorting, and first when doing descending sort.""".stripMargin)
-      query(
-        """MATCH (n)
-          |RETURN n.length, n.name, n.age
-          |ORDER BY n.length""".stripMargin, ResultAssertions((r) => {
+      p("""When sorting the result set, `null` will always come at the end of the result set for ascending sorting, and first when doing descending sort.""")
+      query("""MATCH (n)
+              #RETURN n.length, n.name, n.age
+              #ORDER BY n.length""".stripMargin('#'),
+      ResultAssertions((r) => {
           r.toList should equal(List(Map("n.age" -> 34, "n.name" -> "A", "n.length" -> 170), Map("n.age" -> 32, "n.name" -> "C", "n.length" -> 185), Map("n.age" -> 36, "n.name" -> "B", "n.length" -> null)))
         })) {
         p("The nodes are returned sorted by the length property, with a node without that property last.")
@@ -125,17 +113,16 @@ class OrderByTest extends DocumentingTest {
       }
     }
     section("Ordering in a `WITH` clause", "order-with") {
-      p(
-        """When `ORDER BY` is present on a `WITH` clause , the immediately following clause will receive records in the specified order.
-          |The order is not guaranteed to be retained after the following clause, unless that also has an `ORDER BY` subclause.
-          |The ordering guarantee can be useful to exploit by operations which depend on the order in which they consume values.
-          |For example, this can be used to control the order of items in the list produced by the `collect()` aggregating function.
-          |The `MERGE` and `SET` clauses also have ordering dependencies which can be controlled this way.
-          |""".stripMargin)
-      query(
-        """MATCH (n)
-          |WITH n ORDER BY n.age
-          |RETURN collect(n.name) AS names""".stripMargin, ResultAssertions((r) => {
+      p("""When `ORDER BY` is present on a `WITH` clause , the immediately following clause will receive records in the specified order.
+          #The order is not guaranteed to be retained after the following clause, unless that also has an `ORDER BY` subclause.
+          #The ordering guarantee can be useful to exploit by operations which depend on the order in which they consume values.
+          #For example, this can be used to control the order of items in the list produced by the `collect()` aggregating function.
+          #The `MERGE` and `SET` clauses also have ordering dependencies which can be controlled this way.
+          #""".stripMargin('#'))
+      query("""MATCH (n)
+              #WITH n ORDER BY n.age
+              #RETURN collect(n.name) AS names""".stripMargin('#'),
+      ResultAssertions((r) => {
           r.toList should equal(List(Map("names" -> List("C", "A", "B"))))
         })) {
         p("The list of names built from the `collect` aggregating function contains the names in order of the `age` property.")

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SkipTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SkipTest.scala
@@ -26,40 +26,34 @@ class SkipTest extends DocumentingTest {
 
   override def doc = new DocBuilder {
     doc("SKIP", "query-skip")
-    initQueries(
-      """CREATE (a {name: 'A'}),
-        |       (b {name: 'B'}),
-        |       (c {name: 'C'}),
-        |       (d {name: 'D'}),
-        |       (e {name: 'E'}),
-        |
-        |       (a)-[:KNOWS]->(b),
-        |       (a)-[:KNOWS]->(c),
-        |       (a)-[:KNOWS]->(d),
-        |       (a)-[:KNOWS]->(e)
-      """.stripMargin)
+    initQueries("""CREATE
+                  #  (a {name: 'A'}),
+                  #  (b {name: 'B'}),
+                  #  (c {name: 'C'}),
+                  #  (d {name: 'D'}),
+                  #  (e {name: 'E'}),
+                  #  (a)-[:KNOWS]->(b),
+                  #  (a)-[:KNOWS]->(c),
+                  #  (a)-[:KNOWS]->(d),
+                  #  (a)-[:KNOWS]->(e)""".stripMargin('#'))
     synopsis("`SKIP` defines from which row to start including the rows in the output.")
-    p(
-      """* <<skip-introduction, Introduction>>
-        |* <<skip-first-three-rows, Skip first three rows>>
-        |* <<skip-return-middle-rows, Return middle two rows>>
-        |* <<skip-using-expression, Using an expression with `SKIP` to return a subset of the rows>>
-      """.stripMargin)
+    p("""* <<skip-introduction, Introduction>>
+        #* <<skip-first-three-rows, Skip first three rows>>
+        #* <<skip-return-middle-rows, Return middle two rows>>
+        #* <<skip-using-expression, Using an expression with `SKIP` to return a subset of the rows>>""".stripMargin('#'))
     section("Introduction", "skip-introduction") {
-      p(
-        """By using `SKIP`, the result set will get trimmed from the top.
-          |Please note that no guarantees are made on the order of the result unless the query specifies the `ORDER BY` clause.
-          |`SKIP` accepts any expression that evaluates to a positive integer -- however the expression cannot refer to nodes or relationships.""".stripMargin)
+      p("""By using `SKIP`, the result set will get trimmed from the top.
+          #Please note that no guarantees are made on the order of the result unless the query specifies the `ORDER BY` clause.
+          #`SKIP` accepts any expression that evaluates to a positive integer -- however the expression cannot refer to nodes or relationships.""".stripMargin('#'))
       graphViz()
     }
     section("Skip first three rows", "skip-first-three-rows") {
-      p(
-        """To return a subset of the result, starting from the fourth result, use the following syntax:""".stripMargin)
-      query(
-        """MATCH (n)
-          |RETURN n.name
-          |ORDER BY n.name
-          |SKIP 3""".stripMargin, ResultAssertions((r) => {
+      p("""To return a subset of the result, starting from the fourth result, use the following syntax:""")
+      query("""MATCH (n)
+              #RETURN n.name
+              #ORDER BY n.name
+              #SKIP 3""".stripMargin('#'),
+      ResultAssertions((r) => {
         r.toList should equal(List(Map("n.name" -> "D"), Map("n.name" -> "E")))
       })) {
         p("The first three nodes are skipped, and only the last two are returned in the result.")
@@ -67,14 +61,13 @@ class SkipTest extends DocumentingTest {
       }
     }
     section("Return middle two rows", "skip-return-middle-rows") {
-      p(
-        """To return a subset of the result, starting from somewhere in the middle, use this syntax:""".stripMargin)
-      query(
-        """MATCH (n)
-          |RETURN n.name
-          |ORDER BY n.name
-          |SKIP 1
-          |LIMIT 2""".stripMargin, ResultAssertions((r) => {
+      p("""To return a subset of the result, starting from somewhere in the middle, use this syntax:""")
+      query("""MATCH (n)
+              #RETURN n.name
+              #ORDER BY n.name
+              #SKIP 1
+              #LIMIT 2""".stripMargin('#'),
+      ResultAssertions((r) => {
           r.toList should equal(List(Map("n.name" -> "B"), Map("n.name" -> "C")))
         })) {
         p("Two nodes from the middle are returned.")
@@ -82,16 +75,15 @@ class SkipTest extends DocumentingTest {
       }
     }
     section("Using an expression with `SKIP` to return a subset of the rows", "skip-using-expression") {
-      p(
-        """Skip accepts any expression that evaluates to a positive integer as long as it is not referring to any external variables:""".stripMargin)
-      query(
-        """MATCH (n)
-          |RETURN n.name
-          |ORDER BY n.name
-          |SKIP toInteger(3*rand()) + 1""".stripMargin, ResultAssertions((r) => {
+      p("""Skip accepts any expression that evaluates to a positive integer as long as it is not referring to any external variables:""")
+      query("""MATCH (n)
+              #RETURN n.name
+              #ORDER BY n.name
+              #SKIP 1 + toInteger(3*rand())""".stripMargin('#'),
+      ResultAssertions((r) => {
           r.toSet should contain(Map("n.name" -> "E"))
         })) {
-        p("The first three nodes are skipped, and only the last two are returned in the result.")
+        p("Skip the firs row plus randomly 0, 1, or 2. So randomly skip 1, 2, or 3 rows.")
         resultTable()
       }
     }

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SpatialTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SpatialTest.scala
@@ -41,7 +41,7 @@ class SpatialTest extends DocumentingTest {
         |""".stripMargin)
     note{
       p("""Refer to <<query-functions-spatial>> for information regarding spatial _functions_ allowing for the creation and manipulation of spatial values.""")
-      p("""Refer to <<cypher-ordering>> for information regarding the comparison and ordering of spatial values.""")
+      p("""Refer to <<cypher-ordering, Ordering and comparison of values>> for information regarding the comparison and ordering of spatial values.""")
     }
     section("Introduction", "cypher-spatial-introduction") {
       p(
@@ -71,7 +71,7 @@ class SpatialTest extends DocumentingTest {
         """
           |Data within different coordinate systems are entirely incomparable, and cannot be implicitly converted from one to the other.
           |This is true even if they are both cartesian or both geographic. For example, if you search for 3D points using a 2D range, you will get no results.
-          |However, they can be ordered, as discussed in more detail in the section on <<cypher-ordering, Cypher ordering>>.
+          |However, they can be ordered, as discussed in more detail in <<cypher-ordering, Ordering and comparison of values>>.
         """.stripMargin)
       section("Geographic coordinate reference systems", "cypher-spatial-crs-geographic") {
         p(

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/TemporalTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/TemporalTest.scala
@@ -54,7 +54,7 @@ class TemporalTest extends DocumentingTest {
     note {
       p("""Refer to <<query-functions-temporal-instant-types>> for information regarding temporal _functions_ allowing for the creation and manipulation of temporal values.""")
       p("""Refer to <<query-operators-temporal>> for information regarding temporal _operators_.""")
-      p("""Refer to <<cypher-ordering>> for information regarding the comparison and ordering of temporal values.""")
+      p("""Refer to <<cypher-ordering, Ordering and comparison of values>> for information regarding the comparison and ordering of temporal values.""")
     }
     section("Introduction", "cypher-temporal-introduction") {
       p(


### PR DESCRIPTION
Fixed ordering link name, because it is included it must be explicit set.
Fixed style for order by clause.
Fixed cypher style for skip clause.
Updated limit cypher clause.