### PR TITLE
Add link to the future index section in operations manual

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/ql/administration/indexes-for-search-performance/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/indexes-for-search-performance/index.asciidoc
@@ -420,7 +420,7 @@ include::../indexes/drop-a-non-existing-index.asciidoc[leveloffset=+1]
 Two new types of indexes, point and range indexes, will be introduced in a future release.
 They cannot be used in queries yet, but they can be created and dropped for migration purposes.
 These new index types together with text indexes will replace the current b-tree indexes.
-For more details on these new types, see the <<operations-manual#future-indexes, operations manual>>.
+For more details on these new types, see the <<operations-manual#future-indexes, Operations Manual -> Future indexes>>.
 
 Like b-tree indexes, range indexes are created on one or more properties for all nodes or relationships with a given label or relationship type:
 

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/indexes-for-search-performance/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/indexes-for-search-performance/index.asciidoc
@@ -420,8 +420,7 @@ include::../indexes/drop-a-non-existing-index.asciidoc[leveloffset=+1]
 Two new types of indexes, point and range indexes, will be introduced in a future release.
 They cannot be used in queries yet, but they can be created and dropped for migration purposes.
 These new index types together with text indexes will replace the current b-tree indexes.
-For more details on these new types, see the operations manual.
-// TODO: add the link to the relevant operations manual section when that section exists
+For more details on these new types, see the <<operations-manual#future-indexes, operations manual>>.
 
 Like b-tree indexes, range indexes are created on one or more properties for all nodes or relationships with a given label or relationship type:
 


### PR DESCRIPTION
Add link in the future index section in cypher manual.

~~This PR adds the section in question: https://github.com/neo-technology/neo4j-manual-modeling/pull/2448~~