### PR TITLE
remove empty lines from settings list output

### DIFF
--- a/doctools/src/main/java/org/neo4j/doc/AsciiDocListGenerator.java
+++ b/doctools/src/main/java/org/neo4j/doc/AsciiDocListGenerator.java
@@ -64,6 +64,7 @@ public class AsciiDocListGenerator
             if ( shortenDescription ) {
                 description = shortenDescription(description);
             }
+
             sb.append( "|<<" )
                 .append( id )
                 .append( ',' )
@@ -76,7 +77,7 @@ public class AsciiDocListGenerator
                 .append( ',' )
                 .append( name )
                 .append( ">>: " )
-                .append( description );
+                .append( description.replace("\n\n","\n+\n") );
 
             if ( !description.endsWith( "." ) )
             {


### PR DESCRIPTION
This is the simplest way I could find to fix a problem where some settings descriptions break the AsciiDocListGenerator.

In this case where the description contains `\n\n` to force a paragraph break, the resulting list formatting breaks.

There are other issues here that could be better handled - we currently truncate the description at the end of the first sentence (or the second if the first sentence is just a deprecation warning) but that check relies on there being a space char after the period. Some descriptions don't adhere to this style, so they aren't properly truncated, which is understandable because you have to remember (or know) to put a space after a period at the end of a line like so:

```
@description( "This is the first sentence in a setting description. " +
  "This is the next sentence. ")
```

It might be better to take the whole description at this point, and truncate it after it has been converted to asciidoc, which could probably be done with an asciidoctor extension.