### PR TITLE
4.3 cypher planner operators page (#1388)

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/execution-plan-groups/operators.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/execution-plan-groups/operators.asciidoc
@@ -10,169 +10,162 @@ All operators are listed here, grouped by the similarity of their characteristic
 Certain operators are only used by a subset of the <<cypher-runtime,runtimes>> that Cypher can choose from.
 If that is the case, the example queries will be prefixed with an option to choose one of these runtimes.
 
-//Commented the toc, in case we later decide that we want it.
-// * <<query-plan-all-nodes-scan, AllNodesScan>>
-// * <<query-plan-directed-relationship-by-id-seek, DirectedRelationshipByIdSeek>>
-// * <<query-plan-node-by-id-seek, NodeByIdSeek>>
-// * <<query-plan-node-by-label-scan, NodeByLabelScan>>
-// * <<query-plan-node-index-seek, NodeIndexSeek>>
-// * <<query-plan-node-unique-index-seek, NodeUniqueIndexSeek>>
-// * <<query-plan-multi-node-index-seek, MultiNodeIndexSeek>>
-// * <<query-plan-node-unique-index-seek-by-range, NodeUniqueIndexSeekByRange>>
-// * <<query-plan-node-index-contains-scan, NodeIndexContainsScan>>
-// * <<query-plan-node-index-ends-with-scan, NodeIndexEndsWithScan>>
-// * <<query-plan-node-index-scan, NodeIndexScan>>
-// * <<query-plan-undirected-relationship-by-id-seek, UndirectedRelationshipByIdSeek>>
-// * <<query-plan-apply, Apply>>
-// * <<query-plan-semi-apply, SemiApply>>
-// * <<query-plan-anti-semi-apply, AntiSemiApply>>
-// * <<query-plan-anti, Anti>>
-// * <<query-plan-let-semi-apply, LetSemiApply>>
-// * <<query-plan-let-anti-semi-apply, LetAntiSemiApply>>
-// * <<query-plan-select-or-semi-apply, SelectOrSemiApply>>
-// * <<query-plan-select-or-anti-semi-apply, SelectOrAntiSemiApply>>
-// * <<query-plan-let-select-or-semi-apply, LetSelectOrSemiApply>>
-// * <<query-plan-let-select-or-anti-semi-apply, LetSelectOrAntiSemiApply>>
-// * <<query-plan-merge,Merge>>
-// * <<query-plan-roll-up-apply, RollUpApply>>
-// * <<query-plan-argument, Argument>>
-// * <<query-plan-expand-all, Expand(All)>>
-// * <<query-plan-expand-into, Expand(Into)>>
-// * <<query-plan-optional-expand-all, OptionalExpand(All)>>
-// * <<query-plan-optional-expand-into, OptionalExpand(Into)>>
-// * <<query-plan-varlength-expand-all, VarLengthExpand(All)>>
-// * <<query-plan-varlength-expand-into, VarLengthExpand(Into)>>
-// * <<query-plan-varlength-expand-pruning, VarLengthExpand(Pruning)>>
-// * <<query-plan-assert-same-node, AssertSameNode>>
-// * <<query-plan-empty-result, EmptyResult>>
-// * <<query-plan-produce-results, ProduceResults>>
-// * <<query-plan-load-csv, LoadCSV>>
-// * <<query-plan-node-hash-join, NodeHashJoin>>
-// * <<query-plan-value-hash-join, ValueHashJoin>>
-// * <<query-plan-node-left-right-outer-hash-join, NodeLeftOuterHashJoin>>
-// * <<query-plan-node-left-right-outer-hash-join, NodeRightOuterHashJoin>>
-// * <<query-plan-triadic-selection, TriadicSelection>>
-// * <<query-plan-cartesian-product, CartesianProduct>>
-// * <<query-plan-foreach, Foreach>>
-// * <<query-plan-eager, Eager>>
-// * <<query-plan-eager-aggregation, EagerAggregation>>
-// * <<query-plan-ordered-aggregation, OrderedAggregation>>
-// * <<query-plan-node-count-from-count-store, NodeCountFromCountStore>>
-// * <<query-plan-relationship-count-from-count-store, RelationshipCountFromCountStore>>
-// * <<query-plan-distinct, Distinct>>
-// * <<query-plan-ordered-distinct, OrderedDistinct>>
-// * <<query-plan-filter, Filter>>
-// * <<query-plan-limit, Limit>>
-// * <<query-plan-skip, Skip>>
-// * <<query-plan-sort, Sort>>
-// * <<query-plan-partial-sort, PartialSort>>
-// * <<query-plan-top, Top>>
-// * <<query-plan-partial-top, PartialTop>>
-// * <<query-plan-union, Union>>
-// * <<query-plan-unwind, Unwind>>
-// * <<query-plan-exhaustive-limit,ExhaustiveLimit>>
-// * <<query-plan-optional, Optional>>
-// * <<query-plan-project-endpoints, ProjectEndpoints>>
-// * <<query-plan-projection, Projection>>
-// * <<query-plan-empty-row, EmptyRow>>
-// * <<query-plan-procedure-call, ProcedureCall>>
-// * <<query-plan-cache-properties, CacheProperties>>
-// * <<query-plan-create-nodes---relationships, Create>>
-// * <<query-plan-delete, Delete>>
-// * <<query-plan-detach-delete, DetachDelete>>
-// * <<query-plan-set-labels, SetLabels>>
-// * <<query-plan-remove-labels, RemoveLabels>>
-// * <<query-plan-set-node-properties-from-map, SetNodePropertiesFromMap>>
-// * <<query-plan-set-relationship-properties-from-map, SetRelationshipPropertiesFromMap>>
-// * <<query-plan-set-property, SetProperty>>
-// * <<query-plan-create-unique-constraint, CreateUniqueConstraint>>
-// * <<query-plan-create-node-property-existence-constraint, CreateNodePropertyExistenceConstraint>>
-// * <<query-plan-create-node-key-constraint, CreateNodeKeyConstraint>>
-// * <<query-plan-create-relationship-property-existence-constraint, CreateRelationshipPropertyExistenceConstraint>>
-// * <<query-plan-drop-constraint, DropConstraint>>
-// * <<query-plan-create-index, CreateIndex>>
-// * <<query-plan-drop-index, DropIndex>>
+// --- scan and seek operators ---
 
+// AllNodesScan
 include::../ql/query-plan/all-nodes-scan.asciidoc[]
 
+// DirectedRelationshipIndexScan
+include::../ql/query-plan/directed-relationship-index-scan.asciidoc[]
+// UndirectedRelationshipIndexScan
+include::../ql/query-plan/undirected-relationship-index-scan.asciidoc[]
+
+// DirectedRelationshipIndexSeek
+include::../ql/query-plan/directed-relationship-index-seek.asciidoc[]
+// UndirectedRelationshipIndexSeek
+include::../ql/query-plan/undirected-relationship-index-seek.asciidoc[]
+
+// DirectedRelationshipByIdSeek
 include::../ql/query-plan/directed-relationship-by-id-seek.asciidoc[]
-
-include::../ql/query-plan/node-by-id-seek.asciidoc[]
-
-include::../ql/query-plan/node-by-label-scan.asciidoc[]
-
-include::../ql/query-plan/node-index-seek.asciidoc[]
-
-include::../ql/query-plan/node-unique-index-seek.asciidoc[]
-
-include::../ql/query-plan/multi-node-index-seek.asciidoc[]
-
-include::../ql/query-plan/node-index-seek-by-range.asciidoc[]
-
-include::../ql/query-plan/node-unique-index-seek-by-range.asciidoc[]
-
-include::../ql/query-plan/node-index-contains-scan.asciidoc[]
-
-include::../ql/query-plan/node-index-ends-with-scan.asciidoc[]
-
-include::../ql/query-plan/node-index-scan.asciidoc[]
-
+// UndirectedRelationshipByIdSeek
 include::../ql/query-plan/undirected-relationship-by-id-seek.asciidoc[]
 
+// DirectedRelationshipIndexContainsScan
+include::../ql/query-plan/directed-relationship-index-contains-scan.asciidoc[]
+// UndirectedRelationshipIndexContainsScan
+include::../ql/query-plan/undirected-relationship-index-contains-scan.asciidoc[]
+
+// DirectedRelationshipIndexEndsWithScan
+include::../ql/query-plan/directed-relationship-index-ends-with-scan.asciidoc[]
+// UndirectedRelationshipIndexEndsWithScan
+include::../ql/query-plan/undirected-relationship-index-ends-with-scan.asciidoc[]
+
+// DirectedRelationshipIndexSeekByRange
+include::../ql/query-plan/directed-relationship-index-seek-by-range.asciidoc[]
+// UndirectedRelationshipIndexSeekByRange
+include::../ql/query-plan/undirected-relationship-index-seek-by-range.asciidoc[]
+
+// DirectedRelationshipTypeScan
+include::../ql/query-plan/directed-relationship-type-scan.asciidoc[]
+// UndirectedRelationshipTypeScan
+include::../ql/query-plan/undirected-relationship-type-scan.asciidoc[]
+
+// NodeByIdSeek
+include::../ql/query-plan/node-by-id-seek.asciidoc[]
+
+// NodeByLabelScan
+include::../ql/query-plan/node-by-label-scan.asciidoc[]
+
+// NodeIndexSeek
+include::../ql/query-plan/node-index-seek.asciidoc[]
+
+// NodeUniqueIndexSeek
+include::../ql/query-plan/node-unique-index-seek.asciidoc[]
+
+// MultiNodeIndexSeek
+include::../ql/query-plan/multi-node-index-seek.asciidoc[]
+
+// AssertingMultiNodeIndexSeek
+include::../ql/query-plan/asserting-multi-node-index-seek.asciidoc[]
+
+// NodeIndexSeekByRange
+include::../ql/query-plan/node-index-seek-by-range.asciidoc[]
+
+// NodeUniqueIndexSeekByRange
+include::../ql/query-plan/node-unique-index-seek-by-range.asciidoc[]
+
+// NodeIndexContainsScan
+include::../ql/query-plan/node-index-contains-scan.asciidoc[]
+
+// NodeIndexEndsWithScan
+include::../ql/query-plan/node-index-ends-with-scan.asciidoc[]
+
+// NodeIndexScan
+include::../ql/query-plan/node-index-scan.asciidoc[]
+
+
+// --- apply operators ---
+
+// Apply
 include::../ql/query-plan/apply.asciidoc[]
 
+// SemiApply
 include::../ql/query-plan/semi-apply.asciidoc[]
 
+// AntiSemiApply
 include::../ql/query-plan/anti-semi-apply.asciidoc[]
 
+// Anti
 include::../ql/query-plan/anti.asciidoc[]
 
+// LetSemiApply
 include::../ql/query-plan/let-semi-apply.asciidoc[]
 
+// LetAntiSemiApply
 include::../ql/query-plan/let-anti-semi-apply.asciidoc[]
 
+// SelectOrSemiApply
 include::../ql/query-plan/select-or-semi-apply.asciidoc[]
 
+// SelectOrAntiSemiApply
 include::../ql/query-plan/select-or-anti-semi-apply.asciidoc[]
 
+// LetSelectOrSemiApply
 include::../ql/query-plan/let-select-or-semi-apply.asciidoc[]
 
+// LetSelectOrAntiSemiApply
 include::../ql/query-plan/let-select-or-anti-semi-apply.asciidoc[]
 
-//include::../ql/query-plan/conditional-apply.asciidoc[]
-//Changed in 4.3 to merge
+// ConditionalApply - changed in 4.3 to Merge.
+// AntiConditionalApply - removed in 4.3 (by Merge).
+// Merge
 include::../ql/query-plan/merge.asciidoc[]
 
-//include::../ql/query-plan/anti-conditional-apply.asciidoc[]
-//Removed in 4.3 (by merge)
+// LockingMerge
+include::../ql/query-plan/locking-merge.asciidoc[]
 
+// RollUpApply
 include::../ql/query-plan/roll-up-apply.asciidoc[]
 
+// Argument
 include::../ql/query-plan/argument.asciidoc[]
 
+
+// --- expand operators ---
+
+// Expand(All)
 include::../ql/query-plan/expand-all.asciidoc[]
 
+// Expand(Into)
 include::../ql/query-plan/expand-into.asciidoc[]
 
+// OptionalExpand(All)
 include::../ql/query-plan/optional-expand-all.asciidoc[]
 
+// OptionalExpand(Into)
 include::../ql/query-plan/optional-expand-into.asciidoc[]
 
+// VarLengthExpand(All)
 include::../ql/query-plan/varlength-expand-all.asciidoc[]
 
+// VarLengthExpand(Into)
 include::../ql/query-plan/varlength-expand-into.asciidoc[]
 
+// VarLengthExpand(Pruning)
 include::../ql/query-plan/varlength-expand-pruning.asciidoc[]
 
+// AssertSameNode
 include::../ql/query-plan/assert-same-node.asciidoc[]
 
-//include::../ql/query-plan/drop-result.asciidoc[]
-//Removed in 4.3
+//DropResult - removed in 4.3
 
+// EmptyResult
 include::../ql/query-plan/empty-result.asciidoc[]
 
+// ProduceResults
 include::../ql/query-plan/produce-results.asciidoc[]
 
+// LoadCSV
 include::../ql/query-plan/load-csv.asciidoc[]
 
 
@@ -184,130 +177,184 @@ The query planner assigns these roles so that the smaller of the two inputs is t
 The build input is pulled in eagerly, and is used to build a probe table.
 Once this is complete, the probe table is checked for each row coming from the probe input side.
 
-
 In query plans, the build input is always the left operator, and the probe input the right operator.
 
 There are four hash join operators:
 
-* <<query-plan-node-hash-join, NodeHashJoin>>
-* <<query-plan-value-hash-join, ValueHashJoin>>
-* <<query-plan-node-left-right-outer-hash-join, NodeLeftOuterHashJoin>>
-* <<query-plan-node-left-right-outer-hash-join, NodeRightOuterHashJoin>>
+* <<query-plan-node-hash-join,NodeHashJoin>>
+* <<query-plan-value-hash-join,ValueHashJoin>>
+* <<query-plan-node-left-right-outer-hash-join,NodeLeftOuterHashJoin>>
+* <<query-plan-node-left-right-outer-hash-join,NodeRightOuterHashJoin>>
 
+// NodeHashJoin
 include::../ql/query-plan/node-hash-join.asciidoc[]
 
+// ValueHashJoin
 include::../ql/query-plan/value-hash-join.asciidoc[]
 
+// NodeLeftOuterHashJoin
+// NodeRightOuterHashJoin
 include::../ql/query-plan/node-left-right-outer-hash-join.asciidoc[]
 
+// TriadicSelection
 include::../ql/query-plan/triadic-selection.asciidoc[]
 
+// TriadicBuild
 include::../ql/query-plan/triadic-build.asciidoc[]
 
+// TriadicFilter
 include::../ql/query-plan/triadic-filter.asciidoc[]
 
+// CartesianProduct
 include::../ql/query-plan/cartesian-product.asciidoc[]
 
+// Foreach
 include::../ql/query-plan/foreach.asciidoc[]
 
+// Eager
 include::../ql/query-plan/eager.asciidoc[]
 
+// EagerAggregation
 include::../ql/query-plan/eager-aggregation.asciidoc[]
 
+// OrderedAggregation
 include::../ql/query-plan/ordered-aggregation.asciidoc[]
 
+// NodeCountFromCountStore
 include::../ql/query-plan/node-count-from-count-store.asciidoc[]
 
+// RelationshipCountFromCountStore
 include::../ql/query-plan/relationship-count-from-count-store.asciidoc[]
 
+// Distinct
 include::../ql/query-plan/distinct.asciidoc[]
 
+// OrderedDistinct
 include::../ql/query-plan/ordered-distinct.asciidoc[]
 
+// Filter
 include::../ql/query-plan/filter.asciidoc[]
 
+// Limit
 include::../ql/query-plan/limit.asciidoc[]
 
+// Skip
 include::../ql/query-plan/skip.asciidoc[]
 
+// Sort
 include::../ql/query-plan/sort.asciidoc[]
 
+// PartialSort
 include::../ql/query-plan/partial-sort.asciidoc[]
 
+// Top
 include::../ql/query-plan/top.asciidoc[]
 
+// PartialTop
 include::../ql/query-plan/partial-top.asciidoc[]
 
+// Union
 include::../ql/query-plan/union.asciidoc[]
 
+// Unwind
 include::../ql/query-plan/unwind.asciidoc[]
 
-//include::../ql/query-plan/lock-nodes.asciidoc[]
-//Changed in 4.3
+// LockNodes - changed in 4.3
+// ExhaustiveLimit
 include::../ql/query-plan/exhaustive-limit.asciidoc[]
 
+// Optional
 include::../ql/query-plan/optional.asciidoc[]
 
+// ProjectEndpoints
 include::../ql/query-plan/project-endpoints.asciidoc[]
 
+// Projection
 include::../ql/query-plan/projection.asciidoc[]
 
+// ShortestPath
 include::../ql/query-plan/shortest-path.asciidoc[]
 
+// EmptyRow
 include::../ql/query-plan/empty-row.asciidoc[]
 
+// ProcedureCall
 include::../ql/query-plan/procedure-call.asciidoc[]
 
+// CacheProperties
 include::../ql/query-plan/cache-properties.asciidoc[]
 
+// Create
 include::../ql/query-plan/create-nodes---relationships.asciidoc[]
 
+// Delete
 include::../ql/query-plan/delete.asciidoc[]
 
+// DetachDelete
 include::../ql/query-plan/detach-delete.asciidoc[]
 
-//include::../ql/query-plan/merge-create-node.asciidoc[]
-//Removed in 4.3
+// include::../ql/query-plan/merge-create-node.asciidoc[]
+// Removed in 4.3
 
-//include::../ql/query-plan/merge-create-relationship.asciidoc[]
-//Removed in 4.3
+// include::../ql/query-plan/merge-create-relationship.asciidoc[]
+// Removed in 4.3
 
+// SetLabels
 include::../ql/query-plan/set-labels.asciidoc[]
 
+// RemoveLabels
 include::../ql/query-plan/remove-labels.asciidoc[]
 
+// SetNodePropertiesFromMap
 include::../ql/query-plan/set-node-properties-from-map.asciidoc[]
 
+// SetRelationshipPropertiesFromMap
 include::../ql/query-plan/set-relationship-properties-from-map.asciidoc[]
 
+// SetProperty
 include::../ql/query-plan/set-property.asciidoc[]
 
+// CreateUniqueConstraint
 include::../ql/query-plan/create-unique-constraint.asciidoc[]
 
+// DoNothingIfExists(CONSTRAINT)
 include::../ql/query-plan/create-constraint-only-if-it-does-not-already-exist.asciidoc[]
 
+// CreateNodePropertyExistenceConstraint
 include::../ql/query-plan/create-node-property-existence-constraint.asciidoc[]
 
+// CreateNodeKeyConstraint
 include::../ql/query-plan/create-node-key-constraint.asciidoc[]
 
+// CreateRelationshipPropertyExistenceConstraint
 include::../ql/query-plan/create-relationship-property-existence-constraint.asciidoc[]
 
-include::../ql/query-plan/drop-constraint.asciidoc[]
+// DropConstraint
+include::../ql/query-plan/drop-constraint-by-name.asciidoc[]
 
+// ShowConstraints
 include::../ql/query-plan/listing-constraints.asciidoc[]
 
+// CreateIndex
 include::../ql/query-plan/create-index.asciidoc[]
 
+// DoNothingIfExists(INDEX)
 include::../ql/query-plan/create-index-only-if-it-does-not-already-exist.asciidoc[]
 
+// DropIndex
 include::../ql/query-plan/drop-index.asciidoc[]
 
+// ShowIndexes
 include::../ql/query-plan/listing-indexes.asciidoc[]
 
+// ShowFunctions
 include::../ql/query-plan/listing-functions.asciidoc[]
 
+// ShowProcedures
 include::../ql/query-plan/listing-procedures.asciidoc[]
 
+// ShowTransactions
 include::../ql/query-plan/listing-transactions.asciidoc[]
 
+// TerminateTransactions
 include::../ql/query-plan/terminating-transactions.asciidoc[]

--- a/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
@@ -63,6 +63,11 @@ Tests for the absence of a pattern predicate.
 |
 |
 
+| <<query-plan-asserting-multi-node-index-seek,AssertingMultiNodeIndexSeek>>
+| Used to ensure that no unique constraints are violated.
+|
+|
+|
 
 | <<query-plan-cache-properties,CacheProperties>>
 | Reads node or relationship properties and caches them.
@@ -127,6 +132,42 @@ Tests for the absence of a pattern predicate.
 | <<query-plan-directed-relationship-by-id-seek,DirectedRelationshipByIdSeek>>
 | Reads one or more relationships by id from the relationship store.
 | label:yes[]
+|
+|
+
+| <<query-plan-directed-relationship-index-contains-scan,DirectedRelationshipIndexContainsScan>>
+| Examines all values stored in an index, searching for entries containing a specific string; for example, in queries including `CONTAINS`.
+|
+|
+|
+
+| <<query-plan-directed-relationship-index-ends-with-scan,DirectedRelationshipIndexEndsWithScan>>
+| Examines all values stored in an index, searching for entries ending in a specific string; for example, in queries containing `ENDS WITH`.
+|
+|
+|
+
+| <<query-plan-directed-relationship-index-scan,DirectedRelationshipIndexScan>>
+| Examines all values stored in an index, returning all relationships and their start and end nodes with a particular relationship type and a specified property.
+|
+|
+|
+
+| <<query-plan-directed-relationship-index-seek,DirectedRelationshipIndexSeek>>
+| Finds relationships and their start and end nodes using an index seek.
+|
+|
+|
+
+| <<query-plan-directed-relationship-index-seek-by-range,DirectedRelationshipIndexSeekByRange>>
+| Finds relationships and their start and end nodes using an index seek where the value of the property matches a given prefix string.
+|
+|
+|
+
+| <<query-plan-directed-relationship-type-scan,DirectedRelationshipTypeScan>>
+| Fetches all relationships and their start and end nodes with a specific type from the relationship type index.
+|
 |
 |
 
@@ -259,6 +300,12 @@ Tests for the presence of a pattern predicate in queries containing multiple pat
 | <<query-plan-load-csv,LoadCSV>>
 | Loads data from a CSV source into the query.
 | label:yes[]
+|
+|
+
+| <<query-plan-locking-merge,LockingMerge>>
+| Similar to the `Merge` operator but will lock the start and end node when creating a relationship if necessary.
+|
 |
 |
 
@@ -565,6 +612,42 @@ Tests for the absence of a pattern predicate if an expression predicate evaluate
 | <<query-plan-undirected-relationship-by-id-seek,UndirectedRelationshipByIdSeek>>
 | Reads one or more relationships by ID from the relationship store.
 | label:yes[]
+|
+|
+
+| <<query-plan-undirected-relationship-index-contains-scan,UndirectedRelationshipIndexContainsScan>>
+| Examines all values stored in an index, searching for entries containing a specific string; for example, in queries including `CONTAINS`.
+|
+|
+|
+
+| <<query-plan-undirected-relationship-index-ends-with-scan,UndirectedRelationshipIndexEndsWithScan>>
+| Examines all values stored in an index, searching for entries ending in a specific string; for example, in queries containing `ENDS WITH`.
+|
+|
+|
+
+| <<query-plan-undirected-relationship-index-scan,UndirectedRelationshipIndexScan>>
+| Examines all values stored in an index, returning all relationships and their start and end nodes with a particular relationship type and a specified property.
+|
+|
+|
+
+| <<query-plan-undirected-relationship-index-seek,UndirectedRelationshipIndexSeek>>
+| Finds relationships and their start and end nodes using an index seek.
+|
+|
+|
+
+| <<query-plan-undirected-relationship-index-seek-by-range,UndirectedRelationshipIndexSeekByRange>>
+| Finds relationships and their start and end nodes using an index seek where the value of the property matches a given prefix string.
+|
+|
+|
+
+| <<query-plan-undirected-relationship-type-scan,UndirectedRelationshipTypeScan>>
+| Fetches all relationships and their start and end nodes with a specific type from the relationship type index.
+|
 |
 |
 

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
@@ -651,7 +651,7 @@ class QueryPlanTest extends DocumentingTestBase with SoftReset {
 
   @Test def undirectedRelationshipIndexSeek() {
     profileQuery(
-      title = "Relationship Index Seek",
+      title = "Undirected Relationship Index Seek",
       text =
         """The `UndirectedRelationshipIndexSeek` operator finds relationships and their start and end nodes using an index seek.
           |The relationship variable and the index used are shown in the arguments of the operator.""".stripMargin,


### PR DESCRIPTION
Added missing Cypher planner operators

AssertingMultiNodeIndexSeek
DirectedRelationshipIndexContainsScan
DirectedRelationshipIndexEndsWithScan
DirectedRelationshipIndexScan
DirectedRelationshipIndexSeek
DirectedRelationshipIndexSeekByRange
DirectedRelationshipTypeScan
LockingMerge
UndirectedRelationshipIndexContainsScan
UndirectedRelationshipIndexEndsWithScan
UndirectedRelationshipIndexScan
UndirectedRelationshipIndexSeek
UndirectedRelationshipIndexSeekByRange
UndirectedRelationshipTypeScan