### PR TITLE
Remove example block delimeter from end of file

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/ql/load-csv/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/load-csv/index.asciidoc
@@ -129,4 +129,3 @@ If `LOAD CSV` is invoked with a `file:///` URL that points to your disk `file()`
 +------------------------------------------+
 1 row
 ----
-=======


### PR DESCRIPTION
A warning is reported in the HTML and PDF builds.

The HTML build is unaffected because it is the end of the file.

The PDF build is affected because the PDF is built as if it were a single asciidoc file, so all the remaining content after this example block delimiter is treated as a giant example block, which in turn means the table of contents ends at this point.