### PR TITLE
Remove use of DROP INDEX/CONSTRAINT by schema

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/execution-plan-groups/operators.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/execution-plan-groups/operators.asciidoc
@@ -86,17 +86,12 @@ If that is the case, the example queries will be prefixed with an option to choo
 // * <<query-plan-set-relationship-properties-from-map, SetRelationshipPropertiesFromMap>>
 // * <<query-plan-set-property, SetProperty>>
 // * <<query-plan-create-unique-constraint, CreateUniqueConstraint>>
-// * <<query-plan-drop-unique-constraint, DropUniqueConstraint (deprecated)>>
 // * <<query-plan-create-node-property-existence-constraint, CreateNodePropertyExistenceConstraint>>
-// * <<query-plan-drop-node-property-existence-constraint, DropNodePropertyExistenceConstraint (deprecated)>>
 // * <<query-plan-create-node-key-constraint, CreateNodeKeyConstraint>>
-// * <<query-plan-drop-node-key-constraint, DropNodeKeyConstraint (deprecated)>>
 // * <<query-plan-create-relationship-property-existence-constraint, CreateRelationshipPropertyExistenceConstraint>>
-// * <<query-plan-drop-relationship-property-existence-constraint, DropRelationshipPropertyExistenceConstraint (deprecated)>>
-// * <<query-plan-drop-constraint-by-name, DropConstraint>>
+// * <<query-plan-drop-constraint, DropConstraint>>
 // * <<query-plan-create-index, CreateIndex>>
-// * <<query-plan-drop-index, DropIndex (deprecated)>>
-// * <<query-plan-drop-index-by-name, DropIndex>>
+// * <<query-plan-drop-index, DropIndex>>
 
 include::../ql/query-plan/all-nodes-scan.asciidoc[]
 
@@ -289,27 +284,15 @@ include::../ql/query-plan/set-property.asciidoc[]
 
 include::../ql/query-plan/create-unique-constraint.asciidoc[]
 
-[role=deprecated]
-include::../ql/query-plan/drop-unique-constraint.asciidoc[]
-
 include::../ql/query-plan/create-constraint-only-if-it-does-not-already-exist.asciidoc[]
 
 include::../ql/query-plan/create-node-property-existence-constraint.asciidoc[]
 
-[role=deprecated]
-include::../ql/query-plan/drop-node-property-existence-constraint.asciidoc[]
-
 include::../ql/query-plan/create-node-key-constraint.asciidoc[]
-
-[role=deprecated]
-include::../ql/query-plan/drop-node-key-constraint.asciidoc[]
 
 include::../ql/query-plan/create-relationship-property-existence-constraint.asciidoc[]
 
-[role=deprecated]
-include::../ql/query-plan/drop-relationship-property-existence-constraint.asciidoc[]
-
-include::../ql/query-plan/drop-constraint-by-name.asciidoc[]
+include::../ql/query-plan/drop-constraint.asciidoc[]
 
 include::../ql/query-plan/listing-constraints.asciidoc[]
 
@@ -317,10 +300,7 @@ include::../ql/query-plan/create-index.asciidoc[]
 
 include::../ql/query-plan/create-index-only-if-it-does-not-already-exist.asciidoc[]
 
-[role=deprecated]
-include::../ql/query-plan/drop-index-by-schema.asciidoc[]
-
-include::../ql/query-plan/drop-index-by-name.asciidoc[]
+include::../ql/query-plan/drop-index.asciidoc[]
 
 include::../ql/query-plan/listing-indexes.asciidoc[]
 

--- a/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
@@ -142,47 +142,17 @@ Tests for the absence of a pattern predicate.
 |
 |
 
-| <<query-plan-drop-index-by-schema,DropIndex>>
-| Drops an index from a property for all nodes having a certain label.
-| label:yes[]
-| label:yes[]
-| label:deprecated[]
-
-| <<query-plan-drop-index-by-name,DropIndex>>
+| <<query-plan-drop-index,DropIndex>>
 | Drops an index using its name.
 | label:yes[]
 | label:yes[]
 |
 
