### PR TITLE
Alternative relationship types syntax deprecated in 3.2

### DIFF
--- a/cypher/cypher-docs/src/docs/graphgists/intro/compose-statements.adoc
+++ b/cypher/cypher-docs/src/docs/graphgists/intro/compose-statements.adoc
@@ -22,7 +22,7 @@ Expressing references between nodes as visual patterns makes them easy to unders
 
 If you want to combine the results of two statements that have the same result structure, you can use `UNION [ALL]`.
 
-For instance if you want to list both actors and directors without using the alternative relationship-type syntax `()-[:ACTED_IN|:DIRECTED]->()` you can do this:
+For instance if you want to list both actors and directors without using the alternative relationship-type syntax `()-[:ACTED_IN|DIRECTED]->()` you can do this:
 
 [source, cypher]
 ----

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MatchTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MatchTest.scala
@@ -170,7 +170,7 @@ class MatchTest extends DocumentingTest {
       }
       section("Match on multiple relationship types", "match-on-multiple-rel-types") {
         p("To match on one of multiple types, you can specify this by chaining them together with the pipe symbol `|`.")
-        query("""MATCH (wallstreet {title: 'Wall Street'})<-[:ACTED_IN|:DIRECTED]-(person)
+        query("""MATCH (wallstreet {title: 'Wall Street'})<-[:ACTED_IN|DIRECTED]-(person)
                 #RETURN person.name""".stripMargin('#'),
         assertEveryoneConnectedToWallStreetIsFound) {
           p("Returns nodes with an `ACTED_IN` or `DIRECTED` relationship to *'Wall Street'*.")


### PR DESCRIPTION
`MATCH (n)-[:A|:B|:C {foo: 'bar'}]-() RETURN n` - deprecated in 3.2, removed in 5.0

Replaced by `MATCH (n)-[:A|B|C {foo: 'bar'}]-() RETURN n`

Note:

When using a variable for the relationship...

`MATCH (wallstreet {title: 'Wall Street'})<-[x:ACTED_IN|:DIRECTED]-(person) RETURN x, person.name`

throws an error in Neo4j 4.4.10

```
The semantics of using colon in the separation of alternative relationship types in conjunction with the use of variable binding, inlined property predicates, or variable length is no longer supported.
Please separate the relationships types using `:A|B|C` instead (line 1, column 42 (offset: 41))
"MATCH (wallstreet {title: 'Wall Street'})<-[x:ACTED_IN|:DIRECTED]-(person) RETURN x, person.name"
```