### PR TITLE
Minor updates to the transaction command section

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/TransactionsCommandTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/TransactionsCommandTest.scala
@@ -96,7 +96,7 @@ class TransactionsCommandTest extends DocumentingTest {
 |m|STRING
 
 |m|metaData
-|a|Any metadata associated with the transaction or an empty map if there is none.
+|a|Any metadata associated with the transaction, or an empty map if there is none.
 |m|MAP
 
 |m|parameters

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/TransactionsCommandTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/TransactionsCommandTest.scala
@@ -88,7 +88,7 @@ class TransactionsCommandTest extends DocumentingTest {
 |m|DURATION
 
 |m|allocatedBytes
-|a|The number of bytes allocated on the heap so far by the transaction or 0 if unavailable. label:default-output[]
+|a|The number of bytes allocated on the heap so far by the transaction, or `0` if unavailable. label:default-output[]
 |m|LONG
 
 |m|outerTransactionId

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/TransactionsCommandTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/TransactionsCommandTest.scala
@@ -247,7 +247,7 @@ All users may view all of their own currently executing transactions.
               ||===
               || +database+ | +transactionId+ | +currentQueryId+ | +connectionId+ | +clientAddress+ | +username+ | +currentQuery+ | +startTime+ | +status+ | +elapsedTime+ | +allocatedBytes+
               || +"neo4j"+ | +"neo4j-transaction-3"+ | +"query-1"+ | +""+ | +""+ | +""+ | +"MATCH (n) RETURN n"+ | +"2021-10-20T08:29:39.423Z"+ | +"Running"+ | +PT2.603S+ | +0+
-              |11+d|Rows: 2
+              |11+d|Rows: 1
               ||===
               |""")
       }
@@ -292,7 +292,7 @@ A user with the <<access-control-database-administration-transaction, `TERMINATE
 All users may terminate their own currently executing transactions.
 """.stripMargin('#'))
       }
-      section("Terminate Transactions") {
+      section("Terminate transactions") {
         p(
           """To end running transactions without waiting for them to complete on their own, use the `TERMINATE TRANSACTIONS` command.""")
         query("""TERMINATE TRANSACTIONS "neo4j-transaction-1","neo4j-transaction-2"""", ResultAssertions(p => {
@@ -305,7 +305,7 @@ All users may terminate their own currently executing transactions.
             || +transactionId+ | +username+ | +message+
             || +"neo4j-transaction-1"+ | +"neo4j"+ | +"Transaction terminated."+
             || +"neo4j-transaction-2"+ | +null+ | +"Transaction not found."+
-            |3+d|Rows: 1
+            |3+d|Rows: 2
             ||===""")
       }
     }

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/TransactionsCommandTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/TransactionsCommandTest.scala
@@ -165,7 +165,7 @@ class TransactionsCommandTest extends DocumentingTest {
 |m|LONG
 
 m|initializationStackTrace
-a|The initialization stacktrace for this transaction or an empty string if unavailable.
+a|The initialization stacktrace for this transaction, or an empty string if unavailable.
 m|STRING
 ||===""")
       section("Syntax") {

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/TransactionsCommandTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/TransactionsCommandTest.scala
@@ -153,7 +153,7 @@ class TransactionsCommandTest extends DocumentingTest {
 |m|LONG
 
 |m|estimatedUsedHeapMemory
-|a|The estimated amount of used heap memory allocated by the transaction in bytes or 0 if unavailable.
+|a|The estimated amount of used heap memory allocated by the transaction in bytes, or `0` if unavailable.
 |m|LONG
 
 |m|pageHits

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/TransactionsCommandTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/TransactionsCommandTest.scala
@@ -137,7 +137,7 @@ class TransactionsCommandTest extends DocumentingTest {
 |m|LONG
 
 |m|cpuTime
-|a|CPU time that has been actively spent executing the transaction or 0 if unavailable.
+|a|CPU time that has been actively spent executing the transaction, or `0` if unavailable.
 |m|DURATION
 
 |m|waitTime

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/TransactionsCommandTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/TransactionsCommandTest.scala
@@ -129,7 +129,7 @@ class TransactionsCommandTest extends DocumentingTest {
 |m|STRING
 
 |m|resourceInformation
-|a|Information about any blocked transactions or an empty map if there is none.
+|a|Information about any blocked transactions, or an empty map if there is none.
 |m|MAP
 
 |m|activeLockCount

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/TransactionsCommandTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/TransactionsCommandTest.scala
@@ -145,7 +145,7 @@ class TransactionsCommandTest extends DocumentingTest {
 |m|DURATION
 
 |m|idleTime
-|a|Idle time for this transaction or 0 if unavailable.
+|a|Idle time for this transaction, or `0` if unavailable.
 |m|DURATION
 
 |m|allocatedDirectBytes

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/TransactionsCommandTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/TransactionsCommandTest.scala
@@ -149,7 +149,7 @@ class TransactionsCommandTest extends DocumentingTest {
 |m|DURATION
 
 |m|allocatedDirectBytes
-|a|Amount of off-heap (native) memory allocated by the transaction in bytes or 0 if unavailable.
+|a|Amount of off-heap (native) memory allocated by the transaction in bytes, or `0` if unavailable.
 |m|LONG
 
 |m|estimatedUsedHeapMemory


### PR DESCRIPTION
- Rows count was off on the manual result
- Enabled tracking of cpu time for the time example
- Update SHOW TRANSACTIONS columns with default values
- add in a missed YIELD field

Found when making https://github.com/neo4j/neo4j-documentation/pull/1461, will be covered in 5.0 by that one (and https://github.com/neo4j/neo4j-documentation/pull/1463) so no cherry-picking needed.