-| <<query-plan-drop-constraint-by-name,DropConstraint>>
+| <<query-plan-drop-constraint,DropConstraint>>
 | Drops a constraint using its name.
 | label:yes[]
 | label:yes[]
 |
-
-| <<query-plan-drop-node-key-constraint,DropNodeKeyConstraint>>
-| Drops a node key constraint from a set of properties for all nodes having a certain label.
-| label:yes[]
-| label:yes[]
-| label:deprecated[]
-
-| <<query-plan-drop-node-property-existence-constraint,DropNodePropertyExistenceConstraint>>
-| Drops an existence constraint from a property for all nodes having a certain label.
-| label:yes[]
-| label:yes[]
-| label:deprecated[]
-
-| <<query-plan-drop-relationship-property-existence-constraint,DropRelationshipPropertyExistenceConstraint>>
-| Drops an existence constraint from a property for all relationships of a certain type.
-| label:yes[]
-| label:yes[]
-| label:deprecated[]
-
-| <<query-plan-drop-unique-constraint,DropUniqueConstraint>>
-| Drops a unique constraint from a set of properties for all nodes having a certain label.
-| label:yes[]
-| label:yes[]
-| label:deprecated[]
 
 | <<query-plan-eager,Eager>>
 | For isolation purposes, `Eager` ensures that operations affecting subsequent operations are executed fully for the whole dataset before continuing execution.

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/indexes-for-search-performance/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/indexes-for-search-performance/index.asciidoc
@@ -182,21 +182,6 @@ SHOW [ALL\|BTREE\|FULLTEXT\|LOOKUP\|TEXT] INDEX[ES]
 | List indexes in the database, either all or filtered on index type.
 | When using the `RETURN` clause, the `YIELD` clause is mandatory and must not be omitted.
 
-| [source, cypher, role=noplay]
-----
-DROP INDEX ON :LabelName(propertyName)
-----
-| Drop a single-property index on nodes without specifying a name.
-.2+.^| [deprecated]#This syntax is deprecated.#
-
-| [source, cypher, role=noplay]
-----
-DROP INDEX ON :LabelName (n.propertyName_1,
-n.propertyName_2,
-…
-n.propertyName_n)
-----
-| Drop a composite index on nodes without specifying a name.
 |===
 
 Creating an index requires <<administration-security-administration-database-indexes, the `CREATE INDEX` privilege>>,
