### PR TITLE
Add a 5.0 section to deprecations, additions and removals chapter

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -96,6 +96,46 @@ SHOW CONSTRAINTS YIELD *
 
 a|
 label:syntax[]
+label:removed[]
+[source, cypher, role="noheader"]
+----
+DROP INDEX ON :Label(prop)
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+DROP INDEX name
+----
+
+a|
+label:syntax[]
+label:removed[]
+[source, cypher, role="noheader"]
+----
+DROP CONSTRAINT ON (n:Label) ASSERT (n.prop) IS NODE KEY
+----
+[source, cypher, role="noheader"]
+----
+DROP CONSTRAINT ON (n:Label) ASSERT (n.prop) IS UNIQUE
+----
+[source, cypher, role="noheader"]
+----
+DROP CONSTRAINT ON (n:Label) ASSERT exists(n.prop)
+----
+[source, cypher, role="noheader"]
+----
+DROP CONSTRAINT ON ()-[r:Type]-() ASSERT exists(r.prop)
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+DROP CONSTRAINT name
+----
+
+a|
+label:syntax[]
 label:removed[] +
 For privilege commands:
 [source, cypher, role="noheader"]


### PR DESCRIPTION
also add removal of drop indexes/constraints by schema commands to the 5.0 section, done in https://github.com/neo-technology/neo4j/pull/13438

~~Needs to be rebased and updated after https://github.com/neo4j/neo4j-documentation/pull/1340 / https://github.com/neo4j/neo4j-documentation/pull/1374 goes in~~ 