### PR TITLE
4.0 cypher query syntax fix part 19

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ScalarFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ScalarFunctionsTest.scala
@@ -65,8 +65,8 @@ class ScalarFunctionsTest extends DocumentingTest {
     important {
       p("""The `length()` and `size()` functions are quite similar, and so it is important to take note of the difference.
           #
-          #* The function `length()` only works for <<functions-length, paths>>.
-          #* The function `size()` only works for the three types: <<functions-size-of-string, strings>>, <<functions-size, lists>> and <<functions-size-of-pattern-expression, pattern expressions>>.""".stripMargin('#'))
+          #Function `length()`:: Only works for <<functions-length, paths>>.
+          #Function `size()`:: Only works for the three types: <<functions-size-of-string, strings>>, <<functions-size, lists>>, and <<functions-size-of-pattern-expression, pattern expressions>>.""".stripMargin('#'))
     }
     graphViz()
     section("coalesce()", "functions-coalesce") {
@@ -120,8 +120,9 @@ class ScalarFunctionsTest extends DocumentingTest {
       p("The function `id()` returns the id of a relationship or node.")
       note {
         p("""Neo4j implements the id so that:
-            #* Every node in a database has a unique id compared to other nodes in the same database.
-            #* Every relationship in a database has a unique id compared to other relationships in the same database.""".stripMargin('#'))
+            #
+            #Node:: Every node in a database has a unique id compared to other nodes in the same database.
+            #Relationship:: Every relationship in a database has a unique id compared to other relationships in the same database.""".stripMargin('#'))
       }
       function("id(expression)",
         "An Integer.",

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ScalarFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ScalarFunctionsTest.scala
@@ -118,7 +118,7 @@ class ScalarFunctionsTest extends DocumentingTest {
       }
     }
     section("id()", "functions-id") {
-      p("The function `id()` returns an identifier, the function can be utilized for a relationship or a node.")
+      p("The function `id()` returns an identifier; the function can be utilized for a relationship or a node.")
       note {
         //The note has been approved by kernel team.
         p("""Neo4j implements the id so that:
@@ -188,7 +188,7 @@ class ScalarFunctionsTest extends DocumentingTest {
       }
     }
     section("properties()", "functions-properties") {
-      p("""The function `properties()` returns a map containing all the properties, the function can be utilized for a relationship or a node.
+      p("""The function `properties()` returns a map containing all the properties; the function can be utilized for a relationship or a node.
           #If the argument is already a map, it is returned unchanged.""".stripMargin('#'))
       function("properties(expression)",
         "A Map.",

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ScalarFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ScalarFunctionsTest.scala
@@ -179,7 +179,7 @@ class ScalarFunctionsTest extends DocumentingTest {
           #If the argument is already a map, it is returned unchanged.""".stripMargin('#'))
       function("properties(expression)",
         "A Map.",
-        ("expression", "An expression that returns a *node*, a *relationship*, or a *map*."))
+        ("expression", "An expression that returns a node, a relationship, or a map."))
       considerations("`properties(null)` returns `null`.")
       query("""CREATE (p:Person {name: 'Stefan', city: 'Berlin'})
               #RETURN properties(p)""".stripMargin('#'),
@@ -207,7 +207,7 @@ class ScalarFunctionsTest extends DocumentingTest {
       p("The function `size()` returns the number of elements in a list.")
       function("size(list)",
         "An Integer.",
-        ("list", "An expression that returns a *list*."))
+        ("list", "An expression that returns a list."))
       considerations("`size(null)` returns `null`.")
       query("RETURN size(['Alice', 'Bob'])",
       ResultAssertions((r) => {
@@ -246,7 +246,7 @@ class ScalarFunctionsTest extends DocumentingTest {
           r.toList should equal(List(Map("size(a.name)" -> 7)))
         })) {
         resultTable()
-        p("The number of characters in the string *'Charlie'* is returned.")
+        p("The number of characters in the string `'Charlie'` is returned.")
       }
     }
     section("startNode()", "functions-startnode") {

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ScalarFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ScalarFunctionsTest.scala
@@ -73,7 +73,7 @@ class ScalarFunctionsTest extends DocumentingTest {
       p("The function `coalesce()` returns the first non-`null` value in the given list of expressions.")
       function("coalesce(expression [, expression]*)",
         "The type of the value returned will be that of the first non-`null` expression.",
-        ("expression", "An expression which may return `null`."))
+        ("expression", "An expression that may return `null`."))
       considerations("`null` will be returned if all the arguments are `null`.")
       query("""MATCH (a)
               #WHERE a.name = 'Alice'
@@ -103,7 +103,8 @@ class ScalarFunctionsTest extends DocumentingTest {
       function("head(expression)",
         "The type of the value returned will be that of the first element of the list.",
         ("expression", "An expression that returns a list."))
-      considerations("`head(null)` returns `null`.",
+      considerations(
+        "`head(null)` returns `null`.",
         "`head([])` returns `null`.",
         "If the first element in `list` is `null`, `head(list)` will return `null`.")
       query("""MATCH (a)
@@ -117,13 +118,18 @@ class ScalarFunctionsTest extends DocumentingTest {
       }
     }
     section("id()", "functions-id") {
-      p("The function `id()` returns the id of a relationship or node.")
+      p("The function `id()` returns an identifier, the function can be utilized for a relationship or a node.")
       note {
         //The note has been approved by kernel team.
         p("""Neo4j implements the id so that:
             #
-            #Node:: Every node in a database has a unique id compared to other nodes in the same database, the uniqueness is guaranteed within the scope of a single transaction.
-            #Relationship:: Every relationship in a database has a unique id compared to other relationships in the same database, the uniqueness is guaranteed within the scope of a single transaction.""".stripMargin('#'))
+            #Node::
+            #Every node in a database has an identifier.
+            #The identifier for a node is guaranteed to be unique among other nodes' identifiers in the same database, within the scope of a single transaction.
+            #
+            #Relationship::
+            #Every relationship in a database has an identifier.
+            #The identifier for a relationship is guaranteed to be unique among other relationships' identifiers in the same database, within the scope of a single transaction.""".stripMargin('#'))
       }
       function("id(expression)",
         "An Integer.",
@@ -139,7 +145,7 @@ class ScalarFunctionsTest extends DocumentingTest {
             Map("id(a)" -> 3),
             Map("id(a)" -> 4)))
         })) {
-        p("The node id for each of the nodes is returned.")
+        p("The node identifier for each of the nodes is returned.")
         resultTable()
       }
     }
@@ -148,7 +154,8 @@ class ScalarFunctionsTest extends DocumentingTest {
       function("last(expression)",
         "The type of the value returned will be that of the last element of the list.",
         ("expression", "An expression that returns a list."))
-      considerations("`last(null)` returns `null`.",
+      considerations(
+        "`last(null)` returns `null`.",
         "`last([])` returns `null`.",
         "If the last element in `list` is `null`, `last(list)` will return `null`.")
       query("""MATCH (a)
@@ -181,11 +188,11 @@ class ScalarFunctionsTest extends DocumentingTest {
       }
     }
     section("properties()", "functions-properties") {
-      p("""The function `properties()` returns a map containing all the properties of a node or relationship.
+      p("""The function `properties()` returns a map containing all the properties, the function can be utilized for a relationship or a node.
           #If the argument is already a map, it is returned unchanged.""".stripMargin('#'))
       function("properties(expression)",
         "A Map.",
-        ("expression", "An expression that returns a node, a relationship, or a map."))
+        ("expression", "An expression that returns a relationship, a node, or a map."))
       considerations("`properties(null)` returns `null`.")
       query("""CREATE (p:Person {name: 'Stefan', city: 'Berlin'})
               #RETURN properties(p)""".stripMargin('#'),
@@ -224,9 +231,8 @@ class ScalarFunctionsTest extends DocumentingTest {
       }
     }
     section("size() applied to pattern expression", "functions-size-of-pattern-expression") {
-      p("""This is the same function `size()` as described above, but instead of passing in a list directly, a pattern expression can be provided that can be used in a match query to provide a new set of results.
-          #These results are a _list_ of paths.
-          #The size of the result is calculated, not the length of the expression itself.""".stripMargin('#'))
+      p("""This is the same function `size()` as described above, but you pass in a pattern expression, instead of a list.
+          #The function size will then calculate on a _list_ of paths.""".stripMargin('#'))
       function("size(pattern expression)",
         ("pattern expression", "A pattern expression that returns a list."))
       query("""MATCH (a)
@@ -236,7 +242,7 @@ class ScalarFunctionsTest extends DocumentingTest {
           r.toList should equal(List(Map("fof" -> 3)))
         })) {
         resultTable()
-        p("The number of paths matching the pattern expression is returned.")
+        p("The number of paths matching the pattern expression is returned. (The size of the list of paths).")
       }
     }
     section("size() applied to string", "functions-size-of-string") {
@@ -270,8 +276,10 @@ class ScalarFunctionsTest extends DocumentingTest {
       }
     }
     section("timestamp()", "functions-timestamp") {
-      p("""The function `timestamp()` returns the difference, measured in milliseconds, between the current time and midnight, January 1, 1970 UTC.
-          #It is the equivalent of `datetime().epochMillis`.""".stripMargin('#'))
+      p("The function `timestamp()` returns the difference, measured in milliseconds, between the current time and midnight, January 1, 1970 UTC.")
+      note {
+        p("It is the equivalent of `datetime().epochMillis`.")
+      }
       function("timestamp()",
         "An Integer.")
       considerations("`timestamp()` will return the same value during one entire query, even for long-running queries.")
@@ -291,8 +299,9 @@ class ScalarFunctionsTest extends DocumentingTest {
       p("The function `toBoolean()` converts a string value to a boolean value.")
       function("toBoolean(expression)",
         "A Boolean.",
-        ("expression", "An expression that returns a boolean or string value."))
-      considerations("`toBoolean(null)` returns `null`.",
+        ("expression", "An expression that returns a boolean or a string value."))
+      considerations(
+        "`toBoolean(null)` returns `null`.",
         "If `expression` is a boolean value, it will be returned unchanged.",
         "If the parsing fails, `null` will be returned.")
       query("RETURN toBoolean('true'), toBoolean('not a boolean')",
@@ -303,9 +312,12 @@ class ScalarFunctionsTest extends DocumentingTest {
       }
     }
     section("toFloat()", "functions-tofloat") {
-      p("The function `toFloat()` converts an integer or string value to a floating point number.")
-      function("toFloat(expression)", "A Float.", ("expression", "An expression that returns a numeric or string value."))
-      considerations("`toFloat(null)` returns `null`.",
+      p("The function `toFloat()` converts an integer or a string value to a floating point number.")
+      function("toFloat(expression)",
+        "A Float.",
+        ("expression", "An expression that returns a numeric or a string value."))
+      considerations(
+        "`toFloat(null)` returns `null`.",
         "If `expression` is a floating point number, it will be returned unchanged.",
         "If the parsing fails, `null` will be returned.")
       query("RETURN toFloat('11.5'), toFloat('not a number')",
@@ -316,11 +328,12 @@ class ScalarFunctionsTest extends DocumentingTest {
       }
     }
     section("toInteger()", "functions-tointeger") {
-      p("The function `toInteger()` converts a floating point or string value to an integer value.")
+      p("The function `toInteger()` converts a floating point or a string value to an integer value.")
       function("toInteger(expression)",
         "An Integer.",
-        ("expression", "An expression that returns a numeric or string value."))
-      considerations("`toInteger(null)` returns `null`.",
+        ("expression", "An expression that returns a numeric or a string value."))
+      considerations(
+        "`toInteger(null)` returns `null`.",
         "If `expression` is an integer value, it will be returned unchanged.",
         "If the parsing fails, `null` will be returned.")
       query("RETURN toInteger('42'), toInteger('not a number')",

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ScalarFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ScalarFunctionsTest.scala
@@ -65,9 +65,8 @@ class ScalarFunctionsTest extends DocumentingTest {
     important {
       p("""The `length()` and `size()` functions are quite similar, and so it is important to take note of the difference.
           #
-          #The function `length()` only works for <<functions-length, paths>>.
-          #
-          #The function `size()` only works for the three types: <<functions-size-of-string, strings>>, <<functions-size, lists>> and <<functions-size-of-pattern-expression, pattern expressions>>.""".stripMargin('#'))
+          #* The function `length()` only works for <<functions-length, paths>>.
+          #* The function `size()` only works for the three types: <<functions-size-of-string, strings>>, <<functions-size, lists>> and <<functions-size-of-pattern-expression, pattern expressions>>.""".stripMargin('#'))
     }
     graphViz()
     section("coalesce()", "functions-coalesce") {
@@ -119,6 +118,11 @@ class ScalarFunctionsTest extends DocumentingTest {
     }
     section("id()", "functions-id") {
       p("The function `id()` returns the id of a relationship or node.")
+      note {
+        p("""Neo4j implements the id so that:
+            #* Every node in a database has a unique id compared to other nodes in the same database.
+            #* Every relationship in a database has a unique id compared to other relationships in the same database.""".stripMargin('#'))
+      }
       function("id(expression)",
         "An Integer.",
         ("expression", "An expression that returns a node or a relationship."))

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ScalarFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ScalarFunctionsTest.scala
@@ -31,153 +31,171 @@ class ScalarFunctionsTest extends DocumentingTest {
   override def doc = new DocBuilder {
     doc("Scalar functions", "query-functions-scalar")
     initQueries(
-      """CREATE (alice:Developer {name:'Alice', age: 38, eyes: 'brown'}),
-        |       (bob {name: 'Bob', age: 25, eyes: 'blue'}),
-        |       (charlie {name: 'Charlie', age: 53, eyes: 'green'}),
-        |       (daniel {name: 'Daniel', age: 54, eyes: 'brown'}),
-        |       (eskil {name: 'Eskil', age: 41, eyes: 'blue', array: ['one', 'two', 'three']}),
-        |
-        |       (alice)-[:KNOWS]->(bob),
-        |       (alice)-[:KNOWS]->(charlie),
-        |       (bob)-[:KNOWS]->(daniel),
-        |       (charlie)-[:KNOWS]->(daniel),
-        |       (bob)-[:MARRIED]->(eskil)""")
+      """CREATE
+        #  (alice:Developer {name:'Alice', age: 38, eyes: 'brown'}),
+        #  (bob {name: 'Bob', age: 25, eyes: 'blue'}),
+        #  (charlie {name: 'Charlie', age: 53, eyes: 'green'}),
+        #  (daniel {name: 'Daniel', age: 54, eyes: 'brown'}),
+        #  (eskil {name: 'Eskil', age: 41, eyes: 'blue', liked_colors: ['pink', 'yellow', 'black']}),
+        #  (alice)-[:KNOWS]->(bob),
+        #  (alice)-[:KNOWS]->(charlie),
+        #  (bob)-[:KNOWS]->(daniel),
+        #  (charlie)-[:KNOWS]->(daniel),
+        #  (bob)-[:MARRIED]->(eskil)""".stripMargin('#'))
     synopsis("Scalar functions return a single value.")
     important {
-      p(
-        """The `length()` and `size()` functions are quite similar, and so it is important to take note of the difference.
-     `length()` only works for <<functions-length, paths>>, while `size()` only works for the three types:
-     <<functions-size-of-string, strings>>, <<functions-size, lists>> and <<functions-size-of-pattern-expression, pattern expressions>>.""")
+      p("""The `length()` and `size()` functions are quite similar, and so it is important to take note of the difference.
+          #
+          #The function `length()` only works for <<functions-length, paths>>.
+          #
+          #The function `size()` only works for the three types: <<functions-size-of-string, strings>>, <<functions-size, lists>> and <<functions-size-of-pattern-expression, pattern expressions>>.""".stripMargin('#'))
     }
-    p(
-      """Functions:
-        |
-        |* <<functions-coalesce, coalesce()>>
-        |* <<functions-endnode, endNode()>>
-        |* <<functions-head, head()>>
-        |* <<functions-id, id()>>
-        |* <<functions-last, last()>>
-        |* <<functions-length, length()>>
-        |* <<functions-properties, properties()>>
-        |* <<functions-randomuuid, randomUUID()>>
-        |* <<functions-size, size()>>
-        |* <<functions-size-of-pattern-expression, Size of pattern expression>>
-        |* <<functions-size-of-string, Size of string>>
-        |* <<functions-startnode, startNode()>>
-        |* <<functions-timestamp, timestamp()>>
-        |* <<functions-toboolean, toBoolean()>>
-        |* <<functions-tofloat, toFloat()>>
-        |* <<functions-tointeger, toInteger()>>
-        |* <<functions-type, type()>>""")
+    p("""Functions:
+        #
+        #* <<functions-coalesce, coalesce()>>
+        #* <<functions-endnode, endNode()>>
+        #* <<functions-head, head()>>
+        #* <<functions-id, id()>>
+        #* <<functions-last, last()>>
+        #* <<functions-length, length()>>
+        #* <<functions-properties, properties()>>
+        #* <<functions-randomuuid, randomUUID()>>
+        #* <<functions-size, size()>>
+        #* <<functions-size-of-pattern-expression, Size of pattern expression>>
+        #* <<functions-size-of-string, Size of string>>
+        #* <<functions-startnode, startNode()>>
+        #* <<functions-timestamp, timestamp()>>
+        #* <<functions-toboolean, toBoolean()>>
+        #* <<functions-tofloat, toFloat()>>
+        #* <<functions-tointeger, toInteger()>>
+        #* <<functions-type, type()>>""".stripMargin('#'))
     graphViz()
     section("coalesce()", "functions-coalesce") {
-      p(
-        "`coalesce()` returns the first non-`null` value in the given list of expressions.")
-      function("coalesce(expression [, expression]*)", "The type of the value returned will be that of the first non-`null` expression.", ("expression", "An expression which may return `null`."))
+      p("The function `coalesce()` returns the first non-`null` value in the given list of expressions.")
+      function("coalesce(expression [, expression]*)",
+        "The type of the value returned will be that of the first non-`null` expression.",
+        ("expression", "An expression which may return `null`."))
       considerations("`null` will be returned if all the arguments are `null`.")
-      query(
-        """MATCH (a)
-          |WHERE a.name = 'Alice'
-          |RETURN coalesce(a.hairColor, a.eyes)""".stripMargin, ResultAssertions((r) => {
+      query("""MATCH (a)
+              #WHERE a.name = 'Alice'
+              #RETURN coalesce(a.hairColor, a.eyes)""".stripMargin('#'),
+      ResultAssertions((r) => {
           r.toList should equal(List(Map("coalesce(a.hairColor, a.eyes)" -> "brown")))
         })) {
         resultTable()
       }
     }
     section("endNode()", "functions-endnode") {
-      p(
-        """`endNode()` returns the end node of a relationship.""".stripMargin)
-      function("endNode(relationship)", "A Node.", ("relationship", "An expression that returns a relationship."))
+      p("The function `endNode()` returns the end node of a relationship.")
+      function("endNode(relationship)",
+        "A Node.",
+        ("relationship", "An expression that returns a relationship."))
       considerations("`endNode(null)` returns `null`.")
-      query(
-        """MATCH (x:Developer)-[r]-()
-          |RETURN endNode(r)""".stripMargin, ResultAssertions((r) => {
+      query("""MATCH (x:Developer)-[r]-()
+              #RETURN endNode(r)""".stripMargin('#'),
+      ResultAssertions((r) => {
           r.columnAs[Node]("endNode(r)").toList.map(_.getId) should equal(Array(2, 1))
         })) {
         resultTable()
       }
     }
     section("head()", "functions-head") {
-      p(
-        """`head()` returns the first element in a list.""".stripMargin)
-      function("head(list)", "The type of the value returned will be that of the first element of `list`.", ("list", "An expression that returns a list."))
-      considerations("`head(null)` returns `null`.", "If the first element in `list` is `null`, `head(list)` will return `null`.")
-      query(
-        """MATCH (a)
-          |WHERE a.name = 'Eskil'
-          |RETURN a.array, head(a.array)""".stripMargin, ResultAssertions((r) => {
-          r.columnAs[String]("head(a.array)").toList.head should equal("one")
+      p("The function `head()` returns the first element in a list.")
+      function("head(expression)",
+        "The type of the value returned will be that of the first element of the list.",
+        ("expression", "An expression that returns a list."))
+      considerations("`head(null)` returns `null`.",
+        "`head([])` returns `null`.",
+        "If the first element in `list` is `null`, `head(list)` will return `null`.")
+      query("""MATCH (a)
+              #WHERE a.name = 'Eskil'
+              #RETURN a.liked_colors, head(a.liked_colors)""".stripMargin('#'),
+      ResultAssertions((r) => {
+          r.columnAs[String]("head(a.liked_colors)").toList.head should equal("pink")
         })) {
         p("The first element in the list is returned.")
         resultTable()
       }
     }
     section("id()", "functions-id") {
-      p(
-        """`id()` returns the id of a relationship or node.""".stripMargin)
-      function("id(expression)", "An Integer.", ("expression", "An expression that returns a node or a relationship."))
+      p("The function `id()` returns the id of a relationship or node.")
+      function("id(expression)",
+        "An Integer.",
+        ("expression", "An expression that returns a node or a relationship."))
       considerations("`id(null)` returns `null`.")
-      query(
-        """MATCH (a)
-          |RETURN id(a)""".stripMargin, ResultAssertions((r) => {
-          r.toList should equal(List(Map("id(a)" -> 0), Map("id(a)" -> 1), Map("id(a)" -> 2), Map("id(a)" -> 3), Map("id(a)" -> 4)))
+      //Fix this example to show that ids between nodes and relationships can have the same id.
+      query("""MATCH (a)
+              #RETURN id(a)""".stripMargin('#'), ResultAssertions((r) => {
+          r.toList should equal(List(
+            Map("id(a)" -> 0),
+            Map("id(a)" -> 1),
+            Map("id(a)" -> 2),
+            Map("id(a)" -> 3),
+            Map("id(a)" -> 4)))
         })) {
         p("The node id for each of the nodes is returned.")
         resultTable()
       }
     }
     section("last()", "functions-last") {
-      p(
-        """`last()` returns the last element in a list.""".stripMargin)
-      function("last(expression)", "The type of the value returned will be that of the last element of `list`.", ("list", "An expression that returns a list."))
-      considerations("`last(null)` returns `null`.", "If the last element in `list` is `null`, `last(list)` will return `null`.")
-      query(
-        """MATCH (a)
-          |WHERE a.name = 'Eskil'
-          |RETURN a.array, last(a.array)""".stripMargin, ResultAssertions((r) => {
-          r.columnAs[String]("last(a.array)").toList.head should equal("three")
+      p("The function `last()` returns the last element in a list.")
+      function("last(expression)",
+        "The type of the value returned will be that of the last element of the list.",
+        ("expression", "An expression that returns a list."))
+      considerations("`last(null)` returns `null`.",
+        "`last([])` returns `null`.",
+        "If the last element in `list` is `null`, `last(list)` will return `null`.")
+      query("""MATCH (a)
+              #WHERE a.name = 'Eskil'
+              #RETURN a.liked_colors, last(a.liked_colors)""".stripMargin('#'),
+      ResultAssertions((r) => {
+          r.columnAs[String]("last(a.liked_colors)").toList.head should equal("black")
         })) {
         p("The last element in the list is returned.")
         resultTable()
       }
     }
     section("length()", "functions-length") {
-      p(
-        """`length()` returns the length of a path.""".stripMargin)
-      function("length(path)", "An Integer.", ("path", "An expression that returns a path."))
+      p("The function `length()` returns the length of a path.")
+      function("length(path)",
+        "An Integer.",
+        ("path", "An expression that returns a path."))
       considerations("`length(null)` returns `null`.")
-      query(
-        """MATCH p = (a)-->(b)-->(c)
-          |WHERE a.name = 'Alice'
-          |RETURN length(p)""".stripMargin, ResultAssertions((r) => {
-          r.toList should equal(List(Map("length(p)" -> 2), Map("length(p)" -> 2), Map("length(p)" -> 2)))
+      query("""MATCH p = (a)-->(b)-->(c)
+              #WHERE a.name = 'Alice'
+              #RETURN length(p)""".stripMargin('#'),
+      ResultAssertions((r) => {
+          r.toList should equal(List(
+            Map("length(p)" -> 2),
+            Map("length(p)" -> 2),
+            Map("length(p)" -> 2)))
         })) {
         p("The length of the path `p` is returned.")
         resultTable()
       }
     }
     section("properties()", "functions-properties") {
-      p(
-        """`properties()` returns a map containing all the properties of a node or relationship.
-          |If the argument is already a map, it is returned unchanged.""".stripMargin)
-      function("properties(expression)", "A Map.", ("expression", "An expression that returns a node, a relationship, or a map."))
+      p("""The function `properties()` returns a map containing all the properties of a node or relationship.
+          #If the argument is already a map, it is returned unchanged.""".stripMargin('#'))
+      function("properties(expression)",
+        "A Map.",
+        ("expression", "An expression that returns a *node*, a *relationship*, or a *map*."))
       considerations("`properties(null)` returns `null`.")
-      query(
-        """CREATE (p:Person {name: 'Stefan', city: 'Berlin'})
-          |RETURN properties(p)""".stripMargin, ResultAssertions((r) => {
+      query("""CREATE (p:Person {name: 'Stefan', city: 'Berlin'})
+              #RETURN properties(p)""".stripMargin('#'),
+      ResultAssertions((r) => {
           r.toList should equal(List(Map("properties(p)" -> Map("name" -> "Stefan", "city" -> "Berlin"))))
         })) {
         resultTable()
       }
     }
     section("randomUUID()", "functions-randomuuid") {
-      p(
-        """`randomUUID()` returns a randomly-generated Universally Unique Identifier (UUID), also known as a Globally Unique Identifier (GUID).
-          |This is a 128-bit value with strong guarantees of uniqueness.
-        """.stripMargin)
-      function("randomUUID()", "A String.")
-      query(
-        """RETURN randomUUID() AS uuid""".stripMargin, ResultAssertions((r) => {
+      p("""The function `randomUUID()` returns a randomly-generated Universally Unique Identifier (UUID), also known as a Globally Unique Identifier (GUID).
+          #This is a 128-bit value with strong guarantees of uniqueness.""".stripMargin('#'))
+      function("randomUUID()",
+        "A String.")
+      query("RETURN randomUUID() AS uuid",
+      ResultAssertions((r) => {
           val uuid = r.columnAs[String]("uuid").next()
           UUID.fromString(uuid) should be(a[UUID])
         })) {
@@ -186,12 +204,13 @@ class ScalarFunctionsTest extends DocumentingTest {
       }
     }
     section("size()", "functions-size") {
-      p(
-        """`size()` returns the number of elements in a list.""".stripMargin)
-      function("size(list)", "An Integer.", ("list", "An expression that returns a list."))
+      p("The function `size()` returns the number of elements in a list.")
+      function("size(list)",
+        "An Integer.",
+        ("list", "An expression that returns a *list*."))
       considerations("`size(null)` returns `null`.")
-      query(
-        """RETURN size(['Alice', 'Bob'])""".stripMargin, ResultAssertions((r) => {
+      query("RETURN size(['Alice', 'Bob'])",
+      ResultAssertions((r) => {
           r.toList should equal(List(Map("size(['Alice', 'Bob'])" -> 2)))
         })) {
         resultTable()
@@ -199,15 +218,15 @@ class ScalarFunctionsTest extends DocumentingTest {
       }
     }
     section("size() applied to pattern expression", "functions-size-of-pattern-expression") {
-      p(
-        """This is the same `size()` method as described above, but instead of passing in a list directly, a pattern expression can be provided that can be used in a match query to provide a new set of results.
-          |These results are a _list_ of paths.
-          |The size of the result is calculated, not the length of the expression itself.""".stripMargin)
-      function("size(pattern expression)", ("pattern expression", "A pattern expression that returns a list."))
-      query(
-        """MATCH (a)
-          |WHERE a.name = 'Alice'
-          |RETURN size((a)-->()-->()) AS fof""".stripMargin, ResultAssertions((r) => {
+      p("""This is the same function `size()` as described above, but instead of passing in a list directly, a pattern expression can be provided that can be used in a match query to provide a new set of results.
+          #These results are a _list_ of paths.
+          #The size of the result is calculated, not the length of the expression itself.""".stripMargin('#'))
+      function("size(pattern expression)",
+        ("pattern expression", "A pattern expression that returns a list."))
+      query("""MATCH (a)
+              #WHERE a.name = 'Alice'
+              #RETURN size((a)-->()-->()) AS fof""".stripMargin('#'),
+      ResultAssertions((r) => {
           r.toList should equal(List(Map("fof" -> 3)))
         })) {
         resultTable()
@@ -215,14 +234,15 @@ class ScalarFunctionsTest extends DocumentingTest {
       }
     }
     section("size() applied to string", "functions-size-of-string") {
-      p(
-        """`size()` returns the number of Unicode characters in a string.""".stripMargin)
-      function("size(string)", "An Integer.", ("string", "An expression that returns a string value."))
+      p("The function `size()` returns the number of Unicode characters in a string.")
+      function("size(string)",
+        "An Integer.",
+        ("string", "An expression that returns a string value."))
       considerations("`size(null)` returns `null`.")
-      query(
-        """MATCH (a)
-          |WHERE size(a.name) > 6
-          |RETURN size(a.name)""".stripMargin, ResultAssertions((r) => {
+      query("""MATCH (a)
+              #WHERE size(a.name) > 6
+              #RETURN size(a.name)""".stripMargin('#'),
+      ResultAssertions((r) => {
           r.toList should equal(List(Map("size(a.name)" -> 7)))
         })) {
         resultTable()
@@ -230,27 +250,27 @@ class ScalarFunctionsTest extends DocumentingTest {
       }
     }
     section("startNode()", "functions-startnode") {
-      p(
-        """`startNode()` returns the start node of a relationship.""".stripMargin)
-      function("startNode(relationship)", "A Node.", ("relationship", "An expression that returns a relationship."))
+      p("The function `startNode()` returns the start node of a relationship.")
+      function("startNode(relationship)",
+        "A Node.",
+        ("relationship", "An expression that returns a relationship."))
       considerations("`startNode(null)` returns `null`.")
-      query(
-        """MATCH (x:Developer)-[r]-()
-          |RETURN startNode(r)""".stripMargin, ResultAssertions((r) => {
+      query("""MATCH (x:Developer)-[r]-()
+              #RETURN startNode(r)""".stripMargin('#'),
+      ResultAssertions((r) => {
           r.columnAs[Node]("startNode(r)").toList.map(_.getId) should equal(Array(0, 0))
         })) {
         resultTable()
       }
     }
     section("timestamp()", "functions-timestamp") {
-      p(
-        """`timestamp()` returns the difference, measured in milliseconds, between the current time and midnight, January 1, 1970 UTC.
-          |It is the equivalent of `datetime().epochMillis`.
-          |""".stripMargin)
-      function("timestamp()", "An Integer.")
+      p("""The function `timestamp()` returns the difference, measured in milliseconds, between the current time and midnight, January 1, 1970 UTC.
+          #It is the equivalent of `datetime().epochMillis`.""".stripMargin('#'))
+      function("timestamp()",
+        "An Integer.")
       considerations("`timestamp()` will return the same value during one entire query, even for long-running queries.")
-      query(
-        """RETURN timestamp()""".stripMargin, ResultAssertions((r) => {
+      query("RETURN timestamp()",
+      ResultAssertions((r) => {
           r.toList.head("timestamp()") match {
             // this should pass unless your machine is really slow
             case x: Long => System.currentTimeMillis - x < 100000
@@ -262,50 +282,58 @@ class ScalarFunctionsTest extends DocumentingTest {
       }
     }
     section("toBoolean()", "functions-toboolean") {
-      p(
-        "`toBoolean()` converts a string value to a boolean value.")
-      function("toBoolean(expression)", "A Boolean.", ("expression", "An expression that returns a boolean or string value."))
-      considerations("`toBoolean(null)` returns `null`.", "If `expression` is a boolean value, it will be returned unchanged.", "If the parsing fails, `null` will be returned.")
-      query(
-        """RETURN toBoolean('TRUE'), toBoolean('not a boolean')""".stripMargin, ResultAssertions((r) => {
-          r.toList should equal(List(Map("toBoolean('TRUE')" -> true, "toBoolean('not a boolean')" -> null)))
+      p("The function `toBoolean()` converts a string value to a boolean value.")
+      function("toBoolean(expression)",
+        "A Boolean.",
+        ("expression", "An expression that returns a boolean or string value."))
+      considerations("`toBoolean(null)` returns `null`.",
+        "If `expression` is a boolean value, it will be returned unchanged.",
+        "If the parsing fails, `null` will be returned.")
+      query("RETURN toBoolean('true'), toBoolean('not a boolean')",
+      ResultAssertions((r) => {
+          r.toList should equal(List(Map("toBoolean('true')" -> true, "toBoolean('not a boolean')" -> null)))
         })) {
         resultTable()
       }
     }
     section("toFloat()", "functions-tofloat") {
-      p(
-        "`toFloat()` converts an integer or string value to a floating point number.".stripMargin)
+      p("The function `toFloat()` converts an integer or string value to a floating point number.")
       function("toFloat(expression)", "A Float.", ("expression", "An expression that returns a numeric or string value."))
-      considerations("`toFloat(null)` returns `null`.", "If `expression` is a floating point number, it will be returned unchanged.", "If the parsing fails, `null` will be returned.")
-      query(
-        """RETURN toFloat('11.5'), toFloat('not a number')""".stripMargin, ResultAssertions((r) => {
+      considerations("`toFloat(null)` returns `null`.",
+        "If `expression` is a floating point number, it will be returned unchanged.",
+        "If the parsing fails, `null` will be returned.")
+      query("RETURN toFloat('11.5'), toFloat('not a number')",
+      ResultAssertions((r) => {
           r.toList should equal(List(Map("toFloat('11.5')" -> 11.5, "toFloat('not a number')" -> null)))
         })) {
         resultTable()
       }
     }
     section("toInteger()", "functions-tointeger") {
-      p(
-        """`toInteger()` converts a floating point or string value to an integer value.""".stripMargin)
-      function("toInteger(expression)", "An Integer.", ("expression", "An expression that returns a numeric or string value."))
-      considerations("`toInteger(null)` returns `null`.", "If `expression` is an integer value, it will be returned unchanged.", "If the parsing fails, `null` will be returned.")
-      query(
-        """RETURN toInteger('42'), toInteger('not a number')""".stripMargin, ResultAssertions((r) => {
+      p("The function `toInteger()` converts a floating point or string value to an integer value.")
+      function("toInteger(expression)",
+        "An Integer.",
+        ("expression", "An expression that returns a numeric or string value."))
+      considerations("`toInteger(null)` returns `null`.",
+        "If `expression` is an integer value, it will be returned unchanged.",
+        "If the parsing fails, `null` will be returned.")
+      query("RETURN toInteger('42'), toInteger('not a number')",
+      ResultAssertions((r) => {
           r.toList should equal(List(Map("toInteger('42')" -> 42, "toInteger('not a number')" -> null)))
         })) {
         resultTable()
       }
     }
     section("type()", "functions-type") {
-      p(
-        """`type()` returns the string representation of the relationship type.""".stripMargin)
-      function("type(relationship)", "A String.", ("relationship", "An expression that returns a relationship."))
+      p("The function `type()` returns the string representation of the relationship type.")
+      function("type(relationship)",
+        "A String.",
+        ("relationship", "An expression that returns a relationship."))
       considerations("`type(null)` returns `null`.")
-      query(
-        """MATCH (n)-[r]->()
-          |WHERE n.name = 'Alice'
-          |RETURN type(r)""".stripMargin, ResultAssertions((r) => {
+      query("""MATCH (n)-[r]->()
+              #WHERE n.name = 'Alice'
+              #RETURN type(r)""".stripMargin('#'),
+      ResultAssertions((r) => {
           r.toList should equal(List(Map("type(r)" -> "KNOWS"), Map("type(r)" -> "KNOWS")))
         })) {
         p("The relationship type of `r` is returned.")

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ScalarFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ScalarFunctionsTest.scala
@@ -43,13 +43,6 @@ class ScalarFunctionsTest extends DocumentingTest {
         #  (charlie)-[:KNOWS]->(daniel),
         #  (bob)-[:MARRIED]->(eskil)""".stripMargin('#'))
     synopsis("Scalar functions return a single value.")
-    important {
-      p("""The `length()` and `size()` functions are quite similar, and so it is important to take note of the difference.
-          #
-          #The function `length()` only works for <<functions-length, paths>>.
-          #
-          #The function `size()` only works for the three types: <<functions-size-of-string, strings>>, <<functions-size, lists>> and <<functions-size-of-pattern-expression, pattern expressions>>.""".stripMargin('#'))
-    }
     p("""Functions:
         #
         #* <<functions-coalesce, coalesce()>>
@@ -69,6 +62,13 @@ class ScalarFunctionsTest extends DocumentingTest {
         #* <<functions-tofloat, toFloat()>>
         #* <<functions-tointeger, toInteger()>>
         #* <<functions-type, type()>>""".stripMargin('#'))
+    important {
+      p("""The `length()` and `size()` functions are quite similar, and so it is important to take note of the difference.
+          #
+          #The function `length()` only works for <<functions-length, paths>>.
+          #
+          #The function `size()` only works for the three types: <<functions-size-of-string, strings>>, <<functions-size, lists>> and <<functions-size-of-pattern-expression, pattern expressions>>.""".stripMargin('#'))
+    }
     graphViz()
     section("coalesce()", "functions-coalesce") {
       p("The function `coalesce()` returns the first non-`null` value in the given list of expressions.")

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ScalarFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ScalarFunctionsTest.scala
@@ -119,10 +119,11 @@ class ScalarFunctionsTest extends DocumentingTest {
     section("id()", "functions-id") {
       p("The function `id()` returns the id of a relationship or node.")
       note {
+        //The note has been approved by kernel team.
         p("""Neo4j implements the id so that:
             #
-            #Node:: Every node in a database has a unique id compared to other nodes in the same database.
-            #Relationship:: Every relationship in a database has a unique id compared to other relationships in the same database.""".stripMargin('#'))
+            #Node:: Every node in a database has a unique id compared to other nodes in the same database, the uniqueness is guaranteed within the scope of a single transaction.
+            #Relationship:: Every relationship in a database has a unique id compared to other relationships in the same database, the uniqueness is guaranteed within the scope of a single transaction.""".stripMargin('#'))
       }
       function("id(expression)",
         "An Integer.",


### PR DESCRIPTION
Updated the Scalar functions page.
Fixed some examples and text.