### PR TITLE
Users should not use predicates on varlength relationships

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/PatternTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/PatternTest.scala
@@ -231,11 +231,6 @@ class PatternTest extends DocumentingTest {
       p(
         "You can specify additional constraints by introducing a <<relationship-pattern-predicates,relationship pattern predicate>>:"
       )
-      p("""[source, cypher, role=noplay]
-          |----
-          |(a)-[r:KNOWS WHERE r.since < 2000]->(b)
-          |----
-          |""")
     }
 
     section("Variable-length pattern matching", "cypher-pattern-varlength") {


### PR DESCRIPTION
We have documented this in a central place. Therefore, we should make sure that they visit this place and not just look at the example given here.