### PR TITLE
removing references to deprecated killQuery and killQueries procedures

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -1599,7 +1599,7 @@ label:updated[]
 queryId
 ----
 a|
-The `queryId` procedure format has changed, and no longer includes the database name. For example, `mydb-query-123` is now `query-123`. This change affects built-in procedures `dbms.listQueries()`, `dbms.listActiveLocks(queryId)`, `dbms.killQueries(queryIds)` `and dbms.killQuery(queryId)`.
+The `queryId` procedure format has changed, and no longer includes the database name. For example, `mydb-query-123` is now `query-123`. This change affects the built-in procedure `dbms.listActiveLocks(queryId)`.
 
 a|
 label:functionality[]

--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -193,7 +193,74 @@ Replaced by:
 ON HOME GRAPH
 ----
 
+
+a|
+label:procedure[]
+label:removed[] +
+[source, cypher, role="noheader"]
+----
+dbms.listTransactions
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+SHOW TRANSACTION[S] [transaction-id[,...]]
+[YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
+[WHERE expression]
+[RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
+----
+
+
+a|
+label:procedure[]
+label:removed[] +
+[source, cypher, role="noheader"]
+----
+dbms.killTransaction[s]
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+TERMINATE TRANSACTION[S] transaction-id[,...]
+----
+
+
+a|
+label:procedure[]
+label:removed[] +
+[source, cypher, role="noheader"]
+----
+dbms.listQueries
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+SHOW TRANSACTION[S] [transaction-id[,...]]
+[YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
+[WHERE expression]
+[RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
+----
+
+
+a|
+label:procedure[]
+label:removed[] +
+[source, cypher, role="noheader"]
+----
+dbms.killQuer[y\|ies]
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+TERMINATE TRANSACTION[S] transaction-id[,...]
+----
+
 |===
+
 
 === Updated features
 

--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -1599,7 +1599,7 @@ label:updated[]
 queryId
 ----
 a|
-The `queryId` procedure format has changed, and no longer includes the database name. For example, `mydb-query-123` is now `query-123`. This change affects the built-in procedure `dbms.listActiveLocks(queryId)`.
+The `queryId` procedure format has changed, and no longer includes the database name. For example, `mydb-query-123` is now `query-123`. This change affects built-in procedures `dbms.listQueries()`, `dbms.listActiveLocks(queryId)`, `dbms.killQueries(queryIds)` `and dbms.killQuery(queryId)`.
 
 a|
 label:functionality[]


### PR DESCRIPTION
Removed references to

- dbms.killQuery(<query-id>)
- dbms.killQueries(<query-ids>)