@@ -547,17 +532,3 @@ include::../indexes/create-a-point-index-specifying-the-index-provider.asciidoc[
 include::../indexes/create-a-point-index-specifying-the-index-configuration.asciidoc[leveloffset=+1]
 
 include::../indexes/create-a-point-index-specifying-both-the-index-provider-and-configuration.asciidoc[leveloffset=+1]
-
-
-[role=deprecated]
-[[administration-indexes-examples-deprecated-syntax]]
-== Deprecated syntax
-
-[NOTE]
-====
-This syntax only supports dropping b-tree node property indexes, all others can only be dropped by name.
-====
-
-include::../indexes/drop-a-single-property-index.asciidoc[leveloffset=+1]
-
-include::../indexes/drop-a-composite-index.asciidoc[leveloffset=+1]

--- a/cypher/cypher-docs/src/docs/dev/ql/constraints/examples.adoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/constraints/examples.adoc
@@ -149,16 +149,10 @@ include::../administration/constraints/listing-constraints-with-filtering.asciid
 include::../administration/constraints/create-a-unique-constraint-using-deprecated-syntax.asciidoc[leveloffset=+1]
 
 [discrete]
-include::../administration/constraints/drop-a-unique-constraint.asciidoc[leveloffset=+1]
-
-[discrete]
 include::../administration/constraints/create-a-node-property-existence-constraint-using-deprecated-syntax-1.asciidoc[leveloffset=+1]
 
 [discrete]
 include::../administration/constraints/create-a-node-property-existence-constraint-using-deprecated-syntax-2.asciidoc[leveloffset=+1]
-
-[discrete]
-include::../administration/constraints/drop-a-node-property-existence-constraint.asciidoc[leveloffset=+1]
 
 [discrete]
 include::../administration/constraints/create-a-relationship-property-existence-constraint-using-deprecated-syntax-1.asciidoc[leveloffset=+1]
@@ -167,10 +161,4 @@ include::../administration/constraints/create-a-relationship-property-existence-
 include::../administration/constraints/create-a-relationship-property-existence-constraint-using-deprecated-syntax-2.asciidoc[leveloffset=+1]
 
 [discrete]
-include::../administration/constraints/drop-a-relationship-property-existence-constraint.asciidoc[leveloffset=+1]
-
-[discrete]
 include::../administration/constraints/create-a-node-key-constraint-using-deprecated-syntax.asciidoc[leveloffset=+1]
-
-[discrete]
-include::../administration/constraints/drop-a-node-key-constraint.asciidoc[leveloffset=+1]

--- a/cypher/cypher-docs/src/docs/dev/ql/constraints/syntax.adoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/constraints/syntax.adoc
@@ -121,10 +121,7 @@ Index provider and configuration can be specified using the `OPTIONS` clause.
 [[administration-constraints-syntax-drop]]
 == Syntax for dropping constraints
 
-[discrete]
-=== Drop a constraint
-
-The preferred way of dropping a constraint is by the name of the constraint.
+Dropping a constraint is done by the name of the constraint.
 
 This drop command is optionally idempotent, with the default behavior to throw an error if you attempt to drop the same constraint twice.
 With the `IF EXISTS` flag, no error is thrown and nothing happens should the constraint not exist.
@@ -134,68 +131,6 @@ Dropping a constraint requires the <<administration-security-administration-data
 [source, cypher, role=noplay]
 ----
 DROP CONSTRAINT constraint_name [IF EXISTS]
-----
-
-[discrete]
-=== [deprecated]#Drop a unique constraint without specifying a name#
-
-An old way of dropping a uniqueness constraint was to drop the constraint by specifying the schema of the constraint.
-
-[source, cypher, role=noplay]
-----
-DROP CONSTRAINT
-ON (n:LabelName)
-ASSERT n.propertyName IS UNIQUE
-----
-
-[source, cypher, role=noplay]
-----
-DROP CONSTRAINT
-ON (n:LabelName)
-ASSERT (n.propertyName_1, … n.propertyName_n) IS UNIQUE
-----
-
-[discrete]
-=== [deprecated]#Drop a node property existence constraint without specifying a name#
-
-An old way of dropping a node property existence constraint was to drop the constraint by specifying the schema of the constraint.
-
-[source, cypher, role=noplay]
-----
-DROP CONSTRAINT
-ON (n:LabelName)
-ASSERT EXISTS (n.propertyName)
-----
-
-[discrete]
-=== [deprecated]#Drop a relationship property existence constraint without specifying a name#
-
-An old way of dropping a relationship property existence constraint was to drop the constraint by specifying the schema of the constraint.
-
-[source, cypher, role=noplay]
-----
-DROP CONSTRAINT
-ON ()-"["r:RELATIONSHIP_TYPE"]"-()
-ASSERT EXISTS (r.propertyName)
-----
-
-[discrete]
-=== [deprecated]#Drop a node key constraint without specifying a name#
-
-An old way of dropping a node key constraint was to drop the constraint by specifying the schema of the constraint.
-
-[source, cypher, role=noplay]
-----
-DROP CONSTRAINT
-ON (n:LabelName)
-ASSERT n.propertyName IS NODE KEY
-----
-
-[source, cypher, role=noplay]
-----
-DROP CONSTRAINT
-ON (n:LabelName)
-ASSERT (n.propertyName_1, … n.propertyName_n) IS NODE KEY
 ----
 
 

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ConstraintsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ConstraintsTest.scala
@@ -144,18 +144,6 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
     )
   }
 
