### PR TITLE
Fix wrong link for privileges to show role privileges

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/role-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/role-management-syntax.asciidoc
@@ -29,7 +29,7 @@ SHOW ROLE name PRIVILEGES
     [WHERE expression]
 ----
 | List the privileges granted to a role.
-| <<administration-security-administration-dbms-privileges-role-management, SHOW ROLE PRIVILEGES>>
+| <<administration-security-administration-dbms-privileges-privilege-management, SHOW PRIVILEGE>>
 
 | [source, cypher, role=noplay]
 ----


### PR DESCRIPTION
Should link to `SHOW PRIVILEGE` privilege not `ROLE MANAGEMENT` privileges.