### PR TITLE
Fixed a broken link

### DIFF
--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/IndexTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/IndexTest.scala
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit
 class IndexTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("A:Person KNOWS B:Person")
   val title = "INDEX"
-  override val linkId = "administration/indexes-for-search-performance"
+  override val linkId = "indexes-for-search-performance"
   private val nativeProvider = GenericNativeIndexProvider.DESCRIPTOR.name()
 
   //noinspection RedundantDefaultArgument


### PR DESCRIPTION
https://neo4j.com/docs/cypher-manual/4.3/administration/indexes-for-search-performance

Should be:

https://neo4j.com/docs/cypher-manual/4.3/indexes-for-search-performance