### PR TITLE
Document additional columns for SHOW DATABASES

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/ql/administration/show-databases-columns.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/show-databases-columns.asciidoc
@@ -4,13 +4,13 @@
 |name|The name of the database.|{check-mark}|{check-mark}|
 |databaseID|The database unique ID.||{check-mark}|
 |serverID|The server instance ID.||{check-mark}|
-|address|Instance address in a clustered DBMS. The default for standalone database is `neo4j://localhost:7687`|{check-mark}|{check-mark}|
-|role|the current role of the database (`standalone`, `leader`, `follower`, `read_replica`, `unknown`).|{check-mark}|{check-mark}|
+|address|Instance address in a clustered DBMS. The default for a standalone database is `neo4j://localhost:7687`. |{check-mark}|{check-mark}|
+|role|The current role of the database (`standalone`, `leader`, `follower`, `read_replica`, `unknown`).|{check-mark}|{check-mark}|
 |requestedStatus|The expected status of the database.|{check-mark}|{check-mark}|
 |currentStatus|The actual status of the database.|{check-mark}|{check-mark}|
 |error|An error message explaining why the database is not in the correct state.|{check-mark}|{check-mark}|
-|default|Show if this is the default database for the DBMS.|{check-mark}|{check-mark}|Not returned by `SHOW HOME DATABASE` or `SHOW DEFAULT DATABASE`
-|home|Shown if this is the home database for the current user.|{check-mark}|{check-mark}|Not returned by `SHOW HOME DATABASE` or `SHOW DEFAULT DATABASE`
+|default|Show if this is the default database for the DBMS.|{check-mark}|{check-mark}|Not returned by `SHOW HOME DATABASE` or `SHOW DEFAULT DATABASE`.
+|home|Shown if this is the home database for the current user.|{check-mark}|{check-mark}|Not returned by `SHOW HOME DATABASE` or `SHOW DEFAULT DATABASE`.
 |lastCommittedTxn|The ID of the last transaction received.||{check-mark}|
 |replicationLag|Number of transactions the current database is behind compared to the database on the primary instance. The lag is expressed in negative integers. In standalone environments, the value is always 0.||{check-mark}|
 |===

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/show-databases-columns.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/show-databases-columns.asciidoc
@@ -1,18 +1,17 @@
-[options="header" cols="2l,4,1,2"]
+[options="header" cols="2l,4,1,1,2"]
 |===
-|Column |Description|Included by default|Notes
-|name|The name of the database.|{check-mark}|
-|databaseID|The database unique ID.||
-|serverID|The server instance ID.||
-|address|Instance address in a clustered DBMS.
-The default for standalone database is `neo4j://localhost:7687`|{check-mark}|
-|role|the current role of the database (`standalone`, `leader`, `follower`, `read_replica`, `unknown`).|{check-mark}|
-|requestedStatus|The expected status of the database.|{check-mark}|
-|currentStatus|The actual status of the database.|{check-mark}|
-|error|An error message explaining why the database is not in the correct state.|{check-mark}|
-|default|Show if this is the default database for the DBMS.|{check-mark}|Not returned by `SHOW HOME DATABASE` or `SHOW DEFAULT DATABASE`
-|home|Shown if this is the home database for the current user.|{check-mark}|Not returned by `SHOW HOME DATABASE` or `SHOW DEFAULT DATABASE`
-|lastCommittedTxn|The ID of the last transaction received.||
-|replicationLag|Number of transactions the current database is behind compared to the database on the primary instance. The lag is expressed in negative integers. In standalone environments, the value is always 0.||
+|Column |Description|Default Output|Full Output| Notes
+|name|The name of the database.|{check-mark}|{check-mark}|
+|databaseID|The database unique ID.||{check-mark}|
+|serverID|The server instance ID.||{check-mark}|
+|address|Instance address in a clustered DBMS. The default for standalone database is `neo4j://localhost:7687`|{check-mark}|{check-mark}|
+|role|the current role of the database (`standalone`, `leader`, `follower`, `read_replica`, `unknown`).|{check-mark}|{check-mark}|
+|requestedStatus|The expected status of the database.|{check-mark}|{check-mark}|
+|currentStatus|The actual status of the database.|{check-mark}|{check-mark}|
+|error|An error message explaining why the database is not in the correct state.|{check-mark}|{check-mark}|
+|default|Show if this is the default database for the DBMS.|{check-mark}|{check-mark}|Not returned by `SHOW HOME DATABASE` or `SHOW DEFAULT DATABASE`
+|home|Shown if this is the home database for the current user.|{check-mark}|{check-mark}|Not returned by `SHOW HOME DATABASE` or `SHOW DEFAULT DATABASE`
+|lastCommittedTxn|The ID of the last transaction received.||{check-mark}|
+|replicationLag|Number of transactions the current database is behind compared to the database on the primary instance. The lag is expressed in negative integers. In standalone environments, the value is always 0.||{check-mark}|
 |===
 

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/show-databases-columns.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/show-databases-columns.asciidoc
@@ -1,0 +1,18 @@
+[options="header" cols="2l,4,1,2"]
+|===
+|Column |Description|Included by default|Notes
+|name|The name of the database.|{check-mark}|
+|databaseID|The database unique ID.||
+|serverID|The server instance ID.||
+|address|Instance address in a clustered DBMS.
+The default for standalone database is `neo4j://localhost:7687`|{check-mark}|
+|role|the current role of the database (`standalone`, `leader`, `follower`, `read_replica`, `unknown`).|{check-mark}|
+|requestedStatus|The expected status of the database.|{check-mark}|
+|currentStatus|The actual status of the database.|{check-mark}|
+|error|An error message explaining why the database is not in the correct state.|{check-mark}|
+|default|Show if this is the default database for the DBMS.|{check-mark}|Not returned by `SHOW HOME DATABASE` or `SHOW DEFAULT DATABASE`
+|home|Shown if this is the home database for the current user.|{check-mark}|Not returned by `SHOW HOME DATABASE` or `SHOW DEFAULT DATABASE`
+|lastCommittedTxn|The ID of the last transaction received.||
+|replicationLag|Number of transactions the current database is behind compared to the database on the primary instance. The lag is expressed in negative integers. In standalone environments, the value is always 0.||
+|===
+

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DatabasesTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DatabasesTest.scala
@@ -44,8 +44,12 @@ class DatabasesTest extends DocumentingTest with QueryStatisticsTestSupport {
         |These administrative commands are automatically routed to the `system` database when connected to the DBMS over Bolt.""".stripMargin)
     p("include::databases-command-syntax.asciidoc[]")
     section("Listing databases", "administration-databases-show-databases") {
-      p("There are three different commands for listing databases. Listing all databases, listing a particular database or listing the default database.")
-      p("All available databases can be seen using the command `SHOW DATABASES`.")
+      p(
+        """There are three different commands for listing databases. Listing all databases, listing a particular database or listing the default database.
+          |The `SHOW DATABASES` commands return the following columns:""".stripMargin)
+      p("include::show-databases-columns.asciidoc[]")
+      p(
+        """A summary of all available available databases can be seen using the command `SHOW DATABASES`. """)
       query("SHOW DATABASES", assertDatabasesShown) {
         resultTable()
       }
@@ -56,14 +60,17 @@ class DatabasesTest extends DocumentingTest with QueryStatisticsTestSupport {
             |If a user has not been granted `ACCESS` privilege to any databases, the command can still be executed but will only return the `system` database, which is always visible.
             |""".stripMargin)
           }
