### PR TITLE
Fix broken refcard test by loosing up the assertion

### DIFF
--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ShowProcFuncTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ShowProcFuncTest.scala
@@ -29,17 +29,13 @@ class ShowProcFuncTest extends RefcardTest with QueryStatisticsTestSupport {
   val title = "SHOW FUNCTIONS and PROCEDURES"
   override val linkId = "clauses/#header-listing-procs-functions"
 
-  override def assert(tx:Transaction, name: String, result: DocsExecutionResult): Unit = {
-    name match {
-      case "functions" =>
-        assert(result.toList.size === 143)
-      case "procedures" =>
-        assert(result.toList.size === 73)
-    }
-  }
+  // just make sure we get results
+  // but not the exact number to avoid it breaking
+  // when new functions or procedures gets added to Neo4j
+  override def assert(tx:Transaction, name: String, result: DocsExecutionResult): Unit = assert(result.toList.nonEmpty)
 
   def text = """
-###assertion=functions
+###assertion=result
 //
 
 SHOW FUNCTIONS
@@ -47,7 +43,7 @@ SHOW FUNCTIONS
 
 Listing all available functions.
 
-###assertion=procedures
+###assertion=result
 //
 
 SHOW PROCEDURES EXECUTABLE YIELD name


### PR DESCRIPTION
Should fix: https://trello.com/c/049nLin1/2740-test-failure-showprocfunctestproducedocumentation-is-failing-consistently-on-dev-docstest-build