### PR TITLE
Update documentation to use point.distance instead of distance

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/advanced-query-tuning-example.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/advanced-query-tuning-example.asciidoc
@@ -1136,7 +1136,7 @@ Predicates that will not work:
 
 * Several predicates combined using `OR`
 * Equality or range predicates querying for points (e.g. `WHERE n.place > point({ x: 1, y: 2 })`)
-* Spatial distance predicates (e.g. `WHERE distance(n.place, point({ x: 1, y: 2 })) < 2`)
+* Spatial distance predicates (e.g. `WHERE point.distance(n.place, point({ x: 1, y: 2 })) < 2`)
 
 
 [NOTE]

--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -151,7 +151,7 @@ Node key and uniqueness constraints with b-tree options are deprecated and need 
 a|
 label:functionality[]
 label:deprecated[]
-[[source, cypher, role="noheader"]
+[source, cypher, role="noheader"]
  ----
  distance(n.prop, point({x:0, y:0})
  ----

--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -148,6 +148,20 @@ OPTIONS "{" btree-option: btree-value[, ...] "}"
 a|
 Node key and uniqueness constraints with b-tree options are deprecated and need to be migrated before upgrading to 5.0.
 
+a|
+label:functionality[]
+label:deprecated[]
+[[source, cypher, role="noheader"]
+ ----
+ distance(n.prop, point({x:0, y:0})
+ ----
+ a|
+ Replaced by:
+ [source, cypher, role="noheader"]
+ ----
+ point.distance(n.prop, point({x:0, y:0})
+ ----
+
 |===
 
 

--- a/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
@@ -162,7 +162,6 @@ This section comprises a glossary of all the keywords -- grouped by category and
 | <<functions-datetime-transaction, datetime.transaction()>> | Temporal  | Returns the current _DateTime_ using the `transaction` clock.
 | <<functions-datetime-truncate, datetime.truncate()>>  | Temporal | Returns a _DateTime_ obtained by truncating a value at a specific component boundary. <<functions-temporal-truncate-overview, Truncation summary>>.
 |<<functions-degrees, degrees()>>               | Trigonometric     | Converts radians to degrees.
-|<<functions-distance, distance()>>              | Spatial           | Returns a floating point number representing the geodesic distance between any two points in the same CRS.
 | <<functions-duration, duration(+{map}+)>> | Temporal | Returns a _Duration_ from a map of its components.
 | <<functions-duration-create-string, duration(string)>> | Temporal | Returns a _Duration_ by parsing a string.
 | <<functions-duration-between, duration.between()>> | Temporal | Returns a _Duration_ equal to the difference between two given instants.
@@ -216,6 +215,8 @@ This section comprises a glossary of all the keywords -- grouped by category and
 |<<functions-point-cartesian-3d,point() - Cartesian 3D>> | Spatial           | Returns a 3D point object, given three coordinate values in the Cartesian coordinate system.
 |<<functions-point-wgs84-2d, point() - WGS 84 2D>>          | Spatial           | Returns a 2D point object, given two coordinate values in the WGS 84 coordinate system.
 |<<functions-point-wgs84-3d,point() - WGS 84 3D>> | Spatial         |  Returns a 3D point object, given three coordinate values in the WGS 84 coordinate system.
+|<<functions-distance, point.distance()>>              | Spatial           | Returns true if the provided point is within the bounding box defined by the two provided points.
+|<<functions-distance, point.withinBBox()>>              | Spatial           | Returns a floating point number representing the geodesic distance between any two points in the same CRS.
 |<<functions-properties, properties()>>          | Scalar            | Returns a map containing all the properties of a node or relationship.
 |<<functions-radians, radians()>>               | Trigonometric     | Converts degrees to radians.
 |<<functions-rand, rand()>>                     | Numeric           | Returns a random floating point number in the range from 0 (inclusive) to 1 (exclusive); i.e. `[0, 1)`.

--- a/cypher/cypher-docs/src/docs/dev/ql/functions/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/functions/index.asciidoc
@@ -287,7 +287,7 @@ These functions are used to specify 2D or 3D points in a geographic or cartesian
 [options="header"]
 |===
 | Function | Signature | Description
-1.1+| <<functions-distance,`distance()`>>  | `distance(from :: POINT?, to :: POINT?) :: (FLOAT?)` | Returns a floating point number representing the geodesic distance between any two points in the same CRS.
+1.1+| <<functions-distance,`point.distance()`>>  | `point.distance(from :: POINT?, to :: POINT?) :: (FLOAT?)` | Returns a floating point number representing the geodesic distance between any two points in the same CRS.
 1.1+|<<functions-point-cartesian-2d,`point()` - Cartesian 2D>> | `point(input :: MAP?) :: (POINT?)` | Returns a 2D point object, given two coordinate values in the Cartesian coordinate system.
 1.1+|<<functions-point-cartesian-3d,`point()` - Cartesian 3D>> | `point(input :: MAP?) :: (POINT?)`    | Returns a 3D point object, given three coordinate values in the Cartesian coordinate system.
 1.1+|<<functions-point-wgs84-2d,`point()` - WGS 84 2D>> | `point(input :: MAP?) :: (POINT?)`  | Returns a 2D point object, given two coordinate values in the WGS 84 geographic coordinate system.

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SchemaIndexTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SchemaIndexTest.scala
@@ -699,7 +699,7 @@ class SchemaIndexTest extends DocumentingTestBase with QueryStatisticsTestSuppor
       title = "Spatial distance searches (single-property index)",
       text =
         "If a property with point values is indexed, the index is used for spatial distance searches as well as for range queries.",
-      queryText = "MATCH ()-[r:KNOWS]->() WHERE distance(r.lastMetPoint, point({x: 1, y: 2})) < 2 RETURN r.lastMetPoint",
+      queryText = "MATCH ()-[r:KNOWS]->() WHERE point.distance(r.lastMetPoint, point({x: 1, y: 2})) < 2 RETURN r.lastMetPoint",
       assertions = {
         p =>
           assertEquals(9, p.size)
@@ -718,12 +718,12 @@ class SchemaIndexTest extends DocumentingTestBase with QueryStatisticsTestSuppor
         "If a property with point values is indexed, the index is used for spatial distance searches as well as for range queries. " +
         "Any following (non-existence check) predicates (here on property `p.name` for index `:Person(place,name)`) " +
         "will be rewritten as existence check with a filter.",
-      queryText = "MATCH (p:Person) WHERE distance(p.place, point({x: 1, y: 2})) < 2 AND p.name IS NOT NULL RETURN p.place",
+      queryText = "MATCH (p:Person) WHERE point.distance(p.place, point({x: 1, y: 2})) < 2 AND p.name IS NOT NULL RETURN p.place",
       assertions = {
         p =>
           assertEquals(9, p.size)
           checkPlanDescription(p)("NodeIndexSeek")
-          checkPlanDescriptionArgument(p)("p:Person(place, name) WHERE distance(place, point($autoint_0, $autoint_1)) < $autoint_2 AND name IS NOT NULL")
+          checkPlanDescriptionArgument(p)("p:Person(place, name) WHERE point.distance(place, point($autoint_0, $autoint_1)) < $autoint_2 AND name IS NOT NULL")
       }
     )
   }

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SpatialFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SpatialFunctionsTest.scala
@@ -75,7 +75,7 @@ class SpatialFunctionsTest extends DocumentingTest {
     p(
       """Functions:
         |
-        |* <<functions-distance,distance()>>
+        |* <<functions-distance,point.distance()>>
         |* <<functions-point-wgs84-2d,point() - WGS 84 2D>>
         |* <<functions-point-wgs84-3d,point() - WGS 84 3D>>
         |* <<functions-point-cartesian-2d,point() - Cartesian 2D>>
@@ -83,9 +83,9 @@ class SpatialFunctionsTest extends DocumentingTest {
       """.stripMargin)
     p("The following graph is used for some of the examples below.")
     graphViz()
-    section("distance()", "functions-distance") {
+    section("point.distance()", "functions-distance") {
       p(
-        """`distance()` returns a floating point number representing the geodesic distance between two points in the same Coordinate Reference System (CRS).
+        """`point.distance()` returns a floating point number representing the geodesic distance between two points in the same Coordinate Reference System (CRS).
           |
           |* If the points are in the _Cartesian_ CRS (2D or 3D), then the units of the returned distance will be the same as the units of the points, calculated using Pythagoras' theorem.
           |* If the points are in the _WGS-84_ CRS (2D), then the units of the returned distance will be meters, based on the haversine formula over a spherical earth approximation.
@@ -96,11 +96,11 @@ class SpatialFunctionsTest extends DocumentingTest {
           | ** This formula works well for points close to the earth's surface; for instance, it is well-suited for calculating the distance of an airplane flight.
           |It is less suitable for greater heights, however, such as when calculating the distance between two satellites.
         """.stripMargin)
-      function("distance(point1, point2)", "A Float.", ("point1", "A point in either a geographic or cartesian coordinate system."), ("point2", "A point in the same CRS as 'point1'."))
-      considerations("`distance(null, null)`, `distance(null, point2)` and `distance(point1, null)` all return `null`.", "Attempting to use points with different Coordinate Reference Systems (such as WGS 84 2D and WGS 84 3D) will return `null`.")
+      function("point.distance(point1, point2)", "A Float.", ("point1", "A point in either a geographic or cartesian coordinate system."), ("point2", "A point in the same CRS as 'point1'."))
+      considerations("`point.distance(null, null)`, `point.distance(null, point2)` and `point.distance(point1, null)` all return `null`.", "Attempting to use points with different Coordinate Reference Systems (such as WGS 84 2D and WGS 84 3D) will return `null`.")
       query(
         """WITH point({x: 2.3, y: 4.5, crs: 'cartesian'}) AS p1, point({x: 1.1, y: 5.4, crs: 'cartesian'}) AS p2
-          |RETURN distance(p1,p2) AS dist""".stripMargin, ResultAssertions((r) => {
+          |RETURN point.distance(p1,p2) AS dist""".stripMargin, ResultAssertions((r) => {
           r.toList.head("dist").asInstanceOf[Double] should equal(1.5)
         })) {
         p("The distance between two 2D points in the _Cartesian_ CRS is returned.")
@@ -108,7 +108,7 @@ class SpatialFunctionsTest extends DocumentingTest {
       }
       query(
         """WITH point({longitude: 12.78, latitude: 56.7, height: 100}) as p1, point({latitude: 56.71, longitude: 12.79, height: 100}) as p2
-          |RETURN distance(p1,p2) as dist""".stripMargin, ResultAssertions((r) => {
+          |RETURN point.distance(p1,p2) as dist""".stripMargin, ResultAssertions((r) => {
           Math.round(r.toList.head("dist").asInstanceOf[Double]) should equal(1270)
         })) {
         p("The distance between two 3D points in the _WGS 84_ CRS is returned.")
@@ -117,13 +117,13 @@ class SpatialFunctionsTest extends DocumentingTest {
       query(
         """MATCH (t:TrainStation)-[:TRAVEL_ROUTE]->(o:Office)
           |WITH point({longitude: t.longitude, latitude: t.latitude}) AS trainPoint, point({longitude: o.longitude, latitude: o.latitude}) AS officePoint
-          |RETURN round(distance(trainPoint, officePoint)) AS travelDistance""".stripMargin, ResultAssertions((r) => {
+          |RETURN round(point.distance(trainPoint, officePoint)) AS travelDistance""".stripMargin, ResultAssertions((r) => {
           r.toList.head("travelDistance").asInstanceOf[Double] should equal(27842)
         })) {
         p("The distance between the train station in Copenhagen and the Neo4j office in Malmo is returned.")
         resultTable()
       }
-      query("RETURN distance(null, point({longitude: 56.7, latitude: 12.78})) AS d", ResultAssertions((r) => {
+      query("RETURN point.distance(null, point({longitude: 56.7, latitude: 12.78})) AS d", ResultAssertions((r) => {
         r.toList should equal(List(Map("d" -> null)))
       })) {
         p("If `null` is provided as one or both of the arguments, `null` is returned.")

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SpatialFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SpatialFunctionsTest.scala
@@ -96,7 +96,7 @@ class SpatialFunctionsTest extends DocumentingTest {
           | ** This formula works well for points close to the earth's surface; for instance, it is well-suited for calculating the distance of an airplane flight.
           |It is less suitable for greater heights, however, such as when calculating the distance between two satellites.
         """.stripMargin)
-      function("point.distance(point1, point2)", "A Float.", ("point1", "A point in either a geographic or cartesian coordinate system."), ("point2", "A point in the same CRS as 'point1'."))
+      function("point.distance(point1, point2)", "A Float.", ("point1", "A point in either a geographic or cartesian coordinate system."), ("point2", "A point in the same CRS as `point1`."))
       considerations("`point.distance(null, null)`, `point.distance(null, point2)` and `point.distance(point1, null)` all return `null`.", "Attempting to use points with different Coordinate Reference Systems (such as WGS 84 2D and WGS 84 3D) will return `null`.")
       query(
         """WITH point({x: 2.3, y: 4.5, crs: 'cartesian'}) AS p1, point({x: 1.1, y: 5.4, crs: 'cartesian'}) AS p2

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SpatialTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SpatialTest.scala
@@ -98,12 +98,12 @@ class SpatialTest extends DocumentingTest {
             |is necessary to explicitly convert them.
             |For example, if the incoming `$height` is a string field in kilometers, you would need to type `height: toFloat($height) * 1000`. Likewise if the
             |results of the `distance` function are expected to be returned in kilometers, an explicit conversion is required.
-            |For example: `RETURN distance(a,b) / 1000 AS km`. An example demonstrating conversion on incoming and outgoing values is:
+            |For example: `RETURN point.distance(a,b) / 1000 AS km`. An example demonstrating conversion on incoming and outgoing values is:
           """.stripMargin)
         query("""WITH
                 #  point({latitude:toFloat('13.43'), longitude:toFloat('56.21')}) AS p1,
                 #  point({latitude:toFloat('13.10'), longitude:toFloat('56.41')}) AS p2
-                #RETURN toInteger(distance(p1, p2)/1000) AS km""".stripMargin('#'),
+                #RETURN toInteger(point.distance(p1, p2)/1000) AS km""".stripMargin('#'),
         ResultAssertions((r) => {
             withClue("Expect the distance function to return an integer value") {
               r.head("km") should be(42)
@@ -135,8 +135,8 @@ class SpatialTest extends DocumentingTest {
                 #  point({x: 3, y: 0}) AS p2d,
                 #  point({x: 0, y: 4, z: 1}) AS p3d
                 #RETURN
-                #  distance(p2d, p3d) AS bad,
-                #  distance(p2d, point({x: p3d.x, y: p3d.y})) AS good""".stripMargin('#'),
+                #  point.distance(p2d, p3d) AS bad,
+                #  point.distance(p2d, point({x: p3d.x, y: p3d.y})) AS good""".stripMargin('#'),
         ResultAssertions((r) => {
             withClue("Expect the invalid distance function to return null") {
               (r.head("bad") == null) should be(true)
@@ -298,16 +298,16 @@ class SpatialTest extends DocumentingTest {
               #  point({x: 3, y: 0}) AS p2d,
               #  point({x: 0, y: 4, z: 1}) AS p3d
               #RETURN
-              #  distance(p2d, p3d),
+              #  point.distance(p2d, p3d),
               #  p2d < p3d,
               #  p2d = p3d,
               #  p2d <> p3d,
-              #  distance(p2d, point({x: p3d.x, y: p3d.y}))""".stripMargin('#'),
+              #  point.distance(p2d, point({x: p3d.x, y: p3d.y}))""".stripMargin('#'),
       ResultAssertions(r => {
           r.nonEmpty should be(true)
           val record = r.head
           withClue("Expect the invalid distance function to return null") {
-            (record("distance(p2d, p3d)") == null) should be(true)
+            (record("point.distance(p2d, p3d)") == null) should be(true)
           }
           withClue("Expect the inequality test to return null") {
             (record("p2d < p3d") == null) should be(true)

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ShowProcFuncTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ShowProcFuncTest.scala
@@ -32,7 +32,7 @@ class ShowProcFuncTest extends RefcardTest with QueryStatisticsTestSupport {
   override def assert(tx:Transaction, name: String, result: DocsExecutionResult): Unit = {
     name match {
       case "functions" =>
-        assert(result.toList.size === 144)
+        assert(result.toList.size === 143)
       case "procedures" =>
         assert(result.toList.size === 73)
     }

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ShowProcFuncTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ShowProcFuncTest.scala
@@ -32,7 +32,7 @@ class ShowProcFuncTest extends RefcardTest with QueryStatisticsTestSupport {
   override def assert(tx:Transaction, name: String, result: DocsExecutionResult): Unit = {
     name match {
       case "functions" =>
-        assert(result.toList.size === 143)
+        assert(result.toList.size === 144)
       case "procedures" =>
         assert(result.toList.size === 73)
     }

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SpatialFunctionsTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SpatialFunctionsTest.scala
@@ -78,7 +78,7 @@ Returns a point in a 3D geographic coordinate system, with latitude and longitud
 ###assertion=returns-one parameters=distance
 RETURN
 
-distance(point({x: $x1, y: $y1}), point({x: $x2, y: $y2}))
+point.distance(point({x: $x1, y: $y1}), point({x: $x2, y: $y2}))
 ###
 
 Returns a floating point number representing the linear distance between two points.
@@ -87,7 +87,7 @@ The returned units will be the same as those of the point coordinates, and it wi
 ###assertion=returns-one parameters=distance
 RETURN
 
-distance(point({latitude: $y1, longitude: $x1}), point({latitude: $y2, longitude: $x2}))
+point.distance(point({latitude: $y1, longitude: $x1}), point({latitude: $y2, longitude: $x2}))
 ###
 
 Returns the geodesic distance between two points in meters. It can be used for 3D geographic points as well.


### PR DESCRIPTION
The function `distance` has been deprecated and is replaced by `point.distance`.  This PR tries adds a deprecation section about the distance function and change the documentation so that it uses the new function instead.

Please let me know if you know of any other places to update.

~NOTE: This PR will be red until https://github.com/neo-technology/neo4j/pull/12537 has been merged.~