### PR TITLE
removing 4.3 to avoid redundancy

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/AggregatingFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/AggregatingFunctionsTest.scala
@@ -162,19 +162,8 @@ class AggregatingFunctionsTest extends DocumentingTest {
           resultTable()
         }
       }
-      section("Using `count(expression)` to return the number of values") {
-        p("Instead of simply returning the number of rows with `count(*)`, it may be more useful to return the actual number of values returned by an expression.")
-        query("""MATCH (n {name: 'A'})-->(x)
-                #RETURN count(x)""".stripMargin('#'),
-        ResultAssertions((r) => {
-          r.toList should equal(List(Map("count(x)" -> 4L)))
-        })) {
-          p("The number of nodes that are connected directly (one relationship) to the node, with the name `'A'`, is returned.")
-          resultTable()
-        }
-      }
       section("Counting non-`null` values") {
-        p("The function `count(expression)` can be used to return the number of non-`null` values returned by the expression.")
+        p("Instead of simply returning the number of rows with `count(*)`, the function `count(expression)` can be used to return the number of non-`null` values returned by the expression.")
         query("""MATCH (n:Person)
                 #RETURN count(n.age)""".stripMargin('#'),
         ResultAssertions((r) => {


### PR DESCRIPTION
As per [this discussion](https://neo4j.slack.com/archives/C02JR6LSJ/p1654778959902629?thread_ts=1654776373.970399&cid=C02JR6LSJ).