### PR TITLE
Document point.withinBBox

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -267,6 +267,7 @@ label:deprecated[]
  label:functionality[]
  label:deprecated[]
  [source, cypher, role="noheader"]
+<<<<<<< HEAD
  ----
  point({x:0, y:0}) <= point({x:1, y:1}) <= point({x:2, y:2})
  ----
@@ -288,6 +289,18 @@ IMPERSONATE
 ----
 a|
 New privilege that allows a user to assume privileges of another one.
+=======
+  ----
+  point({x:0, y:0}) <= point({x:1, y:1}) <= point({x:2, y:2})
+  ----
+  a|
+  Using inequality operators `<`, `<=`, `>`, and `>=` on spatial points is deprecated.
+  Please instea use:
+  [source, cypher, role="noheader"]
+  ----
+  point.withinBBox(point({x:1, y:1}), point({x:0, y:0}), point({x:2, y:2}))
+  ----
+>>>>>>> 14fe79a4c9... Apply suggestions from code review
 
 a|
 label:functionality[]

--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -263,6 +263,21 @@ label:deprecated[]
  point.distance(n.prop, point({x:0, y:0})
  ----
 
+ a|
+ label:functionality[]
+ label:deprecated[]
+ [source, cypher, role="noheader"]
+ ----
+ point({x:0, y:0}) <= point({x:1, y:1}) <= point({x:2, y:2})
+ ----
+ a|
+ Using inequality operators `<`, `<=`, `>`, and `>=` on spatial points is deprecated.
+ Please instead use:
+ [source, cypher, role="noheader"]
+ ----
+ point.withinBBox(point({x:1, y:1}), point({x:0, y:0}), point({x:2, y:2}))
+ ----
+
 a|
 label:syntax[]
 label:added[] +

--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -267,7 +267,6 @@ label:deprecated[]
  label:functionality[]
  label:deprecated[]
  [source, cypher, role="noheader"]
-<<<<<<< HEAD
  ----
  point({x:0, y:0}) <= point({x:1, y:1}) <= point({x:2, y:2})
  ----
@@ -289,18 +288,6 @@ IMPERSONATE
 ----
 a|
 New privilege that allows a user to assume privileges of another one.
-=======
-  ----
-  point({x:0, y:0}) <= point({x:1, y:1}) <= point({x:2, y:2})
-  ----
-  a|
-  Using inequality operators `<`, `<=`, `>`, and `>=` on spatial points is deprecated.
-  Please instea use:
-  [source, cypher, role="noheader"]
-  ----
-  point.withinBBox(point({x:1, y:1}), point({x:0, y:0}), point({x:2, y:2}))
-  ----
->>>>>>> 14fe79a4c9... Apply suggestions from code review
 
 a|
 label:functionality[]

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SchemaIndexTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SchemaIndexTest.scala
@@ -999,7 +999,7 @@ class SchemaIndexTest extends DocumentingTestBase with QueryStatisticsTestSuppor
     profileQuery(
       title = "Spatial bounding box searches (single-property index)",
       text = "The ability to do index seeks on bounded ranges works even with the 2D and 3D spatial `Point` types.",
-      queryText = "MATCH (person:Person) WHERE point({x: 1, y: 5}) < person.location < point({x: 2, y: 6}) RETURN person",
+      queryText = "MATCH (person:Person) WHERE point.withinBBox(person.location, point({x: 1.2, y: 5.4}), point({x: 1.3, y: 5.5})) RETURN person.firstname",
       assertions = {
         p =>
           assertEquals(1, p.size)
@@ -1023,12 +1023,12 @@ class SchemaIndexTest extends DocumentingTestBase with QueryStatisticsTestSuppor
         "will be rewritten as existence check with a filter. " +
         "For index `:Person(firstname,place)`, if the predicate on `firstname` is equality or list membership then the bounded range is handled as a range itself. " +
         "If the predicate on `firstname` is anything else then the bounded range is rewritten to existence and filter.",
-      queryText = "MATCH (person:Person) WHERE point({x: 1, y: 5}) < person.place < point({x: 2, y: 6}) AND person.firstname IS NOT NULL RETURN person",
+      queryText = "MATCH (person:Person) WHERE point.withinBBox(person.place, point({x: 1.2, y: 5.4}), point({x: 1.3, y: 5.5})) AND person.firstname IS NOT NULL RETURN person",
       assertions = {
         p =>
           assertEquals(1, p.size)
           checkPlanDescription(p)("NodeIndexSeek")
-          checkPlanDescriptionArgument(p)("BTREE INDEX person:Person(place, firstname) WHERE place > point({x: $autoint_0, y: $autoint_1}) AND place < point({x: $autoint_2, y: $autoint_3}) AND firstname IS NOT NULL")
+          checkPlanDescriptionArgument(p)("BTREE INDEX person:Person(place, firstname) WHERE point.withinBBox(place, point($autodouble_0, $autodouble_1), point($autodouble_2, $autodouble_3)) AND firstname IS NOT NULL")
       }
     )
   }

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SpatialFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SpatialFunctionsTest.scala
@@ -133,8 +133,13 @@ class SpatialFunctionsTest extends DocumentingTest {
     }
     section("point.withinBBox()", "functions-withinBBox") {
       p(
-        """`point.withinBBox()` takes three arguments, the first argument is the point to check and the two other define the lower-left (or south-west) and upper-right (or north-east) point of a bounding box respectively.
-          | The return value will be `true` if the provided point is contained in the bounding box (boundary included) otherwise `false`.
+        """`point.withinBBox()` takes the following arguments:
+          |
+          |* The point to check.
+          |* The lower-left (south-west) point of a bounding box.
+          |* The upper-right (or north-east) point of a bounding box.
+          |
+          | The return value will be true if the provided point is contained in the bounding box (boundary included), otherwise the return value will be false.
         """.stripMargin)
       function("point.withinBBox(point, lowerLeft, upperRight)", "A Boolean.", ("point", "A point in either a geographic or cartesian coordinate system."), ("lowerLeft", "A point in the same CRS as 'point'."), ("upperRight", "A point in the same CRS as 'point'."))
       considerations("`point.withinBBox(p1, p2, p3)` will return `null` if any of the arguments evaluate to `null`.",

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SpatialFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SpatialFunctionsTest.scala
@@ -163,7 +163,7 @@ class SpatialFunctionsTest extends DocumentingTest {
       }
       query(
         """WITH point({longitude: 179, latitude: 55.66}) AS lowerLeft, point({longitude: -179, latitude: 55.70}) AS upperRight
-          |RETURN point.withinBBox(point({longitude: 180, latitude: 55.66}, lowerLeft, upperRight) AS result
+          |RETURN point.withinBBox(point({longitude: 180, latitude: 55.66}), lowerLeft, upperRight) AS result
           |""".stripMargin, ResultAssertions((r) => {
           r.toList.head("result").asInstanceOf[Boolean] shouldBe true
         })) {

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SpatialFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SpatialFunctionsTest.scala
@@ -139,7 +139,8 @@ class SpatialFunctionsTest extends DocumentingTest {
           |* The lower-left (south-west) point of a bounding box.
           |* The upper-right (or north-east) point of a bounding box.
           |
-          | The return value will be true if the provided point is contained in the bounding box (boundary included), otherwise the return value will be false.
+          |
+          |The return value will be true if the provided point is contained in the bounding box (boundary included), otherwise the return value will be false.
         """.stripMargin)
       function("point.withinBBox(point, lowerLeft, upperRight)", "A Boolean.", ("point", "A point in either a geographic or cartesian coordinate system."), ("lowerLeft", "A point in the same CRS as 'point'."), ("upperRight", "A point in the same CRS as 'point'."))
       considerations("`point.withinBBox(p1, p2, p3)` will return `null` if any of the arguments evaluate to `null`.",

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SpatialTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SpatialTest.scala
@@ -285,12 +285,13 @@ class SpatialTest extends DocumentingTest {
           |<<administration-indexes-spatial-distance-searches-single-property-index, 'Spatial distance searches'>>.
         """.stripMargin)
     }
-    section("Comparability and Orderability", "cypher-comparability-orderability") {
+    section("Comparability and orderability", "cypher-comparability-orderability") {
       p(
         """
-          |The orderability and comparability is due to change in the upcoming 5.0 release.
-          |This means that queries that rely on the comparing two points using the inequality operators, `<`, `<=`, `>`, and `>=`, or the specific order of an `ORDER BY n.point` query needs to be rewritten.
-          |The easiest way is to specify the ordering explicitly using for example `point.x`, `point.y` in _cartesian coordinates_ or `point.longitude` and point.latitude` in `geographic coordinates`.
+          |The comparability and orderability of spacial values are due to change in an upcoming future release.
+          |This means that queries that rely on the comparison of two points using the inequality operators, `<`, `⇐`, `>`, and `>=`, or the specific order of an `ORDER BY n.point` query will need to be rewritten.
+          |
+          |The most efficient way to do this is to explicitly specify the ordering. For example, by using `point.x`, `point.y` in _cartesian coordinates_, or `point.longitude` and `point.latitude` in _geographic coordinates_.
         """.stripMargin
       )
     }

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SpatialTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SpatialTest.scala
@@ -39,7 +39,7 @@ class SpatialTest extends DocumentingTest {
         | ** <<cypher-spatial-specifying-spatial-instants, Creating points>>
         | ** <<cypher-spatial-accessing-components-spatial-instants, Accessing components of points>>
         |* <<cypher-spatial-index, Spatial index>>
-        |* <<cypher-comparability-orderability, Comparability and Orderability>>
+        |* <<cypher-comparability-orderability, Comparability and orderability>>
         |""".stripMargin)
     note{
       p("""Refer to <<query-functions-spatial>> for information regarding spatial _functions_ allowing for the creation and manipulation of spatial values.""")


### PR DESCRIPTION
Instead of using inequality operators for spatial points queries should now be using the new `point.withinBBox` function.

Builds on top of https://github.com/neo4j/neo4j-documentation/pull/1266