### PR TITLE
Fix build error caused by Foldable usage

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SchemaIndexTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SchemaIndexTest.scala
@@ -1083,7 +1083,7 @@ class SchemaIndexTest extends DocumentingTestBase with QueryStatisticsTestSuppor
   private def checkPlanDescriptionArgument(result: DocsExecutionResult)(expected: String): Unit = {
     val planDescription = result.executionPlanDescription()
 
-    val res = planDescription.treeExists {
+    val res = planDescription.folder.treeExists {
       case str: String => str.contains(expected)
     }
 


### PR DESCRIPTION
Seems like the build is broken because of code changes in the neo4j repository. 