### PR TITLE
Update so limited result table don't need columns

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ShowFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ShowFunctionsTest.scala
@@ -133,7 +133,7 @@ When using the `RETURN` clause, the `YIELD` clause is mandatory and may not be o
       query("SHOW FUNCTIONS", ResultAssertions(p => {
         p.columns should contain theSameElementsAs Array("name", "category", "description")
       })) {
-        limitedResultTable(List("name", "category", "description"), 20)
+        limitedResultTable(20)
       }
     }
     section("Listing functions with filtering on output columns") {
@@ -150,7 +150,7 @@ When using the `RETURN` clause, the `YIELD` clause is mandatory and may not be o
         p.columnAs[String]("name").foreach(_ should startWith("a"))
         p.columnAs[Boolean]("isBuiltIn").foreach(_ should be(true))
       })) {
-        limitedResultTable(List("name", "isBuiltIn"), 15)
+        limitedResultTable(15)
       }
     }
     section("Listing functions with other filtering") {
@@ -172,7 +172,7 @@ When using the `RETURN` clause, the `YIELD` clause is mandatory and may not be o
         p.columnAs[List[String]]("rolesExecution").foreach(_ should be(null))
         p.columnAs[List[String]]("rolesBoostedExecution").foreach(_ should be(null))
       })) {
-        limitedResultTable(List("name", "category", "description", "rolesExecution", "rolesBoostedExecution"))
+        limitedResultTable(maybeWantedColumns = Some(List("name", "category", "description", "rolesExecution", "rolesBoostedExecution")))
       }
       p("Notice that the two `roles` columns are empty due to missing the <<access-control-dbms-administration-role-management,`SHOW ROLE`>> privilege.")
       logout()
@@ -180,7 +180,7 @@ When using the `RETURN` clause, the `YIELD` clause is mandatory and may not be o
       query("SHOW FUNCTIONS EXECUTABLE BY jake", ResultAssertions(p => {
         p.columns should contain theSameElementsAs Array("name", "category", "description")
       })) {
-        limitedResultTable(List("name", "category", "description"))
+        limitedResultTable()
       }
     }
   }.build()

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ShowProceduresTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ShowProceduresTest.scala
@@ -138,7 +138,7 @@ When using the `RETURN` clause, the `YIELD` clause is mandatory and may not be o
       query("SHOW PROCEDURES", ResultAssertions(p => {
         p.columns should contain theSameElementsAs Array("name", "description", "mode", "worksOnSystem")
       })) {
-        limitedResultTable(List("name", "description", "mode", "worksOnSystem"), 15)
+        limitedResultTable(15)
       }
     }
     section("Listing procedures with filtering on output columns") {
@@ -152,7 +152,7 @@ When using the `RETURN` clause, the `YIELD` clause is mandatory and may not be o
         p.columns should contain theSameElementsAs Array("name", "admin")
         p.columnAs[Boolean]("admin").foreach(_ should be(true))
       })) {
-        limitedResultTable(List("name", "admin"), 7)
+        limitedResultTable(7)
       }
     }
     section("Listing procedures with other filtering") {
@@ -172,7 +172,7 @@ When using the `RETURN` clause, the `YIELD` clause is mandatory and may not be o
         p.columnAs[List[String]]("rolesExecution").foreach(_ should be(null))
         p.columnAs[List[String]]("rolesBoostedExecution").foreach(_ should be(null))
       })) {
-        limitedResultTable(List("name", "description", "rolesExecution", "rolesBoostedExecution"))
+        limitedResultTable(maybeWantedColumns = Some(List("name", "description", "rolesExecution", "rolesBoostedExecution")))
       }
       p("Note that the two `roles` columns are empty due to missing the <<access-control-dbms-administration-role-management,SHOW ROLE>> privilege.")
       logout()
