### PR TITLE
update include link in administration index

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/administration.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/administration.asciidoc
@@ -55,7 +55,7 @@ include::ql/administration/administration-databases.adoc[leveloffset=+1]
 
 include::ql/administration/indexes-for-search-performance/index.asciidoc[leveloffset=+1]
 
-include::ql/administration/indexes-for-full-text-search/index.asciidoc[leveloffset=+1]
+include::ql/administration/indexes/indexes-for-full-text-search/index.asciidoc[leveloffset=+1]
 
 include::ql/administration/constraints/index.asciidoc[leveloffset=+1]
 


### PR DESCRIPTION
Updates the include statement in administration.asciidoc to point to the actual file that contains the content. The current link points to an intermediate file that consists of a single line which is itself another include statement pointing to the correct file.

This seems redundant and confuses the build into keeping the include. The result is that the content is output on the administration index page when it shouldn't be.