### PR TITLE
Add `store` column to `SHOW DATABASES`

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -743,6 +743,7 @@ New columns have been added to the result:
 * `creationTime`
 * `lastStartTime`
 * `lastStopTime`
+* `store`
 
 These columns are only returned in the full result set (with `YIELD`) and not by default.
 |===

--- a/cypher/cypher-docs/src/docs/dev/ql/administration/show-databases-columns.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/administration/show-databases-columns.asciidoc
@@ -16,6 +16,7 @@
 |creationTime|The date and time at which the database was created.||{check-mark}|
 |lastStartTime|The date and time at which the database was last started.||{check-mark}|
 |lastStopTime|The date and time at which the database was last stopped.||{check-mark}|
+|store|Information about the storage engine and format in use by this database. The value is a string formatted as follows: `{storage engine}-{store format}-{major version}.{minor version}`.||{check-mark}|
 |lastCommittedTxn|The ID of the last transaction received.||{check-mark}|
 |replicationLag|Number of transactions the current database is behind compared to the database on the primary instance. The lag is expressed in negative integers. In standalone environments, the value is always 0.||{check-mark}|
 |===


### PR DESCRIPTION
Add a new column to `SHOW DATABASES` that gives information on the
storage engines and store format in use on the database.