### PR TITLE
Speeds up macOS build

### DIFF
--- a/cypher/cypher-docs/src/test/java/org/neo4j/cypher/TestEnterpriseDatabaseManagementServiceBuilder.java
+++ b/cypher/cypher-docs/src/test/java/org/neo4j/cypher/TestEnterpriseDatabaseManagementServiceBuilder.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher;
+
+import com.neo4j.enterprise.edition.EnterpriseEditionModule;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.neo4j.common.DependencyResolver;
+import org.neo4j.common.Edition;
+import org.neo4j.configuration.Config;
+import org.neo4j.graphdb.config.Setting;
+import org.neo4j.graphdb.factory.module.GlobalModule;
+import org.neo4j.graphdb.factory.module.edition.AbstractEditionModule;
+import org.neo4j.graphdb.security.URLAccessRule;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.impl.factory.DbmsInfo;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.monitoring.Monitors;
+import org.neo4j.test.TestDatabaseManagementServiceBuilder;
+import org.neo4j.time.SystemNanoClock;
+
+public class TestEnterpriseDatabaseManagementServiceBuilder extends TestDatabaseManagementServiceBuilder
+{
+    public TestEnterpriseDatabaseManagementServiceBuilder( Path databaseRootDir )
+    {
+        super( databaseRootDir );
+    }
+
+    @Override
+    protected Config augmentConfig( Config config )
+    {
+        return config;
+    }
+
+    @Override
+    protected DbmsInfo getDbmsInfo( Config config )
+    {
+        return DbmsInfo.ENTERPRISE;
+    }
+
+    @Override
+    protected Function<GlobalModule,AbstractEditionModule> getEditionFactory( Config config )
+    {
+        return EnterpriseEditionModule::new;
+    }
+
+    @Override
+    public String getEdition()
+    {
+        return Edition.ENTERPRISE.toString();
+    }
+
+    // Override to allow chaining
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder impermanent()
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.impermanent();
+    }
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder useLazyProcedures( boolean useLazyProcedures )
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.useLazyProcedures( useLazyProcedures );
+    }
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder setFileSystem( FileSystemAbstraction fileSystem )
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.setFileSystem( fileSystem );
+    }
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder setDatabaseRootDirectory( Path storeDir )
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.setDatabaseRootDirectory( storeDir );
+    }
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder setInternalLogProvider( LogProvider internalLogProvider )
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.setInternalLogProvider( internalLogProvider );
+    }
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder setClock( SystemNanoClock clock )
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.setClock( clock );
+    }
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder noOpSystemGraphInitializer()
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.noOpSystemGraphInitializer();
+    }
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder setExternalDependencies( DependencyResolver dependencies )
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.setExternalDependencies( dependencies );
+    }
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder setMonitors( Monitors monitors )
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.setMonitors( monitors );
+    }
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder setUserLogProvider( LogProvider logProvider )
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.setUserLogProvider( logProvider );
+    }
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder addURLAccessRule( String protocol, URLAccessRule rule )
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.addURLAccessRule( protocol, rule );
+    }
+
+    @Override
+    public <T> TestEnterpriseDatabaseManagementServiceBuilder setConfig( Setting<T> setting, T value )
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.setConfig( setting, value );
+    }
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder setConfig( Map<Setting<?>,Object> config )
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.setConfig( config );
+    }
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder setConfig( Config fromConfig )
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.setConfig( fromConfig );
+    }
+}

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ConstraintsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ConstraintsTest.scala
@@ -40,9 +40,6 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
   override def parent: Option[String] = Some("Administration")
   override def section: String = "Constraints"
 
-  override protected def newDatabaseManagementService(directory: File): DatabaseManagementService = new EnterpriseDatabaseManagementServiceBuilder(directory)
-    .setConfig(databaseConfig()).build()
-
   private val nativeProvider = GenericNativeIndexProvider.DESCRIPTOR.name()
   private val nativeLuceneProvider = NativeLuceneFusionIndexProviderFactory30.DESCRIPTOR.name()
   private val cartesianMin = SPATIAL_CARTESIAN_MIN.getSettingName

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentingTestBase.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentingTestBase.scala
@@ -38,6 +38,7 @@ import org.neo4j.cypher.internal.runtime.isGraphKernelResultValue
 import org.neo4j.cypher.internal.util.Eagerly
 import org.neo4j.cypher.ExecutionEngineHelper
 import org.neo4j.cypher.GraphIcing
