### PR TITLE
Fix wrong link for privileges to show role privileges

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/ql/administration/security/role-management-syntax.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/security/role-management-syntax.asciidoc
@@ -38,7 +38,7 @@ SHOW ROLE[S] name[, ...] PRIVILEGE[S] [AS [REVOKE] COMMAND[S]]
 | List the privileges granted to the specified roles.
 
 When using the `RETURN` clause, the `YIELD` clause is mandatory and may not be omitted.
-| <<administration-security-administration-dbms-privileges-role-management, SHOW ROLE PRIVILEGES>>
+| <<administration-security-administration-dbms-privileges-privilege-management, SHOW PRIVILEGE>>
 
 | [source, cypher, role=noplay]
 ----


### PR DESCRIPTION
Should link to `SHOW PRIVILEGE` privilege not `ROLE MANAGEMENT` privileges.

Cherry-pick of https://github.com/neo4j/neo4j-documentation/pull/1235