+      p(
+        """In this example, the detailed information for a particular database can be seen using the command `SHOW DATABASE name YIELD *`. When a `YIELD`
+          |is specified, the full set of columns is returned.
+          |""".stripMargin)
+      query("SHOW DATABASE movies YIELD *", assertDatabaseShown("movies")) {
+        resultTable()
+      }
       p("The number of databases can be seen using a `count()` aggregation with `YIELD` and `RETURN`.")
       query("SHOW DATABASES YIELD * RETURN count(*) as count", ResultAssertions({ r: DocsExecutionResult =>
         r.columnAs[Int]("count").toSet should be(Set(4))
       })){
-        resultTable()
-      }
-      p("A particular database can be seen using the command `SHOW DATABASE name`.")
-      query("SHOW DATABASE system", assertDatabaseShown("system")) {
         resultTable()
       }
       p("The default database can be seen using the command `SHOW DEFAULT DATABASE`.")

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DatabasesTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DatabasesTest.scala
@@ -45,8 +45,8 @@ class DatabasesTest extends DocumentingTest with QueryStatisticsTestSupport {
     p("include::databases-command-syntax.asciidoc[]")
     section("Listing databases", "administration-databases-show-databases") {
       p(
-        """There are three different commands for listing databases. Listing all databases, listing a particular database or listing the default database.
-          |The `SHOW DATABASES` commands return the following columns:""".stripMargin)
+        """There are four different commands for listing databases. Listing all databases, listing a particular database, listing the default database, or listing the home database.
+          |These commands return the following columns:""".stripMargin)
       p("include::show-databases-columns.asciidoc[]")
       p(
         """A summary of all available available databases can be seen using the command `SHOW DATABASES`. """)
@@ -62,7 +62,7 @@ class DatabasesTest extends DocumentingTest with QueryStatisticsTestSupport {
           }
       p(
         """In this example, the detailed information for a particular database can be seen using the command `SHOW DATABASE name YIELD *`. When a `YIELD`
-          |is specified, the full set of columns is returned.
+          |clause is provided, the full set of columns is returned.
           |""".stripMargin)
       query("SHOW DATABASE movies YIELD *", assertDatabaseShown("movies")) {
         resultTable()

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DatabasesTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DatabasesTest.scala
@@ -45,11 +45,11 @@ class DatabasesTest extends DocumentingTest with QueryStatisticsTestSupport {
     p("include::databases-command-syntax.asciidoc[]")
     section("Listing databases", "administration-databases-show-databases") {
       p(
-        """There are four different commands for listing databases. Listing all databases, listing a particular database, listing the default database, or listing the home database.
+        """There are four different commands for listing databases: listing all databases, listing a particular database, listing the default database, and listing the home database.
           |These commands return the following columns:""".stripMargin)
       p("include::show-databases-columns.asciidoc[]")
       p(
-        """A summary of all available available databases can be seen using the command `SHOW DATABASES`. """)
+        """A summary of all available databases can be displayed using the command `SHOW DATABASES`. """)
       query("SHOW DATABASES", assertDatabasesShown) {
         resultTable()
       }
@@ -61,7 +61,7 @@ class DatabasesTest extends DocumentingTest with QueryStatisticsTestSupport {
             |""".stripMargin)
           }
       p(
-        """In this example, the detailed information for a particular database can be seen using the command `SHOW DATABASE name YIELD *`. When a `YIELD`
+        """In this example, the detailed information for a particular database can be displayed using the command `SHOW DATABASE name YIELD *`. When a `YIELD`
           |clause is provided, the full set of columns is returned.
           |""".stripMargin)
       query("SHOW DATABASE movies YIELD *", assertDatabaseShown("movies")) {


### PR DESCRIPTION
Document columns in SHOW DATABASES fully. Add `YIELD *` example returning full column set