-  @Test def drop_unique_constraint() {
-    generateConsole = false
-
-    prepareAndTestQuery(
-      title = "Drop a unique constraint",
-      text = "By using `DROP CONSTRAINT`, a b-tree index-backed unique constraint is removed from the database.",
-      queryText = "DROP CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE",
-      prepare = _ => executePreparationQueries(List("CREATE CONSTRAINT FOR (book:Book) REQUIRE book.isbn IS UNIQUE")),
-      assertions = _ => assertNodeConstraintDoesNotExist("Book", "isbn")
-    )
-  }
-
   @Test def play_nice_with_unique_property_constraint() {
     generateConsole = false
 
@@ -242,18 +230,6 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
       optionalResultExplanation = "Note no constraint will be created if any other constraint with that name or another node property existence constraint on the same schema already exists. " +
         "Assuming a constraint with the name `constraint_name` already existed:",
       assertions = _ => assertConstraintWithNameExists("constraint_name", "Book", List("isbn"))
-    )
-  }
-
-  @Test def drop_node_property_existence_constraint() {
-    generateConsole = false
-
-    prepareAndTestQuery(
-      title = "Drop a node property existence constraint",
-      text = "By using `DROP CONSTRAINT`, a node property existence constraint is removed from the database.",
-      queryText = "DROP CONSTRAINT ON (book:Book) ASSERT exists(book.isbn)",
-      prepare = _ => executePreparationQueries(List("CREATE CONSTRAINT FOR (book:Book) REQUIRE book.isbn IS NOT NULL")),
-      assertions = _ => assertNodeConstraintDoesNotExist("Book", "isbn")
     )
   }
 
@@ -344,18 +320,6 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
       optionalResultExplanation = "Note no constraint will be created if any other constraint with that name or another relationship property existence constraint on the same schema already exists. " +
         "Assuming a constraint with the name `constraint_name` already existed:",
       assertions = _ => assertConstraintWithNameExists("constraint_name", "LIKED", List("since"), forRelationship = true)
-    )
-  }
-
-  @Test def drop_relationship_property_existence_constraint() {
-    generateConsole = false
-
-    prepareAndTestQuery(
-      title = "Drop a relationship property existence constraint",
-      text = "To remove a relationship property existence constraint from the database, use `DROP CONSTRAINT`.",
-      queryText = "DROP CONSTRAINT ON ()-[like:LIKED]-() ASSERT exists(like.day)",
-      prepare = _ => executePreparationQueries(List("CREATE CONSTRAINT FOR ()-[like:LIKED]-() REQUIRE like.day IS NOT NULL")),
-      assertions = _ => assertRelationshipConstraintDoesNotExist("LIKED", "day")
     )
   }
 
@@ -486,18 +450,6 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
     )
   }
 
-  @Test def drop_node_key_constraint() {
-    generateConsole = false
-
-    prepareAndTestQuery(
-      title = "Drop a node key constraint",
-      text = "Use `DROP CONSTRAINT` to remove a b-tree index-backed node key constraint from the database.",
-      queryText = "DROP CONSTRAINT ON (n:Person) ASSERT (n.firstname, n.surname) IS NODE KEY",
-      prepare = _ => executePreparationQueries(List("CREATE CONSTRAINT FOR (n:Person) REQUIRE (n.firstname, n.surname) IS NODE KEY")),
-      assertions = _ => assertNodeKeyConstraintDoesNotExist("Person", "firstname", "surname")
-    )
-  }
-
   @Test def play_nice_with_node_key_constraint() {
     generateConsole = false
 
@@ -592,20 +544,8 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
     assert(hasNodeKeyConstraint(labelName, propNames.toSeq))
   }
 
-  private def assertNodeConstraintDoesNotExist(labelName: String, propName: String) {
-    assert(!hasNodeConstraint(labelName, propName))
-  }
-
-  private def assertNodeKeyConstraintDoesNotExist(labelName: String, propNames: String*) {
-    assert(!hasNodeKeyConstraint(labelName, propNames.toSeq))
-  }
-
   private def assertRelationshipConstraintExist(typeName: String, propName: String) {
     assert(hasRelationshipConstraint(typeName, propName))
-  }
-
-  private def assertRelationshipConstraintDoesNotExist(typeName: String, propName: String) {
-    assert(!hasRelationshipConstraint(typeName, propName))
   }
 
   def assertConstraintWithNameExists(name: String, expectedLabelOrType: String, expectedProperties: List[String], forRelationship: Boolean = false) {

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
@@ -121,21 +121,6 @@ class QueryPlanTest extends DocumentingTestBase with SoftReset {
     )
   }
 
