### PR TITLE
Create instance of OIDCSetting for OpenID Connect docs

### DIFF
--- a/config-docs/src/main/java/org/neo4j/doc/ConfigDocsGenerator.java
+++ b/config-docs/src/main/java/org/neo4j/doc/ConfigDocsGenerator.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.doc;
 
+import com.neo4j.configuration.SecuritySettings;
+
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Comparator;
@@ -47,7 +49,10 @@ public class ConfigDocsGenerator
 
     public ConfigDocsGenerator()
     {
-        config = Config.defaults( GraphDatabaseSettings.SERVER_DEFAULTS );
+        SecuritySettings.OIDCSetting oidcSetting = SecuritySettings.OIDCSetting.forProvider( "<provider>" );
+        config = Config.newBuilder()
+                       .set( oidcSetting.auth_flow, oidcSetting.auth_flow.defaultValue() )
+                       .setDefaults( GraphDatabaseSettings.SERVER_DEFAULTS ).build();
     }
 
     public String document( Predicate<SettingImpl<Object>> filter, String id, String title, String idPrefix )


### PR DESCRIPTION
GroupSettings are not instantiated when building the configuration
object, thus they are not included in the generated docs. Create an
instance of OIDCSetting so at least the OIDC settings are documented.

In future we should consider doing this for the other groupsettings instances, but they don't all have the required annotations to produce docs, so this is more work. 