### PR TITLE
Fix a broken deprecation label in the Query tuning section

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/query-tuning.asciidoc
@@ -48,7 +48,7 @@ To read more about the execution plan operators mentioned in this chapter, see <
 ** <<query-using-index-hint,Index hints>>
 ** <<query-using-scan-hint,Scan hints>>
 ** <<query-using-join-hint,Join hints>>
-** <<query-using-periodic-commit-hint,`PERIODIC COMMIT` query hint>>
+** [deprecated]#<<query-using-periodic-commit-hint,`PERIODIC COMMIT` query hint>>#
 
 
 [[cypher-query-options]]
@@ -85,10 +85,10 @@ Here we detail the available versions:
 
 | 4.3
 | This will force the query to use Neo4j Cypher 4.3.
-| 
+|
 
 | 4.4
-| This will force the query to use Neo4j Cypher 4.4. 
+| This will force the query to use Neo4j Cypher 4.4.
 As this is the default version, it is not necessary to use this option explicitly.
 | {check-mark}
 |===
@@ -203,7 +203,7 @@ This table describes the available query options for the connect-components plan
 ====
 Using this option can significantly _reduce_ the planning time of the query.
 ====
-| 
+|
 
 | connectComponentsPlanner=idp
 | Use the cost based IDP search algorithm when combining sub-plans.

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/UsingTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/UsingTest.scala
@@ -264,7 +264,7 @@ class UsingTest extends DocumentingTest {
         }
       }
     }
-    section("[deprecated]#`PERIODIC COMMIT` query hint"#, "query-using-periodic-commit-hint") {
+    section("[deprecated]#`PERIODIC COMMIT` query hint#", "query-using-periodic-commit-hint") {
       p("""The `PERIODIC COMMIT` query hint will be removed in the next major release. It is recommended to use <<subquery-call-in-transactions, `CALL { ... } IN TRANSACTIONS`>> instead.""")
       p("""Importing large amounts of data using <<query-load-csv, `LOAD CSV`>> with a single Cypher query may fail due to memory constraints.
           #This will manifest itself as an `OutOfMemoryError`.""".stripMargin('#'))

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/UsingTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/UsingTest.scala
@@ -264,7 +264,7 @@ class UsingTest extends DocumentingTest {
         }
       }
     }
-    section("[deprecated]#`PERIODIC COMMIT` query hint", "query-using-periodic-commit-hint") {
+    section("[deprecated]#`PERIODIC COMMIT` query hint"#, "query-using-periodic-commit-hint") {
       p("""The `PERIODIC COMMIT` query hint will be removed in the next major release. It is recommended to use <<subquery-call-in-transactions, `CALL { ... } IN TRANSACTIONS`>> instead.""")
       p("""Importing large amounts of data using <<query-load-csv, `LOAD CSV`>> with a single Cypher query may fail due to memory constraints.
           #This will manifest itself as an `OutOfMemoryError`.""".stripMargin('#'))

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/UsingTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/UsingTest.scala
@@ -54,7 +54,7 @@ class UsingTest extends DocumentingTest {
         |* <<query-using-index-hint,Index hints>>
         |* <<query-using-scan-hint,Scan hints>>
         |* <<query-using-join-hint,Join hints>>
-        |* <<query-using-periodic-commit-hint,`PERIODIC COMMIT` query hint>>""")
+        |* [deprecated]#<<query-using-periodic-commit-hint,`PERIODIC COMMIT` query hint>>#""")
     section("Introduction", "query-using-introduction") {
       p("""When executing a query, Neo4j needs to decide where in the query graph to start matching.
           |This is done by looking at the `MATCH` clause and the `WHERE` conditions and using that information to find useful indexes, or other starting points.""")


### PR DESCRIPTION
FYI @martin-neotech 

This section has been removed in the 5.0 documentation, so this PR does not require cherry picking.