+import org.neo4j.cypher.TestEnterpriseDatabaseManagementServiceBuilder
 import org.neo4j.dbms.api.DatabaseManagementService
 import org.neo4j.dbms.api.DatabaseManagementServiceBuilder
 import org.neo4j.doc.test.GraphDatabaseServiceCleaner.cleanDatabaseContent
@@ -47,14 +48,17 @@ import org.neo4j.exceptions.Neo4jException
 import org.neo4j.graphdb._
 import org.neo4j.graphdb.config.Setting
 import org.neo4j.internal.kernel.api.security.SecurityContext
+import org.neo4j.io.fs.EphemeralFileSystemAbstraction
 import org.neo4j.kernel.api.KernelTransaction.Type
 import org.neo4j.kernel.impl.api.index.IndexingService
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingMode
 import org.neo4j.kernel.impl.coreapi.InternalTransaction
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade
 import org.neo4j.kernel.impl.query.Neo4jTransactionalContextFactory
 import org.neo4j.kernel.impl.query.QuerySubscriber
 import org.neo4j.kernel.impl.query.QuerySubscriberAdapter
 import org.neo4j.kernel.impl.util.ValueUtils
+import org.neo4j.test.rule.TestDirectory
 import org.neo4j.values.virtual.VirtualValues
 import org.neo4j.visualization.asciidoc.AsciidocHelper
 import org.neo4j.visualization.graphviz.AsciiDocStyle
@@ -560,7 +564,6 @@ abstract class DocumentingTestBase extends JUnitSuite with DocumentationHelper w
   def tearDown() {
     if (managementService != null) {
       managementService.shutdown()
-      FileUtils.forceDelete(dbFolder)
     }
   }
 
@@ -575,15 +578,13 @@ abstract class DocumentingTestBase extends JUnitSuite with DocumentationHelper w
       OnlineBackupSettings.online_backup_enabled -> java.lang.Boolean.FALSE
     ).asJava
 
