### PR TITLE
fixed the footer info of query result

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/QueryResultContentBuilder.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/QueryResultContentBuilder.scala
@@ -45,9 +45,9 @@ class QueryResultContentBuilder(valueFormatter: Any => String)
       ResultRow(values)
     }
 
-    val footerRows = if (rowCount == 1) "1 row" else s"$rowCount rows"
+    val footerRows = s"Rows: $rowCount"
     val footer = if (result.queryStatistics().containsUpdates)
-      footerRows + ", " + result.queryStatistics().toString
+      footerRows + "\n" + result.queryStatistics().toString
     else
       footerRows
 


### PR DESCRIPTION
The footer result is weirdly formatted like

```
1 row, Nodes created: 1
Properties set: 2
Labels added: 1
```

this fix will show:

```
Rows: 1
Nodes created: 1
Properties set: 2
Labels added: 1
```