-  @Test def dropUniqueConstraint() {
-    executePreparationQueries {
-      List("CREATE CONSTRAINT FOR (c:Country) REQUIRE c.name is UNIQUE")
-    }
-
-    profileQuery(
-      title = "Drop Unique Constraint",
-      text =
-        """The `DropUniqueConstraint` operator removes a unique constraint from all nodes having a certain set of properties and label.
-          |The following query will drop a unique constraint on the `name` property of nodes with the `Country` label.""".stripMargin,
-      queryText = """DROP CONSTRAINT ON (c:Country) ASSERT c.name is UNIQUE""",
-      assertions = p => assertThat(p.executionPlanString(), containsString("DropConstraint"))
-    )
-  }
-
   @Test def doNothingIfExistsForConstraint() {
     profileQuery(
       title = "Create Constraint only if it does not already exist",
@@ -171,22 +156,6 @@ class QueryPlanTest extends DocumentingTestBase with SoftReset {
     )
   }
 
-  @Test def dropNodePropertyExistenceConstraint() {
-    executePreparationQueries {
-      List("CREATE CONSTRAINT FOR (p:Person) REQUIRE p.name IS NOT NULL")
-    }
-
-    profileQuery(
-      title = "Drop Node Property Existence Constraint",
-      text =
-        """The `DropNodePropertyExistenceConstraint` operator removes an existence constraint from a property for all nodes having a certain label.
-          |This will only appear in Enterprise Edition.
-        """.stripMargin,
-      queryText = """DROP CONSTRAINT ON (p:Person) ASSERT exists(p.name)""",
-      assertions = p => assertThat(p.executionPlanString(), containsString("DropConstraint"))
-    )
-  }
-
   @Test def createNodeKeyConstraint() {
     profileQuery(
       title = "Create Node Key Constraint",
@@ -201,22 +170,6 @@ class QueryPlanTest extends DocumentingTestBase with SoftReset {
         assertThat(plan, containsString("CreateConstraint"))
         assertThat(plan, containsString("node_key"))
       }
-    )
-  }
-
-  @Test def dropNodeKeyConstraint() {
-    executePreparationQueries {
-      List("CREATE CONSTRAINT FOR (e:Employee) REQUIRE (e.firstname, e.surname) IS NODE KEY")
-    }
-
-    profileQuery(
-      title = "Drop Node Key Constraint",
-      text =
-        """The `DropNodeKeyConstraint` operator removes a node key constraint from a set of properties for all nodes having a certain label.
-          |This will only appear in Enterprise Edition.
-        """.stripMargin,
-      queryText = """DROP CONSTRAINT ON (e:Employee) ASSERT (e.firstname, e.surname) IS NODE KEY""",
-      assertions = p => assertThat(p.executionPlanString(), containsString("DropConstraint"))
     )
   }
 
@@ -236,28 +189,13 @@ class QueryPlanTest extends DocumentingTestBase with SoftReset {
     )
   }
 
