### PR TITLE
Add examples for failing to create already existing indexes and constraints

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/ql/administration/indexes-for-search-performance/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/indexes-for-search-performance/index.asciidoc
@@ -252,6 +252,14 @@ include::../indexes/create-a-relationship-type-lookup-index.asciidoc[leveloffset
 
 include::../indexes/create-a-token-lookup-index-specifying-the-index-provider.asciidoc[leveloffset=+1]
 
+include::../indexes/failure-to-create-an-already-existing-index.asciidoc[leveloffset=+1]
+
+include::../indexes/failure-to-create-an-index-with-the-same-name-as-an-already-existing-index.asciidoc[leveloffset=+1]
+
+include::../indexes/failure-to-create-an-index-when-a-constraint-already-exists.asciidoc[leveloffset=+1]
+
+include::../indexes/failure-to-create-an-index-with-the-same-name-as-an-already-existing-constraint.asciidoc[leveloffset=+1]
+
 
 [[administration-indexes-list-indexes]]
 == Listing indexes

--- a/cypher/cypher-docs/src/docs/dev/ql/constraints/examples.adoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/constraints/examples.adoc
@@ -19,6 +19,12 @@ include::../administration/constraints/create-a-unique-constraint-only-if-it-doe
 include::../administration/constraints/create-a-unique-constraint-with-specified-index-provider-and-configuration.asciidoc[leveloffset=+1]
 
 [discrete]
+include::../administration/constraints/failure-to-create-an-already-existing-unique-property-constraint.asciidoc[leveloffset=+1]
+
+[discrete]
+include::../administration/constraints/failure-to-create-a-unique-property-constraint-on-same-schema-as-existing-index.asciidoc[leveloffset=+1]
+
+[discrete]
 include::../administration/constraints/create-a-node-that-complies-with-unique-property-constraints.asciidoc[leveloffset=+1]
 
 [discrete]
@@ -37,6 +43,9 @@ include::../administration/constraints/create-a-node-property-existence-constrai
 
 [discrete]
 include::../administration/constraints/create-a-node-property-existence-constraint-only-if-it-does-not-already-exist.asciidoc[leveloffset=+1]
+
+[discrete]
+include::../administration/constraints/failure-to-create-an-already-existing-node-property-existence-constraint.asciidoc[leveloffset=+1]
 
 [discrete]
 include::../administration/constraints/create-a-node-that-complies-with-property-existence-constraints.asciidoc[leveloffset=+1]
@@ -60,6 +69,9 @@ include::../administration/constraints/create-a-relationship-property-existence-
 
 [discrete]
 include::../administration/constraints/create-a-relationship-property-existence-constraint-only-if-it-does-not-already-exist.asciidoc[leveloffset=+1]
+
+[discrete]
+include::../administration/constraints/failure-to-create-an-already-existing-relationship-property-existence-constraint.asciidoc[leveloffset=+1]
 
 [discrete]
 include::../administration/constraints/create-a-relationship-that-complies-with-property-existence-constraints.asciidoc[leveloffset=+1]
@@ -89,6 +101,12 @@ include::../administration/constraints/create-a-node-key-constraint-with-specifi
 
 [discrete]
 include::../administration/constraints/create-a-node-key-constraint-with-specified-index-configuration.asciidoc[leveloffset=+1]
+
+[discrete]
+include::../administration/constraints/failure-to-create-a-node-key-constraint-when-a-unique-property-constraint-exists-on-the-same-schema.asciidoc[leveloffset=+1]
+
+[discrete]
+include::../administration/constraints/failure-to-create-a-node-key-constraint-with-the-same-name-as-existing-index.asciidoc[leveloffset=+1]
 
 [discrete]
 include::../administration/constraints/create-a-node-that-complies-with-node-key-constraints.asciidoc[leveloffset=+1]

--- a/graphviz/src/main/java/org/neo4j/visualization/asciidoc/AsciidocHelper.java
+++ b/graphviz/src/main/java/org/neo4j/visualization/asciidoc/AsciidocHelper.java
@@ -180,7 +180,7 @@ public class AsciidocHelper
 
     public static String createQueryFailureSnippet( final String output )
     {
-        return "[source]\n----\n" + wrapText( output ) + "\n----\n";
+        return "[source, role=nocopy]\n----\n" + wrapText( output ) + "\n----\n";
     }
 
     private static String wrapText( final String text )


### PR DESCRIPTION
Do we want to add these tests in older versions as well? And if so, how far back? 