### PR TITLE
4.4 execution plan summary

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
@@ -76,6 +76,12 @@ Tests for the absence of a pattern predicate.
 |
 |
 
+| <<query-plan-create-nodes---relationships,Create>>
+| Creates nodes and relationships.
+|
+| label:yes[]
+|
+
 | <<query-plan-create-index,CreateIndex>>
 | Creates an index for either nodes or relationships.
 |
@@ -84,12 +90,6 @@ Tests for the absence of a pattern predicate.
 
 | <<query-plan-create-node-key-constraint,CreateNodeKeyConstraint>>
 | Creates a node key constraint on a set of properties for all nodes having a certain label.
-|
-| label:yes[]
-|
-
-| <<query-plan-create-nodes---relationships,Create>>
-| Creates nodes and relationships.
 |
 | label:yes[]
 |
@@ -148,6 +148,12 @@ Tests for the absence of a pattern predicate.
 |
 |
 
+| <<query-plan-drop-constraint-by-name,DropConstraint>>
+| Drops a constraint using its name.
+| label:yes[]
+| label:yes[]
+|
+
 | <<query-plan-drop-index-by-schema,DropIndex>>
 | Drops an index from a property for all nodes having a certain label.
 | label:yes[]
@@ -156,12 +162,6 @@ Tests for the absence of a pattern predicate.
 
 | <<query-plan-drop-index-by-name,DropIndex>>
 | Drops an index using its name.
-| label:yes[]
-| label:yes[]
-|
-
-| <<query-plan-drop-constraint-by-name,DropConstraint>>
-| Drops a constraint using its name.
 | label:yes[]
 | label:yes[]
 |
@@ -254,18 +254,18 @@ Tests for the absence of a pattern predicate in queries containing multiple patt
 |
 |
 
-| <<query-plan-let-select-or-semi-apply,LetSelectOrSemiApply>>
-a|
-Performs a nested loop.
-Tests for the presence of a pattern predicate that is combined with other predicates.
-|
-|
-|
-
 | <<query-plan-let-select-or-anti-semi-apply,LetSelectOrAntiSemiApply>>
 a|
 Performs a nested loop.
 Tests for the absence of a pattern predicate that is combined with other predicates.
+|
+|
+|
+
+| <<query-plan-let-select-or-semi-apply,LetSelectOrSemiApply>>
+a|
+Performs a nested loop.
+Tests for the presence of a pattern predicate that is combined with other predicates.
 |
 |
 |
@@ -380,20 +380,6 @@ Tests for the presence of a pattern predicate in queries containing multiple pat
 |
 |
 
-| <<query-plan-ordered-aggregation,OrderedAggregation>>
-a|
-Like `EagerAggregation` but relies on the ordering of incoming rows.
-Is not eager.
-|
-|
-|
-
-| <<query-plan-ordered-distinct,OrderedDistinct>>
-| Like `Distinct` but relies on the ordering of incoming rows.
-|
-|
-|
-
 | <<query-plan-optional,Optional>>
 | Yields a single row with all columns set to `null` if no data is returned by its source.
 |
@@ -408,6 +394,20 @@ Is not eager.
 
 | <<query-plan-optional-expand-into,OptionalExpand(Into)>>
 | Traverses all relationships between two nodes, producing a single row with the relationship and end node set to `null` if no matching relationships are found (the start node will be the node with the smallest degree).
+|
+|
+|
+
+| <<query-plan-ordered-aggregation,OrderedAggregation>>
+a|
+Like `EagerAggregation` but relies on the ordering of incoming rows.
+Is not eager.
+|
+|
+|
+
+| <<query-plan-ordered-distinct,OrderedDistinct>>
+| Like `Distinct` but relies on the ordering of incoming rows.
 |
 |
 |

--- a/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
@@ -89,13 +89,13 @@ Tests for the absence of a pattern predicate.
 |
 
 | <<query-plan-create-node-key-constraint,CreateNodeKeyConstraint>>
-| Creates a node key constraint on a set of properties for all nodes having a certain label.
+| Creates a node key constraint on a set of properties for all nodes with a certain label.
 |
 | label:yes[]
 |
 
 | <<query-plan-create-node-property-existence-constraint,CreateNodePropertyExistenceConstraint>>
-| Creates an existence constraint on a property for all nodes having a certain label.
+| Creates an existence constraint on a property for all nodes with a certain label.
 |
 | label:yes[]
 |
@@ -107,7 +107,7 @@ Tests for the absence of a pattern predicate.
 |
 
 | <<query-plan-create-unique-constraint,CreateUniqueConstraint>>
-| Creates a unique constraint on a set of properties for all nodes having a certain label.
+| Creates a unique constraint on a set of properties for all nodes with a certain label.
 |
 | label:yes[]
 |
@@ -155,7 +155,7 @@ Tests for the absence of a pattern predicate.
 |
 
 | <<query-plan-drop-index-by-schema,DropIndex>>
-| Drops an index from a property for all nodes having a certain label.
+| Drops an index from a property for all nodes with a certain label.
 | label:yes[]
 | label:yes[]
 | label:deprecated[]
@@ -167,13 +167,13 @@ Tests for the absence of a pattern predicate.
 |
 
 | <<query-plan-drop-node-key-constraint,DropNodeKeyConstraint>>
-| Drops a node key constraint from a set of properties for all nodes having a certain label.
+| Drops a node key constraint from a set of properties for all nodes with a certain label.
 | label:yes[]
 | label:yes[]
 | label:deprecated[]
 
 | <<query-plan-drop-node-property-existence-constraint,DropNodePropertyExistenceConstraint>>
