### PR TITLE
Escape all default values with `+++` to ensure no formatting is done

### DIFF
--- a/config-docs/src/main/java/org/neo4j/doc/ConfigDocsGenerator.java
+++ b/config-docs/src/main/java/org/neo4j/doc/ConfigDocsGenerator.java
@@ -94,9 +94,14 @@ public class ConfigDocsGenerator
         }
         else if ( setting.defaultValue() != null )
         {
-            return Optional.of( setting.valueToString( setting.defaultValue() ) );
+            return Optional.of( escapeAsciiDoc( setting.valueToString( setting.defaultValue() ) ) );
         }
         return Optional.empty();
+    }
+
+    private static String escapeAsciiDoc( String input )
+    {
+        return "+++" + input + "+++"; // https://docs.asciidoctor.org/asciidoc/latest/pass/pass-macro/
     }
 
     private String documentSummary( String id, String title, List<SettingDescription> settingDescriptions )


### PR DESCRIPTION
This should fix issues with bold/italic text in default values of the setting appendix, e.g `metrics.filter`

Cherry picked from #1258 