### PR TITLE
Speeds up macOS build

### DIFF
--- a/cypher/cypher-docs/src/test/java/org/neo4j/cypher/TestEnterpriseDatabaseManagementServiceBuilder.java
+++ b/cypher/cypher-docs/src/test/java/org/neo4j/cypher/TestEnterpriseDatabaseManagementServiceBuilder.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ * This file is a commercial add-on to Neo4j Enterprise Edition.
+ */
+package org.neo4j.cypher;
+
+import com.neo4j.enterprise.edition.EnterpriseEditionModule;
+import com.neo4j.kernel.impl.enterprise.configuration.OnlineBackupSettings;
+
+import java.io.File;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.neo4j.common.DependencyResolver;
+import org.neo4j.common.Edition;
+import org.neo4j.configuration.Config;
+import org.neo4j.configuration.helpers.SocketAddress;
+import org.neo4j.graphdb.config.Setting;
+import org.neo4j.graphdb.factory.module.GlobalModule;
+import org.neo4j.graphdb.factory.module.edition.AbstractEditionModule;
+import org.neo4j.graphdb.security.URLAccessRule;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.layout.DatabaseLayout;
+import org.neo4j.io.layout.Neo4jLayout;
+import org.neo4j.kernel.impl.factory.DatabaseInfo;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.monitoring.Monitors;
+import org.neo4j.test.TestDatabaseManagementServiceBuilder;
+import org.neo4j.time.SystemNanoClock;
+
+public class TestEnterpriseDatabaseManagementServiceBuilder extends TestDatabaseManagementServiceBuilder
+{
+    public TestEnterpriseDatabaseManagementServiceBuilder( File databaseRootDir )
+    {
+        super( databaseRootDir );
+    }
+
+    @Override
+    protected Config augmentConfig( Config config )
+    {
+        return config;
+    }
+
+    @Override
+    protected DatabaseInfo getDatabaseInfo()
+    {
+        return DatabaseInfo.ENTERPRISE;
+    }
+
+    @Override
+    protected Function<GlobalModule,AbstractEditionModule> getEditionFactory()
+    {
+        return EnterpriseEditionModule::new;
+    }
+
+    @Override
+    public String getEdition()
+    {
+        return Edition.ENTERPRISE.toString();
+    }
+
+    // Override to allow chaining
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder impermanent()
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.impermanent();
+    }
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder setFileSystem( FileSystemAbstraction fileSystem )
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.setFileSystem( fileSystem );
+    }
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder setDatabaseRootDirectory( File storeDir )
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.setDatabaseRootDirectory( storeDir );
+    }
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder setInternalLogProvider( LogProvider internalLogProvider )
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.setInternalLogProvider( internalLogProvider );
+    }
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder setClock( SystemNanoClock clock )
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.setClock( clock );
+    }
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder noOpSystemGraphInitializer()
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.noOpSystemGraphInitializer();
+    }
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder setExternalDependencies( DependencyResolver dependencies )
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.setExternalDependencies( dependencies );
+    }
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder setMonitors( Monitors monitors )
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.setMonitors( monitors );
+    }
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder setUserLogProvider( LogProvider logProvider )
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.setUserLogProvider( logProvider );
+    }
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder addURLAccessRule( String protocol, URLAccessRule rule )
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.addURLAccessRule( protocol, rule );
+    }
+
+    @Override
+    public <T> TestEnterpriseDatabaseManagementServiceBuilder setConfig( Setting<T> setting, T value )
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.setConfig( setting, value );
+    }
+
+    @Override
+    public TestEnterpriseDatabaseManagementServiceBuilder setConfig( Map<Setting<?>,Object> config )
+    {
+        return (TestEnterpriseDatabaseManagementServiceBuilder) super.setConfig( config );
+    }
+}
+

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ConstraintsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ConstraintsTest.scala
@@ -34,9 +34,6 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
   override def parent = Some("Administration")
   override def section: String = "Constraints"
 