@@ -180,7 +180,7 @@ When using the `RETURN` clause, the `YIELD` clause is mandatory and may not be o
       query("SHOW PROCEDURES EXECUTABLE BY jake", ResultAssertions(p => {
         p.columns should contain theSameElementsAs Array("name", "description", "mode", "worksOnSystem")
       })) {
-        limitedResultTable(List("name", "description", "mode", "worksOnSystem"))
+        limitedResultTable()
       }
     }
   }.build()

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/DocBuilder.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/DocBuilder.scala
@@ -130,19 +130,20 @@ trait DocBuilder {
     queryScope.addContent(new TablePlaceHolder(queryScope.assertions, queryScope.params:_*))
   }
 
-  /**Print a smaller version of the result without changing the query.
+  /** Print a smaller version of the result without changing the query.
    * Can limit the amount of printed rows and columns.
    * Will print the given columns in the given order.
    *
-   * @param wantedColumns the columns to be displayed, in the wanted display order
-   * @param rows          the number of result rows to display
+   * @param maybeWantedColumns the columns to be displayed, in the wanted display order.
+   *                           If no column list is given, all columns will be displayed (this is default).
+   * @param rows               the number of result rows to display
    */
-  def limitedResultTable(wantedColumns: List[String], rows: Int = 10): Unit = {
+  def limitedResultTable(rows: Int = 10, maybeWantedColumns: Option[List[String]] = None): Unit = {
     assert(rows > 0, "Cannot display less than one row")
     val queryScope = scope.collectFirst {
       case q: QueryScope => q
     }.get
-    queryScope.addContent(new LimitedTablePlaceHolder(wantedColumns, rows, queryScope.assertions, queryScope.params:_*))
+    queryScope.addContent(new LimitedTablePlaceHolder(maybeWantedColumns, rows, queryScope.assertions, queryScope.params: _*))
   }
 
   def statsOnlyResultTable(): Unit = {

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/Document.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/Document.scala
@@ -411,7 +411,7 @@ trait QueryResultPlaceHolder {
 
 // NOTE: These must _not_ be case classes, otherwise they will not be compared by identity
 class TablePlaceHolder(val assertions: QueryAssertions, val params: (String, Any)*) extends Content with QueryResultPlaceHolder
-class LimitedTablePlaceHolder(val wantedColumns: List[String], val rows: Int, assertions: QueryAssertions, params: (String, Any)*) extends TablePlaceHolder(assertions, params: _*)
+class LimitedTablePlaceHolder(val maybeWantedColumns: Option[List[String]], val rows: Int, assertions: QueryAssertions, params: (String, Any)*) extends TablePlaceHolder(assertions, params: _*)
 class StatsOnlyTablePlaceHolder(assertions: QueryAssertions, params: (String, Any)*) extends TablePlaceHolder(assertions, params: _*)
 class ErrorOnlyTablePlaceHolder(assertions: QueryAssertions, params: (String, Any)*) extends TablePlaceHolder(assertions, params: _*)
 class GraphVizPlaceHolder(val options: String) extends Content with QueryResultPlaceHolder

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/QueryRunner.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/QueryRunner.scala
@@ -95,7 +95,7 @@ class QueryRunner(formatter: (GraphDatabaseQueryService, InternalTransaction) =>
   private def runSingleQuery(dbms: RestartableDatabase, query: DatabaseQuery, assertions: QueryAssertions, content: TablePlaceHolder): QueryRunResult = {
     val format: (InternalTransaction) => (DocsExecutionResult) => Content = (tx: InternalTransaction) => content match {
       case _: StatsOnlyTablePlaceHolder => statsOnly(_)
-      case l: LimitedTablePlaceHolder => new LimitedQueryResultContentBuilder(l.wantedColumns, l.rows, new LimitedValueFormatter(dbms.getInnerDb, tx))
+      case l: LimitedTablePlaceHolder => new LimitedQueryResultContentBuilder(l.maybeWantedColumns, l.rows, new LimitedValueFormatter(dbms.getInnerDb, tx))
       case _ => formatter(dbms.getInnerDb, tx)(_)
     }
 


### PR DESCRIPTION
since column order has been fixed it can use the columns from the result instead of needing to list all columns explicitly