-  protected def newDatabaseManagementService(directory: File): DatabaseManagementService = {
-    new DatabaseManagementServiceBuilder(directory).setConfig(databaseConfig()).build()
-  }
-
   override def hardReset() {
     tearDown()
-    dbFolder = new File("target/example-db" + System.nanoTime())
-    managementService = newDatabaseManagementService(dbFolder)
-    val database: GraphDatabaseService = managementService.database(DEFAULT_DATABASE_NAME)
+    val fs = new EphemeralFileSystemAbstraction()
+    val td = TestDirectory.testDirectory(this.getClass, fs)
+    dbFolder = td.prepareDirectoryForTest("target/example-db" + System.nanoTime()).toFile
+    managementService = new TestEnterpriseDatabaseManagementServiceBuilder(dbFolder.toPath).setFileSystem(fs).setConfig(databaseConfig).build()
+    val database = managementService.database( DEFAULT_DATABASE_NAME )
     db = new GraphDatabaseCypherService(database)
 
     engine = ExecutionEngineFactory.createCommunityEngineFromDb(database) // TODO: This should be Enterprise!

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ExecutionEngineFactory.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ExecutionEngineFactory.scala
@@ -20,7 +20,6 @@
 package org.neo4j.cypher.docgen
 
 import java.io.File
-
 import org.neo4j.configuration.Config
 import org.neo4j.configuration.GraphDatabaseSettings.{DEFAULT_DATABASE_NAME, SYSTEM_DATABASE_NAME}
 import org.neo4j.cypher.internal.cache.ExecutorBasedCaffeineCacheFactory
@@ -29,8 +28,9 @@ import org.neo4j.cypher.internal.config.CypherConfiguration
 import org.neo4j.cypher.internal.javacompat.{GraphDatabaseCypherService, MonitoringCacheTracer}
 import org.neo4j.cypher.internal.tracing.TimingCompilationTracer
 import org.neo4j.cypher.internal.{ExecutionEngine, _}
-import org.neo4j.dbms.api.{DatabaseManagementService, DatabaseManagementServiceBuilder}
+import org.neo4j.dbms.api.{DatabaseManagementService}
 import org.neo4j.graphdb.GraphDatabaseService
+import org.neo4j.io.fs.EphemeralFileSystemAbstraction
 import org.neo4j.kernel.api.Kernel
 import org.neo4j.kernel.database.Database
 import org.neo4j.kernel.impl.query.QueryEngineProvider
@@ -38,10 +38,15 @@ import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.logging.internal.LogService
 import org.neo4j.monitoring.Monitors
 import org.neo4j.scheduler.JobScheduler
+import org.neo4j.test.TestDatabaseManagementServiceBuilder
+import org.neo4j.test.rule.TestDirectory
 
 object ExecutionEngineFactory {
   def createDbAndCommunityEngine(): (DatabaseManagementService, GraphDatabaseService, ExecutionEngine) = {
-    val managementService: DatabaseManagementService = new DatabaseManagementServiceBuilder(new File("target/example-db")).build()
+    val fs = new EphemeralFileSystemAbstraction()
+    val td = TestDirectory.testDirectory(this.getClass, fs)
+    val dbFolder = td.prepareDirectoryForTest("target/example-db" + System.nanoTime()).toFile
+    val managementService: DatabaseManagementService = new TestDatabaseManagementServiceBuilder(dbFolder.toPath).setFileSystem(fs).build()
     val graph: GraphDatabaseService = managementService.database(DEFAULT_DATABASE_NAME)
 
     (managementService, graph, createExecutionEngineFromDb(graph))

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
@@ -19,18 +19,11 @@
  */
 package org.neo4j.cypher.docgen
 
-import com.neo4j.dbms.api.EnterpriseDatabaseManagementServiceBuilder
 import org.hamcrest.CoreMatchers._
 import org.junit.Assert._
 import org.junit.Test
-import org.neo4j.dbms.api.DatabaseManagementService
-
-import java.io.File
 
 class QueryPlanTest extends DocumentingTestBase with SoftReset {
-
-  override protected def newDatabaseManagementService(directory: File): DatabaseManagementService =
-    new EnterpriseDatabaseManagementServiceBuilder(directory).setConfig(databaseConfig()).build()
 
   override val setupQueries = List(
     """CREATE (me:Person {name: 'me'})

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SchemaIndexTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SchemaIndexTest.scala
@@ -64,7 +64,6 @@ class SchemaIndexTest extends DocumentingTestBase with QueryStatisticsTestSuppor
   override def parent: Option[String] = Some("Administration")
   override def section = "Indexes"
 
-
   @Test def create_index_on_a_single_property() {
     testQuery(
       title = "Create a single-property index for nodes",

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/RestartableDatabase.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/RestartableDatabase.scala
@@ -29,6 +29,7 @@ import org.apache.commons.io.FileUtils
 import org.neo4j.configuration.GraphDatabaseSettings
 import org.neo4j.configuration.GraphDatabaseSettings.DEFAULT_DATABASE_NAME
 import org.neo4j.configuration.helpers.SocketAddress
+import org.neo4j.cypher.TestEnterpriseDatabaseManagementServiceBuilder
 import org.neo4j.cypher.docgen.ExecutionEngineFactory
 import org.neo4j.cypher.internal.ExecutionEngine
 import org.neo4j.cypher.internal.javacompat.{GraphDatabaseCypherService, ResultSubscriber}
@@ -37,11 +38,14 @@ import org.neo4j.dbms.api.DatabaseManagementService
 import org.neo4j.graphdb.config.Setting
 import org.neo4j.internal.kernel.api.connectioninfo.ClientConnectionInfo
 import org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED
+import org.neo4j.io.fs.EphemeralFileSystemAbstraction
 import org.neo4j.kernel.api.KernelTransaction.Type
 import org.neo4j.kernel.api.procedure.GlobalProcedures
 import org.neo4j.kernel.api.security.AuthToken
 import org.neo4j.kernel.impl.coreapi.InternalTransaction
 import org.neo4j.kernel.impl.util.ValueUtils
+import org.neo4j.test.TestDatabaseManagementServiceBuilder
+import org.neo4j.test.rule.TestDirectory
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -68,13 +72,15 @@ class RestartableDatabase(init: RunnableInitialization)
 
   private def createAndStartIfNecessary() {
     if (graph == null) {
-      dbFolder = new File("target/example-db" + System.nanoTime()).toPath
+      val fs = new EphemeralFileSystemAbstraction()
+      val td = TestDirectory.testDirectory(this.getClass, fs)
+      dbFolder = td.prepareDirectoryForTest("target/example-db" + System.nanoTime())
       val config: Map[Setting[_], Object] = Map(
         GraphDatabaseSettings.auth_enabled -> TRUE,
         OnlineBackupSettings.online_backup_listen_address -> new SocketAddress("127.0.0.1", 0),
         OnlineBackupSettings.online_backup_enabled ->  FALSE
       )
-      managementService = new EnterpriseDatabaseManagementServiceBuilder(dbFolder).setConfig(config.asJava).build()
+      managementService = new TestEnterpriseDatabaseManagementServiceBuilder(dbFolder).setFileSystem(fs).setConfig(config.asJava).build()
 
       //    managementService = graphDatabaseFactory(Files.createTempDirectory("test").getParent.toFile).impermanent().setConfig(config.asJava).setInternalLogProvider(logProvider).build()
       managementService.listDatabases().toArray().foreach { name =>
@@ -155,7 +161,6 @@ class RestartableDatabase(init: RunnableInitialization)
   private def restart() {
     if (graph == null) return
     managementService.shutdown()
-    FileUtils.forceDelete(dbFolder.toFile)
     graphs.clear()
     graph = null
     eengine = null

--- a/cypher/refcard-tests/pom.xml
+++ b/cypher/refcard-tests/pom.xml
@@ -87,6 +87,12 @@
             <version>${project.version}</version>
             <type>test-jar</type>
         </dependency>
+        <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>io-test-utils</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- neo4j-cypher -->
         <dependency>
@@ -145,6 +151,12 @@
             <artifactId>neo4j-kernel</artifactId>
             <version>${neo4j.version}</version>
             <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.neo4j.community</groupId>
+            <artifactId>it-test-support</artifactId>
+            <version>${neo4j.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/RefcardTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/RefcardTest.scala
@@ -19,34 +19,43 @@
  */
 package org.neo4j.cypher.docgen
 
-import java.io._
-import java.nio.charset.StandardCharsets
-import java.util
-
 import com.neo4j.configuration.OnlineBackupSettings
-import com.neo4j.dbms.api.EnterpriseDatabaseManagementServiceBuilder
 import org.apache.commons.io.FileUtils
 import org.apache.maven.artifact.versioning.ComparableVersion
-import org.junit.{After, Before, Test}
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
 import org.neo4j.configuration.GraphDatabaseSettings.DEFAULT_DATABASE_NAME
 import org.neo4j.configuration.helpers.SocketAddress
 import org.neo4j.cypher.GraphIcing
-import org.neo4j.cypher.docgen.tooling.{DocsExecutionResult, Prettifier}
+import org.neo4j.cypher.TestEnterpriseDatabaseManagementServiceBuilder
+import org.neo4j.cypher.docgen.tooling.DocsExecutionResult
+import org.neo4j.cypher.docgen.tooling.Prettifier
 import org.neo4j.cypher.internal.ExecutionEngine
-import org.neo4j.cypher.internal.javacompat.{GraphDatabaseCypherService, GraphImpl, ResultSubscriber}
-import org.neo4j.cypher.internal.runtime.{RuntimeJavaValueConverter, isGraphKernelResultValue}
+import org.neo4j.cypher.internal.javacompat.GraphDatabaseCypherService
+import org.neo4j.cypher.internal.javacompat.GraphImpl
+import org.neo4j.cypher.internal.javacompat.ResultSubscriber
+import org.neo4j.cypher.internal.runtime.RuntimeJavaValueConverter
+import org.neo4j.cypher.internal.runtime.isGraphKernelResultValue
 import org.neo4j.dbms.api.DatabaseManagementService
-import org.neo4j.doc.test.{GraphDatabaseServiceCleaner, GraphDescription}
-import org.neo4j.exceptions.{InternalException, Neo4jException}
+import org.neo4j.doc.test.GraphDatabaseServiceCleaner
+import org.neo4j.doc.test.GraphDescription
+import org.neo4j.exceptions.InternalException
+import org.neo4j.exceptions.Neo4jException
 import org.neo4j.graphdb._
 import org.neo4j.graphdb.config.Setting
+import org.neo4j.io.fs.EphemeralFileSystemAbstraction
 import org.neo4j.kernel.api.KernelTransaction
 import org.neo4j.kernel.impl.coreapi.InternalTransaction
 import org.neo4j.kernel.impl.query.Neo4jTransactionalContextFactory
 import org.neo4j.kernel.impl.util.ValueUtils
+import org.neo4j.test.rule.TestDirectory
 import org.neo4j.visualization.asciidoc.AsciidocHelper
 import org.scalatest.Assertions
 
+import java.io._
+import java.nio.charset.StandardCharsets
+import java.util
 import scala.collection.JavaConverters._
 
 /*
@@ -251,7 +260,6 @@ abstract class RefcardTest extends Assertions with DocumentationHelper with Grap
   def teardown() {
     if (managementService != null) {
       managementService.shutdown()
-      FileUtils.forceDelete(folder)
     }
     allQueriesWriter.close()
   }
@@ -261,8 +269,13 @@ abstract class RefcardTest extends Assertions with DocumentationHelper with Grap
     dir = createDir(section)
     allQueriesWriter = new OutputStreamWriter(new FileOutputStream(new File("target/all-queries.asciidoc"), true),
       StandardCharsets.UTF_8)
-    folder = new File("target/example-db" + System.nanoTime())
-    managementService = newDatabaseManagementService(folder)
+    val fs = new EphemeralFileSystemAbstraction()
+    val td = TestDirectory.testDirectory(this.getClass, fs)
+    folder = td.prepareDirectoryForTest("target/example-db" + System.nanoTime()).toFile
+    managementService = new TestEnterpriseDatabaseManagementServiceBuilder(folder.toPath)
+      .setFileSystem(fs)
+      .setConfig(databaseConfig())
+      .build()
     val graph = getGraph
     db = new GraphDatabaseCypherService(graph)
 
@@ -289,11 +302,6 @@ abstract class RefcardTest extends Assertions with DocumentationHelper with Grap
   protected def getGraph: GraphDatabaseService = managementService.database(DEFAULT_DATABASE_NAME)
 
   protected def cleanGraph: Unit = GraphDatabaseServiceCleaner.cleanDatabaseContent(db.getGraphDatabaseService)
-
-  protected def newDatabaseManagementService(directory: File): DatabaseManagementService =
-    new EnterpriseDatabaseManagementServiceBuilder(directory)
-      .setConfig(databaseConfig())
-      .build()
 
   protected def databaseConfig(): util.Map[Setting[_], Object] = {
     Map[Setting[_], Object](


### PR DESCRIPTION
Cherry picks #1274 for version 4.3.

## What
Speeds up the build on OSX systems, by using a file system in memory rather than in disk. The reason for that is that `sun.nio.ch.FileChannelImpl.force` is [10x times](https://bugs.openjdk.java.net/browse/JDK-8205162) slower in an OSX than in Linux. Hat tip to @zimmre.

Writing the database files to memory speeds up that.