### PR TITLE
Add missing operators

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/execution-plan-groups/operators.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/execution-plan-groups/operators.asciidoc
@@ -45,6 +45,9 @@ include::../ql/query-plan/directed-relationship-index-seek-by-range.asciidoc[]
 // UndirectedRelationshipIndexSeekByRange
 include::../ql/query-plan/undirected-relationship-index-seek-by-range.asciidoc[]
 
+// UnionNodeByLabelsScan
+include::../ql/query-plan/union-node-by-labels-scan.asciidoc[]
+
 // DirectedRelationshipTypeScan
 include::../ql/query-plan/directed-relationship-type-scan.asciidoc[]
 // UndirectedRelationshipTypeScan
@@ -158,6 +161,9 @@ include::../ql/query-plan/varlength-expand-into.asciidoc[]
 
 // VarLengthExpand(Pruning)
 include::../ql/query-plan/varlength-expand-pruning.asciidoc[]
+
+// VarLengthExpand(Pruning, BFS)
+include::../ql/query-plan/breadth-first-varlength-expand-pruning.asciidoc[]
 
 // AssertSameNode
 include::../ql/query-plan/assert-same-node.asciidoc[]

--- a/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/execution-plans-operator-summary.asciidoc
@@ -669,6 +669,12 @@ Tests for the absence of a pattern predicate if an expression predicate evaluate
 |
 |
 
+| <<query-plan-union-node-by-labels-scan,UnionNodeByLabelsScan>>
+| Fetches all nodes that have at least one of the provided labels from the node label index.
+|
+|
+|
+
 | <<query-plan-unwind,Unwind>>
 | Returns one row per item in a list.
 |
@@ -695,6 +701,13 @@ Tests for the absence of a pattern predicate if an expression predicate evaluate
 
 | <<query-plan-varlength-expand-pruning,VarLengthExpand(Pruning)>>
 | Traverses variable-length relationships from a given node and only returns unique end nodes.
+|
+|
+|
+
+| <<query-plan-varlength-expand-pruning,VarLengthExpand(Pruning, BFS)>>
+| Traverses variable-length relationships much like the <<query-plan-varlength-expand-all, `VarLengthExpand(All)`>> operator.
+However, as an optimization, it instead performs a breadth-first search (BFS) and while expanding, some paths are not explored if they are guaranteed to produce an end node that has already been found (by means of a previous path traversal).
 |
 |
 |


### PR DESCRIPTION
Following #1496 - tests for new operators were added, but there was some missing includes to the asciidoc pages, required for them to appear in the output. 

This PR adds `UnionNodeByLabelsScan` and `VarLengthExpand(Pruning, BFS)` to the Operator pages.

@pontusmelke please could you confirm that neither of these operators require labels for `leaf`, `updating`, or `eager` when they appear in the table on this page: https://neo4j.com/docs/cypher-manual/current/execution-plans/operator-summary/