-  @Test def dropRelationshipPropertyExistenceConstraint() {
-    executePreparationQueries {
-      List("CREATE CONSTRAINT FOR ()-[l:LIKED]-() REQUIRE l.when IS NOT NULL")
-    }
-
-    profileQuery(
-      title = "Drop Relationship Property Existence Constraint",
-      text =
-        """The `DropRelationshipPropertyExistenceConstraint` operator removes an existence constraint from a property for all relationships of a certain type.
-          |This will only appear in Enterprise Edition.""".stripMargin,
-      queryText = """DROP CONSTRAINT ON ()-[l:LIKED]-() ASSERT exists(l.when)""",
-      assertions = p => assertThat(p.executionPlanString(), containsString("DropConstraint"))
-    )
-  }
-
-  @Test def dropNamedConstraint() {
+  @Test def dropConstraint() {
     executePreparationQueries {
       List("CREATE CONSTRAINT name FOR (c:Country) REQUIRE c.name is UNIQUE")
     }
 
     profileQuery(
-      title = "Drop Constraint by name",
+      title = "Drop Constraint",
       text =
         """The `DropConstraint` operator removes a constraint using the name of the constraint, no matter the type.""".stripMargin,
       queryText = """DROP CONSTRAINT name""",
@@ -325,26 +263,11 @@ class QueryPlanTest extends DocumentingTestBase with SoftReset {
 
   @Test def dropIndex() {
     executePreparationQueries {
-      List("CREATE INDEX FOR (c:Country) ON (c.name)")
-    }
-
-    profileQuery(
-      title = "Drop Index by schema",
-      text =
-        """The `DropIndex` operator removes an index from a property for all nodes having a certain label.
-          |The following query will drop an index on the `name` property of nodes with the `Country` label.""".stripMargin,
-      queryText = """DROP INDEX ON :Country(name)""",
-      assertions = p => assertThat(p.executionPlanString(), containsString("DropIndex"))
-    )
-  }
-
-  @Test def dropNamedIndex() {
-    executePreparationQueries {
       List("CREATE INDEX name FOR (c:Country) ON (c.name)")
     }
 
     profileQuery(
-      title = "Drop Index by name",
+      title = "Drop Index",
       text =
         """The `DropIndex` operator removes an index using the name of the index.""".stripMargin,
       queryText = """DROP INDEX name""",

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SchemaIndexTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SchemaIndexTest.scala
@@ -460,27 +460,6 @@ class SchemaIndexTest extends DocumentingTestBase with QueryStatisticsTestSuppor
     )
   }
 
-  @Test def drop_index_on_a_label_single_property() {
-    prepareAndTestQuery(
-      title = "Drop a single-property index",
-      text = "A b-tree index on all nodes with a label and single property combination can be dropped with `DROP INDEX ON :Label(property)`.",
-      prepare = _ => executePreparationQueries(List("create btree index for (p:Person) on (p.firstname)")),
-      queryText = "DROP INDEX ON :Person(firstname)",
-      assertions = _ => assertIndexesOnLabels("Person", List(List("middlename"), List("surname"), List("location"), List("highScore")))
-    )
-  }
-
-  @Test def drop_index_on_a_label_composite_property() {
-    prepareAndTestQuery(
-      title = "Drop a composite index",
-      text = "A composite b-tree index on all nodes with a label and multiple property combination can be dropped with `DROP INDEX ON :Label(prop1, ..., propN)`. " +
-      "The following statement will drop a composite index on all nodes labeled with `Person` and which have both an `age` and `country` property: ",
-      prepare = _ => executePreparationQueries(List("create btree index for (p:Person) on (p.age, p.country)")),
-      queryText = "DROP INDEX ON :Person(age, country)",
-      assertions = _ => assertIndexesOnLabels("Person", List(List("firstname"), List("middlename"), List("surname"), List("location"), List("highScore")))
-    )
-  }
-
   @Test def drop_index() {
     prepareAndTestQuery(
       title = "Drop an index",

--- a/cypher/cypher-prettifier/src/main/scala/org/neo4j/cypher/docgen/tooling/PrettifierParser.scala
+++ b/cypher/cypher-prettifier/src/main/scala/org/neo4j/cypher/docgen/tooling/PrettifierParser.scala
@@ -116,12 +116,10 @@ class PrettifierParser(val keepMyNewlines: Boolean) extends Parser with Base wit
         keyword("CREATE INDEX") | // These are for the named versions, sadly they will break the query on the ON keyword
         keyword("CREATE BTREE INDEX") | // Sadly these will break the query on the ON keyword
         keyword("CREATE LOOKUP INDEX") | // Sadly these will break the query on the ON keyword
-        keyword("DROP INDEX ON") | // Deprecated
         keyword("DROP INDEX") |
         showIndexBreakingKeyword |
         keyword("CREATE CONSTRAINT ON") |
         keyword("CREATE CONSTRAINT") | // These are for the named versions, sadly they will break the query on the ON keyword
-        keyword("DROP CONSTRAINT ON") | // Deprecated
         keyword("DROP CONSTRAINT") |
         showConstraintBreakingKeyword |
         keyword("USING PERIODIC COMMIT") |


### PR DESCRIPTION
The command is being removed in https://github.com/neo-technology/neo4j/pull/13438 (but this pr is not dependent on that going in first)