### PR TITLE
Remove example block delimiter from end of file (#1196)

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/ql/load-csv/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/load-csv/index.asciidoc
@@ -129,4 +129,3 @@ If `LOAD CSV` is invoked with a `file:///` URL that points to your disk `file()`
 +------------------------------------------+
 1 row
 ----
-=======


### PR DESCRIPTION
(cherry picked from commit cea3e26b2941dd040db04f6a0f9994052d649cc9)