### PR TITLE
Upgrade docs build to Scala 2.13

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SpatialFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SpatialFunctionsTest.scala
@@ -20,12 +20,12 @@
 package org.neo4j.cypher.docgen
 
 import java.util
-
 import org.neo4j.cypher.docgen.tooling._
 import org.neo4j.graphdb.spatial
 import org.neo4j.graphdb.spatial.Coordinate
+import org.neo4j.graphdb.spatial.Point
 
-import collection.JavaConverters._
+import scala.jdk.CollectionConverters.SeqHasAsJava
 
 class SpatialFunctionsTest extends DocumentingTest {
 
@@ -48,6 +48,14 @@ class SpatialFunctionsTest extends DocumentingTest {
     override def getCRS: spatial.CRS = crs
 
     override def getCoordinates: util.List[Coordinate] = List(new Coordinate(x, y)).asJava
+
+    override def equals(obj: Any): Boolean = {
+      obj match {
+        case other: Point =>
+          (other.getCRS.getHref == this.getCRS.getHref) && other.getCoordinates == this.getCoordinates
+        case _ => false
+      }
+    }
   }
 
   class TestPoint3D(x: Double, y: Double, z: Double, crs: CRS) extends TestPoint2D(x, y, crs) {

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/QueryResultContentBuilder.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/QueryResultContentBuilder.scala
@@ -68,7 +68,7 @@ class LimitedQueryResultContentBuilder(maybeWantedColumns: Option[List[String]],
     val (oldResult, resultColumns) = super.getResultList(result)
     val wantedColumns = maybeWantedColumns.getOrElse(resultColumns.toList) // if no columns are given, use those from the result
     val limitedOnRows = oldResult.slice(0, numberOfRows)
-    val limitedOnColumns = limitedOnRows.map(m => m.filterKeys(k => wantedColumns.contains(k)))
+    val limitedOnColumns = limitedOnRows.map(m => m.view.filterKeys(k => wantedColumns.contains(k)).toMap)
     val columnsRemoved = limitedOnColumns.head.keySet.size < limitedOnRows.head.keySet.size // assumes we have at least one row
 
     // This will add a new (empty) column if any columns were removed.

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/QueryRunner.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/QueryRunner.scala
@@ -43,7 +43,7 @@ class QueryRunner(formatter: (GraphDatabaseQueryService, InternalTransaction) =>
   def runQueries(contentsWithInit: Seq[ContentWithInit], title: String): TestRunResult = {
 
     val groupedByInits: Map[RunnableInitialization, Seq[(DatabaseQuery, QueryResultPlaceHolder)]] =
-      contentsWithInit.groupBy(_.initKey).mapValues(_.map(cwi => cwi.queryToPresent -> cwi.queryResultPlaceHolder))
+      contentsWithInit.groupBy(_.initKey).view.mapValues(_.map(cwi => cwi.queryToPresent -> cwi.queryResultPlaceHolder)).toMap
     var graphVizCounter = 0
 
     val results: Iterable[RunResult] = groupedByInits.flatMap {

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/QueryStatisticsTestSupport.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/QueryStatisticsTestSupport.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.docgen.tooling
 
 import org.neo4j.cypher.internal.runtime.QueryStatistics
 import org.scalatest.Assertions
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
   * This class was forked form the Neo4j repo QueryStatisticsTestSupport, to remove the

--- a/cypher/pom.xml
+++ b/cypher/pom.xml
@@ -17,8 +17,8 @@
 
     <properties>
         <license-text.header>../build/GPL-3-header.txt</license-text.header>
-        <scala.version>2.12.10</scala.version>
-        <scala.binary.version>2.12</scala.binary.version>
+        <scala.version>2.13.8</scala.version>
+        <scala.binary.version>2.13</scala.binary.version>
         <hsqldb.version>2.3.2</hsqldb.version>
     </properties>
 
@@ -33,7 +33,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>4.2.0</version>
+                <version>4.4.0</version>
                 <executions>
                     <execution>
                         <id>scala-compile</id>
@@ -52,11 +52,6 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <args>
-                        <arg>-Xmax-classfile-name</arg>
-                        <arg>100</arg>
-                        <!--arg>-deprecation</arg-->
-                    </args>
                     <jvmArgs>
                         <jvmArg>-Xms64m</jvmArg>
                         <jvmArg>-Xmx1024m</jvmArg>
@@ -90,7 +85,7 @@
             <dependency>
                 <groupId>org.scalatest</groupId>
                 <artifactId>scalatest_${scala.binary.version}</artifactId>
-                <version>3.0.5</version>
+                <version>3.0.9</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>


### PR DESCRIPTION
These changes allow docs to be built against a Scala 2.13 build of Neo4j. 