-| Drops an existence constraint from a property for all nodes having a certain label.
+| Drops an existence constraint from a property for all nodes with a certain label.
 | label:yes[]
 | label:yes[]
 | label:deprecated[]
@@ -185,7 +185,7 @@ Tests for the absence of a pattern predicate.
 | label:deprecated[]
 
 | <<query-plan-drop-unique-constraint,DropUniqueConstraint>>
-| Drops a unique constraint from a set of properties for all nodes having a certain label.
+| Drops a unique constraint from a set of properties for all nodes with a certain label.
 | label:yes[]
 | label:yes[]
 | label:deprecated[]
@@ -341,7 +341,7 @@ Tests for the presence of a pattern predicate in queries containing multiple pat
 |
 
 | <<query-plan-node-index-scan,NodeIndexScan>>
-| Examines all values stored in an index, returning all nodes with a particular label having a specified property.
+| Examines all values stored in an index, returning all nodes with a particular label with a specified property.
 | label:yes[]
 |
 |

--- a/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
@@ -215,7 +215,9 @@ Tests for the absence of a pattern predicate.
 |
 
 | <<query-plan-exhaustive-limit,ExhaustiveLimit>>
-| The `ExhaustiveLimit` operator is similar to the `Limit` operator, but will always exhaust the input. Used when combining `LIMIT` and updates.
+a|
+The `ExhaustiveLimit` operator is similar to the `Limit` operator, but will always exhaust the input.
+Used when combining `LIMIT` and updates.
 |
 |
 |

--- a/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
@@ -31,6 +31,12 @@ This table comprises all the execution plan operators ordered lexicographically.
 |
 |
 
+| <<query-plan-anti,Anti>>
+| Tests for the absence of a pattern.
+|
+|
+|
+
 | <<query-plan-anti-semi-apply,AntiSemiApply>>
 a|
 Performs a nested loop.

--- a/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
@@ -214,6 +214,12 @@ Tests for the absence of a pattern predicate.
 |
 |
 
+| <<query-plan-exhaustive-limit,ExhaustiveLimit>>
+| The `ExhaustiveLimit` operator is just like a normal Limit but will always exhaust the input. Used when combining `LIMIT` and updates.
+|
+|
+|
+
 | <<query-plan-expand-all,Expand(All)>>
 | Traverses incoming or outgoing relationships from a given node.
 |

--- a/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
@@ -216,7 +216,7 @@ Tests for the absence of a pattern predicate.
 
 | <<query-plan-exhaustive-limit,ExhaustiveLimit>>
 a|
-The `ExhaustiveLimit` operator is similar to the `Limit` operator, but will always exhaust the input.
+The `ExhaustiveLimit` operator is similar to the `Limit` operator, but always exhausts the input.
 Used when combining `LIMIT` and updates.
 |
 |
@@ -395,7 +395,7 @@ Tests for the presence of a pattern predicate in queries containing multiple pat
 |
 
 | <<query-plan-optional-expand-into,OptionalExpand(Into)>>
-| Traverses all relationships between two nodes, producing a single row with the relationship and end node set to `null` if no matching relationships are found (the start node will be the node with the smallest degree).
+| Traverses all relationships between two nodes, producing a single row with the relationship and end node set to `null` if no matching relationships are found (the start node is the node with the smallest degree).
 |
 |
 |

--- a/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
@@ -215,7 +215,7 @@ Tests for the absence of a pattern predicate.
 |
 
 | <<query-plan-exhaustive-limit,ExhaustiveLimit>>
-| The `ExhaustiveLimit` operator is just like a normal Limit but will always exhaust the input. Used when combining `LIMIT` and updates.
+| The `ExhaustiveLimit` operator is similar to the `Limit` operator, but will always exhaust the input. Used when combining `LIMIT` and updates.
 |
 |
 |

--- a/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
@@ -572,6 +572,18 @@ Tests for the absence of a pattern predicate if an expression predicate evaluate
 |
 | label:eager[]
 
+| <<query-plan-triadic-build,TriadicBuild>>
+| The `TriadicBuild` operator is used in conjunction with `TriadicFilter` to solve triangular queries.
+|
+|
+|
+
+| <<query-plan-triadic-filter,TriadicFilter>>
+| The `TriadicFilter` operator is used in conjunction with `TriadicBuild` to solve triangular queries.
+|
+|
+|
+
 | <<query-plan-triadic-selection,TriadicSelection>>
 | Solves triangular queries, such as the very common 'find my friend-of-friends that are not already my friend'.
 |

--- a/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
@@ -512,6 +512,12 @@ Tests for the absence of a pattern predicate if an expression predicate evaluate
 | label:yes[]
 |
 
+| <<query-plan-shortest-path,ShortestPath>>
+| Finds one or all shortest paths between two previously matches node variables.
+|
+|
+|
+
 | <<query-plan-listing-constraints,ShowConstraints>>
 | Lists the available constraints.
 | label:yes[]


### PR DESCRIPTION
Added missing execution plan operators to the summary list.

Anti - https://neo4j.com/docs/cypher-manual/4.4/execution-plans/operators/#query-plan-anti
ExhaustiveLimit - https://neo4j.com/docs/cypher-manual/4.4/execution-plans/operators/#query-plan-exhaustive-limit
ShortestPath - https://neo4j.com/docs/cypher-manual/4.4/execution-plans/operators/#query-plan-shortest-path
TriadicBuild - https://neo4j.com/docs/cypher-manual/4.4/execution-plans/operators/#query-plan-triadic-build
TriadicFilter - https://neo4j.com/docs/cypher-manual/4.4/execution-plans/operators/#query-plan-triadic-filter