### PR TITLE
Add `FULLTEXT` filtering to `SHOW INDEXES`

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -54,6 +54,7 @@ Replacement syntax for deprecated and removed features are also indicated.
 | `ON DEFAULT DATABASE` for privilege commands  | Syntax        | Deprecated    | Replaced by `ON HOME DATABASE`
 | `ON DEFAULT GRAPH` for privilege commands     | Syntax        | Deprecated    | Replaced by `ON HOME GRAPH`
 | `CREATE INDEX [name] FOR ()-[r:TYPE]-() ON (r.prop)` | Functionality | Added | Allows creating indexes on relationships.
+| `SHOW FULLTEXT INDEXES`   | Functionality | Updated  | Now allows easy filtering for `SHOW INDEXES` on fulltext indexes. Allows `YIELD` and `WHERE` but not `BRIEF` or `VERBOSE`.
 |===
 
 [[cypher-deprecations-additions-removals-4.2]]

--- a/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
@@ -49,7 +49,7 @@ This section comprises a glossary of all the keywords -- grouped by category and
 |<<query-return, RETURN ... [AS]>>                    | Projecting   |  Defines what to include in the query result set.
 |<<query-set, SET>>                          | Writing     |  Update labels on nodes and properties on nodes and relationships.
 |<<administration-constraints-list-constraint, SHOW [ALL\|UNIQUE\|NODE EXIST[S]\|RELATIONSHIP EXIST[S]\|EXIST[S]\|NODE KEY] CONSTRAINT[S] [BRIEF\|VERBOSE [OUTPUT]]>> | Schema | List constraints in the database, either all or filtered on type.
-|<<administration-indexes-list-indexes, SHOW [ALL\|BTREE] INDEX[ES]>> | Schema | List indexes in the database, either all or B-tree only. Also allows `WHERE` and `YIELD` clauses.
+|<<administration-indexes-list-indexes, SHOW [ALL\|BTREE\|FULLTEXT] INDEX[ES]>> | Schema | List indexes in the database, either all or filtered on B-tree or fulltext indexes. Also allows `WHERE` and `YIELD` clauses.
 |<<query-skip, SKIP>>                            | Reading/Writing | A sub-clause defining from which row to start including the rows in the output.
 |<<query-union, UNION>>                      | Set operations   |  Combines the result of multiple queries. Duplicates are removed.
 |<<query-union, UNION ALL>>                      | Set operations   |  Combines the result of multiple queries. Duplicates are retained.

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/indexes-for-search-performance/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/indexes-for-search-performance/index.asciidoc
@@ -126,12 +126,12 @@ With `IF EXISTS`, no error is thrown and nothing happens should the index not ex
 
 | [source, cypher, role=noplay]
 ----
-SHOW [ALL\|BTREE] INDEX[ES]
+SHOW [ALL\|BTREE\|FULLTEXT] INDEX[ES]
     [YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
     [WHERE expression]
     [RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
 ----
-| List indexes in the database, either all or B-tree only.
+| List indexes in the database, either all or filtered on B-tree or fulltext indexes.
 | When using the `RETURN` clause, the `YIELD` clause is mandatory and may not be omitted.
 
 | [source, cypher, role=noplay]

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SchemaIndexTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SchemaIndexTest.scala
@@ -186,8 +186,11 @@ class SchemaIndexTest extends DocumentingTestBase with QueryStatisticsTestSuppor
       title = "Listing indexes with filtering",
       text =
         """
-          |One way of filtering the output from `SHOW INDEXES` is to use the `BTREE` keyword to only list `BTREE` indexes.
-          |Another is to use the `WHERE` clause, for example to only show indexes not belonging to constraints.""".stripMargin,
+          |One way of filtering the output from `SHOW INDEXES` by index type is the use of type keywords,
+          |listed in the <<administration-indexes-syntax, syntax table>>.
+          |As an example, to show only B-tree indexes, use `SHOW BTREE INDEXES`.
+          |Another, more flexible way of filtering the output is to use the `WHERE` clause.
+          |An example is to only show indexes not belonging to constraints.""".stripMargin,
       prepare = _ => executePreparationQueries(List("create index for ()-[r:KNOWS]-() on (r.since)")),
       queryText = "SHOW BTREE INDEXES WHERE uniqueness = 'NONUNIQUE'",
       optionalResultExplanation =

--- a/cypher/cypher-prettifier/src/main/scala/org/neo4j/cypher/docgen/tooling/PrettifierParser.scala
+++ b/cypher/cypher-prettifier/src/main/scala/org/neo4j/cypher/docgen/tooling/PrettifierParser.scala
@@ -179,7 +179,9 @@ class PrettifierParser(val keepMyNewlines: Boolean) extends Parser with Base wit
     keyword("SHOW ALL INDEX") |
     keyword("SHOW ALL INDEXES") |
     keyword("SHOW BTREE INDEX") |
-    keyword("SHOW BTREE INDEXES")
+    keyword("SHOW BTREE INDEXES") |
+    keyword("SHOW FULLTEXT INDEX") |
+    keyword("SHOW FULLTEXT INDEXES")
   }
 
   def joinWithUpdatingBreakingKeywords: Rule1[BreakingKeywords] =

--- a/cypher/cypher-prettifier/src/test/scala/org/neo4j/cypher/docgen/tooling/PrettifierParserTest.scala
+++ b/cypher/cypher-prettifier/src/test/scala/org/neo4j/cypher/docgen/tooling/PrettifierParserTest.scala
@@ -168,6 +168,7 @@ class PrettifierParserTest extends ParserTestBase[Seq[SyntaxToken], Seq[SyntaxTo
       ("show index", Seq(BreakingKeywords("show index"))),
       ("show all indexes", Seq(BreakingKeywords("show all indexes"))),
       ("show btree index", Seq(BreakingKeywords("show btree index"))),
+      ("show fulltext index", Seq(BreakingKeywords("show fulltext index"))),
       ("show index yield *", Seq(BreakingKeywords("show index"), NonBreakingKeywords("yield"), AnyText("*"))),
       ("show index where type = 'BTREE'", Seq(BreakingKeywords("show index"), BreakingKeywords("where"), AnyText("type"), AnyText("="), EscapedText("BTREE", '\''))),
       // deprecated

--- a/cypher/cypher-prettifier/src/test/scala/org/neo4j/cypher/docgen/tooling/PrettifierTest.scala
+++ b/cypher/cypher-prettifier/src/test/scala/org/neo4j/cypher/docgen/tooling/PrettifierTest.scala
@@ -77,6 +77,7 @@ class PrettifierTest extends Suite
   test("should not break SHOW INDEXES") {
     actual("show indexes") should equal(expected("SHOW INDEXES"))
     actual("show btree index yield *") should equal(expected("SHOW BTREE INDEX YIELD *"))
+    actual("show fulltext indexes") should equal(expected("SHOW FULLTEXT INDEXES"))
     // deprecated
     actual("show all indexes brief output") should equal(expected("SHOW ALL INDEXES BRIEF OUTPUT"))
     actual("show btree index verbose") should equal(expected("SHOW BTREE INDEX VERBOSE"))


### PR DESCRIPTION
~~Currently have broken tests due to relationship property indexes now being blocked (https://github.com/neo-technology/neo4j/pull/9567), fixed by https://github.com/neo4j/neo4j-documentation/pull/1069.~~