### PR TITLE
Update index preference when planning indexes (and other small fixes)

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/query-tuning-indexes.adoc
+++ b/cypher/cypher-docs/src/docs/dev/query-tuning-indexes.adoc
@@ -75,7 +75,8 @@ In summary, `TEXT` indexes support the following predicates:
 When multiple indexes are available and able to solve a predicate, there is an order defined that decides which index to use.
 It is defined as such:
 
-* `TEXT` indexes are preferred over `BTREE` indexes.
+* `TEXT` indexes are preferred over `BTREE` indexes for `CONTAINS` and `ENDS WITH`.
+* `BTREE` indexes are preferred over `TEXT` indexes in all other cases.
 
 include::ql/administration/indexes/node-btree-index-example.asciidoc[leveloffset=2]
 

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/PatternTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/PatternTest.scala
@@ -188,7 +188,7 @@ class PatternTest extends DocumentingTest {
     section("Variable-length pattern matching", "cypher-pattern-varlength") {
       caution {
         p("""Variable length pattern matching in versions 2.1.x and earlier does not enforce relationship uniqueness for patterns described within a single `MATCH` clause.
-            |This means that a query such as the following: `MATCH (a)-[r]\->(b), p = (a)-[*]\->(c) RETURN *, relationships(p) AS rs` may include `r` as part of the `rs` set.
+            |This means that a query such as the following: `MATCH (a)-[r]\->(b), p = (a)-[\*]\->(c) RETURN *, relationships(p) AS rs` may include `r` as part of the `rs` set.
             |This behavior has changed in versions 2.2.0 and later, in such a way that `r` will be excluded from the result set, as this better adheres to the rules of relationship uniqueness as documented here <<cypher-result-uniqueness>>.
             |If you have a query pattern that needs to retrace relationships rather than ignoring them as the relationship uniqueness rules normally dictate, you can accomplish this using multiple match clauses, as follows: `MATCH (a)-[r]\->(b) MATCH p = (a)-[*]\->(c) RETURN *, relationships(p)`.
             |This will work in all versions of Neo4j that support the `MATCH` clause, namely 2.0.0 and later.""")

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PatternsTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PatternsTest.scala
@@ -141,7 +141,7 @@ Relationship of type `KNOWS` from `n` to `m`.
 ###assertion=related
 MATCH
 
-(n)-[:KNOWS|:LOVES]->(m)
+(n)-[:KNOWS|LOVES]->(m)
 
 WHERE id(n) = %A% AND id(m) = %B%
 


### PR DESCRIPTION
* Fix formatting issue where `*` in variable length patterns was rendered as **bold** text.
* Use new (and not old, outdated) syntax for multiple type predicates on relationship pattern.
* Updates index preference order to match update in https://github.com/neo-technology/neo4j/pull/12734.