-  override protected def newDatabaseManagementService(directory: File): DatabaseManagementService = new EnterpriseDatabaseManagementServiceBuilder(directory).build()
-
-
   @Test def create_unique_constraint() {
     testQuery(
       title = "Create a unique constraint",

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentingTestBase.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentingTestBase.scala
@@ -23,7 +23,6 @@ import java.io.{ByteArrayOutputStream, File, PrintWriter, StringWriter}
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeUnit
 
-import org.apache.commons.io.FileUtils
 import org.junit.{After, Before}
 import org.neo4j.configuration.GraphDatabaseSettings.DEFAULT_DATABASE_NAME
 import org.neo4j.cypher.docgen.tooling.{DocsExecutionResult, Prettifier}
@@ -34,19 +33,22 @@ import org.neo4j.cypher.internal.javacompat.{GraphDatabaseCypherService, GraphIm
 import org.neo4j.cypher.internal.runtime.{RuntimeJavaValueConverter, isGraphKernelResultValue}
 import org.neo4j.cypher.internal.v4_0.util.Eagerly
 import org.neo4j.cypher.{ExecutionEngineHelper, GraphIcing}
-import org.neo4j.dbms.api.{DatabaseManagementService, DatabaseManagementServiceBuilder}
+import org.neo4j.dbms.api.DatabaseManagementService
+import org.neo4j.cypher.TestEnterpriseDatabaseManagementServiceBuilder
 import org.neo4j.doc.test.GraphDatabaseServiceCleaner.cleanDatabaseContent
 import org.neo4j.doc.test.GraphDescription
 import org.neo4j.doc.tools.AsciiDocGenerator
 import org.neo4j.exceptions.Neo4jException
 import org.neo4j.graphdb._
 import org.neo4j.internal.kernel.api.security.SecurityContext
+import org.neo4j.io.fs.EphemeralFileSystemAbstraction
 import org.neo4j.kernel.api.KernelTransaction.Type
 import org.neo4j.kernel.impl.api.index.IndexingService
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingMode
 import org.neo4j.kernel.impl.coreapi.InternalTransaction
 import org.neo4j.kernel.impl.query.{Neo4jTransactionalContextFactory, QuerySubscriber, QuerySubscriberAdapter}
 import org.neo4j.kernel.impl.util.ValueUtils
+import org.neo4j.test.rule.TestDirectory
 import org.neo4j.values.virtual.VirtualValues
 import org.neo4j.visualization.asciidoc.AsciidocHelper
 import org.neo4j.visualization.graphviz.{AsciiDocStyle, GraphStyle, GraphvizWriter}
@@ -538,7 +540,6 @@ abstract class DocumentingTestBase extends JUnitSuite with DocumentationHelper w
   def tearDown() {
     if (managementService != null) {
       managementService.shutdown()
-      FileUtils.deleteDirectory(dbFolder)
     }
   }
 
@@ -547,13 +548,13 @@ abstract class DocumentingTestBase extends JUnitSuite with DocumentationHelper w
     hardReset()
   }
 
-  protected def newDatabaseManagementService(directory: File): DatabaseManagementService = new DatabaseManagementServiceBuilder(directory).build()
-
   override def hardReset() {
     tearDown()
-    dbFolder = new File("target/example-db" + System.nanoTime())
-    managementService = newDatabaseManagementService(dbFolder)
-    val database: GraphDatabaseService = managementService.database(DEFAULT_DATABASE_NAME)
+    val fs = new EphemeralFileSystemAbstraction()
+    val td = TestDirectory.testDirectory(this.getClass, fs)
+    dbFolder = td.prepareDirectoryForTest("target/example-db" + System.nanoTime())
+    managementService = new TestEnterpriseDatabaseManagementServiceBuilder(dbFolder).setFileSystem(fs).build()
+    val database = managementService.database( DEFAULT_DATABASE_NAME )
     db = new GraphDatabaseCypherService(database)
 
     engine = ExecutionEngineFactory.createCommunityEngineFromDb(database) // TODO: This should be Enterprise!

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ExecutionEngineFactory.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ExecutionEngineFactory.scala
@@ -20,15 +20,15 @@
 package org.neo4j.cypher.docgen
 
 import java.io.File
-
 import org.neo4j.configuration.Config
 import org.neo4j.configuration.GraphDatabaseSettings.{DEFAULT_DATABASE_NAME, SYSTEM_DATABASE_NAME}
 import org.neo4j.cypher.internal.compiler.CypherPlannerConfiguration
 import org.neo4j.cypher.internal.javacompat.{GraphDatabaseCypherService, MonitoringCacheTracer}
 import org.neo4j.cypher.internal.tracing.TimingCompilationTracer
 import org.neo4j.cypher.internal.{ExecutionEngine, _}
-import org.neo4j.dbms.api.{DatabaseManagementService, DatabaseManagementServiceBuilder}
+import org.neo4j.dbms.api.{DatabaseManagementService}
 import org.neo4j.graphdb.GraphDatabaseService
+import org.neo4j.io.fs.EphemeralFileSystemAbstraction
 import org.neo4j.kernel.api.Kernel
 import org.neo4j.kernel.database.Database
 import org.neo4j.kernel.impl.query.QueryEngineProvider
@@ -36,10 +36,15 @@ import org.neo4j.kernel.internal.GraphDatabaseAPI
 import org.neo4j.logging.internal.LogService
 import org.neo4j.monitoring.Monitors
 import org.neo4j.scheduler.JobScheduler
+import org.neo4j.test.TestDatabaseManagementServiceBuilder
+import org.neo4j.test.rule.TestDirectory
 
 object ExecutionEngineFactory {
   def createDbAndCommunityEngine(): (DatabaseManagementService, GraphDatabaseService, ExecutionEngine) = {
-    val managementService: DatabaseManagementService = new DatabaseManagementServiceBuilder(new File("target/example-db")).build()
+    val fs = new EphemeralFileSystemAbstraction()
+    val td = TestDirectory.testDirectory(this.getClass, fs)
+    val dbFolder = td.prepareDirectoryForTest("target/example-db" + System.nanoTime())
+    val managementService: DatabaseManagementService = new TestDatabaseManagementServiceBuilder(dbFolder).setFileSystem(fs).build()
     val graph: GraphDatabaseService = managementService.database(DEFAULT_DATABASE_NAME)
 
     (managementService, graph, createExecutionEngineFromDb(graph))

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
@@ -19,17 +19,11 @@
  */
 package org.neo4j.cypher.docgen
 
-import java.io.File
-
 import org.hamcrest.CoreMatchers._
 import org.junit.Assert._
 import org.junit.Test
-import org.neo4j.dbms.api.DatabaseManagementService
-import com.neo4j.dbms.api.EnterpriseDatabaseManagementServiceBuilder
 
 class QueryPlanTest extends DocumentingTestBase with SoftReset {
-
-  override protected def newDatabaseManagementService(directory: File): DatabaseManagementService = new EnterpriseDatabaseManagementServiceBuilder(directory).build()
 
   override val setupQueries = List(
     """CREATE (me:Person {name: 'me'})

--- a/cypher/refcard-tests/pom.xml
+++ b/cypher/refcard-tests/pom.xml
@@ -87,6 +87,12 @@
             <version>${project.version}</version>
             <type>test-jar</type>
         </dependency>
+        <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>io-test-utils</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- neo4j-cypher -->
         <dependency>
@@ -145,6 +151,12 @@
             <artifactId>neo4j-kernel</artifactId>
             <version>${neo4j.version}</version>
             <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.neo4j.community</groupId>
+            <artifactId>it-test-support</artifactId>
+            <version>${neo4j.version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Cherry picks #1274 for version 4.0.

## What
Speeds up the build on OSX systems, by using a file system in memory rather than in disk. The reason for that is that `sun.nio.ch.FileChannelImpl.force` is [10x times](https://bugs.openjdk.java.net/browse/JDK-8205162) slower in an OSX than in Linux. Hat tip to @zimmre.

Writing the database files to memory speeds up that.