### PR TITLE
Bump guava from 27.1-jre to 29.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -410,7 +410,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>27.1-jre</version>
+                <version>29.0-jre</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
Resubmission of #1071 from a green branch of 4.3