### PR TITLE
Cleans old unused repo

### DIFF
--- a/server-docs/pom.xml
+++ b/server-docs/pom.xml
@@ -132,11 +132,4 @@
         </profile>
     </profiles>
 
-    <repositories>
-        <repository>
-            <id>selenium-repository</id>
-            <url>http://selenium.googlecode.com/svn/repository</url>
-        </repository>
-    </repositories>
-
 </project>


### PR DESCRIPTION
## What
Cleans up unused repo. Thanks to @mnd999 for the pointer.

## Why
It's an http repo that doesn't exist anymore. By default in newer mvn versions, http repositories are [blocked by default](https://stackoverflow.com/questions/67001968/how-to-disable-maven-blocking-external-http-repositores), so this causes an error when building the docs.