### PR TITLE
Generate internal settings documentation

### DIFF
--- a/config-docs/pom.xml
+++ b/config-docs/pom.xml
@@ -107,6 +107,18 @@
                                     <arg file="${project.build.directory}/docs/ops/all-settings.adoc" />
                                 </java>
 
+                                <!-- All internal settings -->
+                                <java classname="org.neo4j.doc.ConfigDocsTool"
+                                      classpathref="maven.compile.classpath" failonerror="true" fork="true">
+                                    <arg value="--id=settings-reference-internal-settings" />
+                                    <arg value="--id-prefix=internal_" />
+                                    <arg value="--title=Internal settings" />
+                                    <arg value="--deprecated=true" />
+                                    <arg value="--unsupported" />
+                                    <arg value="--internal=true" />
+                                    <arg file="${project.build.directory}/docs/ops/internal-settings.adoc" />
+                                </java>
+
                                 <!-- All deprecated settings -->
                                 <java classname="org.neo4j.doc.ConfigDocsTool"
                                       classpathref="maven.compile.classpath" failonerror="true" fork="true">

--- a/config-docs/src/main/java/org/neo4j/doc/ConfigDocsTool.java
+++ b/config-docs/src/main/java/org/neo4j/doc/ConfigDocsTool.java
@@ -103,7 +103,7 @@ public class ConfigDocsTool {
                 // If true, no filter is added. If false, require {@code SettingImpl<Object#isInternal()} to be false.
                 case "internal":
                     return null == e.getValue() || "true".equalsIgnoreCase(e.getValue())
-                            ? Stream.empty()
+                            ? Stream.of( SettingImpl::internal )
                             : Stream.of(v -> !v.internal());
                 // Include only the setting matching this name.
                 case "name":


### PR DESCRIPTION
Will output an additional `/docs/ops/internal-settings.adoc` with (only) the settings marked as internal