### PR TITLE
Document EXISTS and COUNT subqueries

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/clause.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/clause.asciidoc
@@ -79,10 +79,6 @@ These comprise sub-clauses that must operate as part of reading clauses.
 m|<<query-where, WHERE>>
 |Adds constraints to the patterns in a `MATCH` or `OPTIONAL MATCH` clause or filters the results of a `WITH` clause.
 
-//WHERE EXISTS { ... }
-m|<<existential-subqueries, WHERE EXISTS +++{ ... }+++>>
-|An existential sub-query used to filter the results of a `MATCH`, `OPTIONAL MATCH` or `WITH` clause.
-
 //ORDER BY [ASC[ENDING] | DESC[ENDING]]
 m|<<query-order, ORDER BY &#91;ASC&#91;ENDING&#93; &#124; DESC&#91;ENDING&#93;&#93;>>
 |A sub-clause following `RETURN` or `WITH`, specifying that the output should be sorted in either ascending (the default) or descending order.

--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -877,6 +877,16 @@ Cypher now supports float literals for the values `Infinity` and `NaN`.
 `NaN` defines a quiet not-a-number value and does not throw any exceptions in arithmetic operations.
 Both values are implemented according to the Floating-Point Standard IEEE 754.
 
+a|
+label:functionality[]
+label:added[]
+[source, cypher, role="noheader"]
+----
+COUNT { (n) WHERE n.foo = "bar" }
+----
+a|
+New expression which returns the number of occurrences of a pattern.
+
 |===
 
 [[cypher-deprecations-additions-removals-4.4]]

--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -2855,7 +2855,7 @@ label:new[]
 WHERE EXISTS {...}
 ----
 a|
-Existential sub-queries are sub-clauses used to filter the results of a `MATCH`, `OPTIONAL MATCH`, or `WITH` clause.
+EXISTS sub-queries are sub-clauses used to filter the results of a `MATCH`, `OPTIONAL MATCH`, or `WITH` clause.
 
 a|
 label:clause[]

--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -885,7 +885,7 @@ label:added[]
 COUNT { (n) WHERE n.foo = "bar" }
 ----
 a|
-New expression which returns the number of occurrences of a pattern.
+New expression which returns the number of results of a subquery.
 
 |===
 

--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -2865,7 +2865,7 @@ label:new[]
 WHERE EXISTS {...}
 ----
 a|
-EXISTS sub-queries are sub-clauses used to filter the results of a `MATCH`, `OPTIONAL MATCH`, or `WITH` clause.
+`EXISTS` subqueries are subclauses used to filter the results of a `MATCH`, `OPTIONAL MATCH`, or `WITH` clause.
 
 a|
 label:clause[]

--- a/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
@@ -279,6 +279,7 @@ This section comprises a glossary of all the keywords -- grouped by category and
 |Name           | Description
 | <<query-syntax-case, CASE Expression>>   | A generic conditional expression, similar to if/else statements available in other languages.
 | <<existential-subqueries, EXISTS {...}>> | An EXISTS expression is used to evaluate the existence of a subquery.
+| <<count-subqueries, COUNT {...}>>  | An expression used to compute the number of results of a subquery.
 |===
 
 

--- a/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
@@ -72,7 +72,6 @@ This section comprises a glossary of all the keywords -- grouped by category and
 |<<query-using-scan-hint, USING SCAN variable:Label>>              | Hint | Scan hints are used to force the planner to do a label scan (followed by a filtering operation) instead of using an index.
 |<<query-with, WITH ... [AS]>>                        | Projecting   |  Allows query parts to be chained together, piping the results from one to be used as starting points or criteria in the next.
 |<<query-where, WHERE>>                          | Reading sub-clause | A sub-clause used to add constraints to the patterns in a `MATCH` or `OPTIONAL MATCH` clause, or to filter the results of a `WITH` clause.
-|<<existential-subqueries, WHERE EXISTS {...}>>  | Reading sub-clause | An existential sub-query used to filter the results of a `MATCH`, `OPTIONAL MATCH` or `WITH` clause.
 |===
 
 
@@ -278,7 +277,8 @@ This section comprises a glossary of all the keywords -- grouped by category and
 [options="header"]
 |===
 |Name           | Description
-| <<query-syntax-case, CASE Expression>>  | A generic conditional expression, similar to if/else statements available in other languages.
+| <<query-syntax-case, CASE Expression>>   | A generic conditional expression, similar to if/else statements available in other languages.
+| <<existential-subqueries, EXISTS {...}>> | An EXISTS expression is used to evaluate the existence of a subquery.
 |===
 
 

--- a/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
@@ -278,7 +278,7 @@ This section comprises a glossary of all the keywords -- grouped by category and
 |===
 |Name           | Description
 | <<query-syntax-case, CASE Expression>>   | A generic conditional expression, similar to if/else statements available in other languages.
-| <<existential-subqueries, EXISTS {...}>> | An EXISTS expression is used to evaluate the existence of a subquery.
+| <<existential-subqueries, EXISTS {...}>> | An `EXISTS` expression is used to evaluate the existence of a subquery.
 | <<count-subqueries, COUNT {...}>>  | An expression used to compute the number of results of a subquery.
 |===
 

--- a/cypher/cypher-docs/src/docs/dev/syntax/expressions.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/syntax/expressions.asciidoc
@@ -67,7 +67,7 @@ An expression in Cypher can be:
 * An operator application: `1 + 2`, `3 < 4`.
 * A predicate expression is an expression that returns true or false: `a.prop = 'Hello'`, `length(p) > 10`, `a.name IS NOT NULL`.
 * A special case of predicates are label and relationship type expressions: `(n:A|B)`, `()-[r:R1|R2]->()`.
-* An existential subquery is an expression that returns true or false:
+* A subquery expression, for example:
 `EXISTS {
   MATCH (n)-[r]->(p)
   WHERE p.name = 'Sven'

--- a/cypher/cypher-docs/src/docs/dev/syntax/expressions.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/syntax/expressions.asciidoc
@@ -16,8 +16,8 @@ This section contains an overview of expressions in Cypher with examples.
  ** <<syntax-use-case-result, Using the result of `CASE` in the succeeding clause or statement>>
  ** <<syntax-use-case-with-null, Using `CASE` with null values>>
 * <<cypher-subquery-expressions, Subquery expressions>>
- ** <<existential-subqueries, EXISTS subqueries>>
- ** <<count-subqueries, COUNT subqueries>>
+ ** <<existential-subqueries, `EXISTS` subqueries>>
+ ** <<count-subqueries, `COUNT` subqueries>>
 * <<query-syntax-label, Label expressions>>
  ** <<syntax-no-label, Match without label expression>>
  ** <<syntax-on-single-label, Match on single node label>>

--- a/cypher/cypher-docs/src/docs/dev/syntax/expressions.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/syntax/expressions.asciidoc
@@ -15,6 +15,8 @@ This section contains an overview of expressions in Cypher with examples.
  ** <<syntax-distinguish-case, Distinguishing between when to use the simple and generic `CASE` forms>>
  ** <<syntax-use-case-result, Using the result of `CASE` in the succeeding clause or statement>>
  ** <<syntax-use-case-with-null, Using `CASE` with null values>>
+* <<cypher-subquery-expressions, Subquery expressions>>
+ ** <<existential-subqueries, EXISTS subqueries>>
 * <<query-syntax-label, Label expressions>>
  ** <<syntax-no-label, Match without label expression>>
  ** <<syntax-on-single-label, Match on single node label>>

--- a/cypher/cypher-docs/src/docs/dev/syntax/expressions.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/syntax/expressions.asciidoc
@@ -17,6 +17,7 @@ This section contains an overview of expressions in Cypher with examples.
  ** <<syntax-use-case-with-null, Using `CASE` with null values>>
 * <<cypher-subquery-expressions, Subquery expressions>>
  ** <<existential-subqueries, EXISTS subqueries>>
+ ** <<count-subqueries, COUNT subqueries>>
 * <<query-syntax-label, Label expressions>>
  ** <<syntax-no-label, Match without label expression>>
  ** <<syntax-on-single-label, Match on single node label>>

--- a/cypher/cypher-docs/src/docs/dev/syntax/expressions.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/syntax/expressions.asciidoc
@@ -106,6 +106,7 @@ Any number literal may contain an underscore `_` between digits.
 There may be an underscore between the `0x` or `0o` and the digits for hexadecimal and octal literals.
 
 include::../ql/query-syntax-case.adoc[leveloffset=+1]
+include::../ql/cypher-subquery-expressions.adoc[leveloffset=+1]
 include::../ql/query-syntax-label.adoc[leveloffset=+1]
 
 

--- a/cypher/cypher-docs/src/docs/dev/syntax/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/syntax/index.asciidoc
@@ -11,6 +11,9 @@ This section describes the syntax of the Cypher query language.
 * <<cypher-expressions, Expressions>>
  ** <<cypher-expressions-general, Expressions in general>>
  ** <<cypher-expressions-string-literals, Note on string literals>>
+ ** <<cypher-subquery-expressions, Subquery expressions>>
+  *** <<existential-subqueries, `EXISTS` subqueries>>
+  *** <<count-subqueries, `COUNT` subqueries>>
  ** <<query-syntax-case, `CASE` Expressions>>
 * <<cypher-variables, Variables>>
 * <<cypher-reserved, Reserved keywords>>
@@ -45,9 +48,6 @@ This section describes the syntax of the Cypher query language.
  ** <<cypher-pattern-relationship, Patterns for relationships>>
  ** <<cypher-pattern-varlength, Variable-length pattern matching>>
  ** <<cypher-pattern-path-variables, Assigning to path variables>>
-* <<cypher-subquery-expressions, Subquery expressions>>
- ** <<existential-subqueries, `EXISTS` subqueries>>
- ** <<count-subqueries, `COUNT` subqueries>>
 * <<cypher-temporal, Temporal (Date/Time) values>>
  ** <<cypher-temporal-timezones, Time zones>>
  ** <<cypher-temporal-instants, Temporal instants>>
@@ -103,8 +103,6 @@ include::../ql/query-operators.adoc[leveloffset=+1]
 include::comments.asciidoc[leveloffset=+1]
 
 include::../ql/cypher-patterns.adoc[leveloffset=+1]
-
-include::../ql/cypher-subquery-expressions.adoc[leveloffset=+1]
 
 include::../ql/cypher-temporal.adoc[leveloffset=+1]
 

--- a/cypher/cypher-docs/src/docs/dev/syntax/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/syntax/index.asciidoc
@@ -47,6 +47,7 @@ This section describes the syntax of the Cypher query language.
  ** <<cypher-pattern-path-variables, Assigning to path variables>>
 * <<cypher-subquery-expressions, Subquery expressions>>
  ** <<existential-subqueries, EXISTS subqueries>>
+ ** <<count-subqueries, COUNT subqueries>>
 * <<cypher-temporal, Temporal (Date/Time) values>>
  ** <<cypher-temporal-timezones, Time zones>>
  ** <<cypher-temporal-instants, Temporal instants>>

--- a/cypher/cypher-docs/src/docs/dev/syntax/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/syntax/index.asciidoc
@@ -45,6 +45,8 @@ This section describes the syntax of the Cypher query language.
  ** <<cypher-pattern-relationship, Patterns for relationships>>
  ** <<cypher-pattern-varlength, Variable-length pattern matching>>
  ** <<cypher-pattern-path-variables, Assigning to path variables>>
+* <<cypher-subquery-expressions, Subquery expressions>>
+ ** <<existential-subqueries, EXISTS subqueries>>
 * <<cypher-temporal, Temporal (Date/Time) values>>
  ** <<cypher-temporal-timezones, Time zones>>
  ** <<cypher-temporal-instants, Temporal instants>>

--- a/cypher/cypher-docs/src/docs/dev/syntax/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/syntax/index.asciidoc
@@ -103,6 +103,8 @@ include::comments.asciidoc[leveloffset=+1]
 
 include::../ql/cypher-patterns.adoc[leveloffset=+1]
 
+include::../ql/cypher-subquery-expressions.adoc[leveloffset=+1]
+
 include::../ql/cypher-temporal.adoc[leveloffset=+1]
 
 include::../ql/cypher-spatial.adoc[leveloffset=+1]

--- a/cypher/cypher-docs/src/docs/dev/syntax/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/syntax/index.asciidoc
@@ -46,8 +46,8 @@ This section describes the syntax of the Cypher query language.
  ** <<cypher-pattern-varlength, Variable-length pattern matching>>
  ** <<cypher-pattern-path-variables, Assigning to path variables>>
 * <<cypher-subquery-expressions, Subquery expressions>>
- ** <<existential-subqueries, EXISTS subqueries>>
- ** <<count-subqueries, COUNT subqueries>>
+ ** <<existential-subqueries, `EXISTS` subqueries>>
+ ** <<count-subqueries, `COUNT` subqueries>>
 * <<cypher-temporal, Temporal (Date/Time) values>>
  ** <<cypher-temporal-timezones, Time zones>>
  ** <<cypher-temporal-instants, Temporal instants>>

--- a/cypher/cypher-docs/src/docs/dev/syntax/reserved.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/syntax/reserved.asciidoc
@@ -24,7 +24,6 @@ If any reserved keyword is escaped -- i.e. is encapsulated by backticks ```, suc
 * `CREATE`
 * `DELETE`
 * `DETACH`
-* `EXISTS`
 * `FOREACH`
 * `LOAD`
 * `MATCH`
@@ -61,8 +60,10 @@ If any reserved keyword is escaped -- i.e. is encapsulated by backticks ```, suc
 
 * `ALL`
 * `CASE`
+* `COUNT`
 * `ELSE`
 * `END`
+* `EXISTS`
 * `THEN`
 * `WHEN`
 

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/PredicateFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/PredicateFunctionsTest.scala
@@ -121,8 +121,8 @@ class PredicateFunctionsTest extends DocumentingTest {
       }
       note {
         p(
-          """Note that the **function** `exists()` looks very similar to the **clause** `EXISTS {...}`, but they are not the same and should not be confused.
-            #See <<existential-subqueries, Using existential subqueries in `WHERE`>> for more information.""".stripMargin('#'))
+          """Note that the **function** `exists()` looks very similar to the **expression** `EXISTS {...}`, but they are not the same and should not be confused.
+            #See <<existential-subqueries, Using EXISTS subqueries>> for more information.""".stripMargin('#'))
       }
     }
     section("isEmpty()", "functions-isempty") {

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ScalarFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ScalarFunctionsTest.scala
@@ -268,8 +268,8 @@ class ScalarFunctionsTest extends DocumentingTest {
     section("size() applied to pattern comprehension", "functions-size-of-pattern-comprehension") {
       p("""This is the same function `size()` as described above, but you pass in a pattern comprehension.
           #The function size will then calculate on a _list_ of paths.""".stripMargin('#'))
-      function("size(pattern expression)",
-        ("pattern expression", "A pattern expression that returns a list."))
+      function("size(pattern comprehension)",
+        ("pattern comprehension", "A pattern comprehension that returns a list."))
       query("""MATCH (a)
               #WHERE a.name = 'Alice'
               #RETURN size([p=(a)-->()-->() | p]) AS fof""".stripMargin('#'),

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
@@ -51,7 +51,7 @@ class SubqueryExpressionsTest extends DocumentingTest {
     section("EXISTS subqueries", "existential-subqueries") {
       p(
         """An EXISTS subquery can be used to find out if a specified pattern exists at least once in the data.
-          #It serves the same purpose as a path pattern but is more powerful because it allows you to use `MATCH` and `WHERE` clauses internally.
+          #It serves the same purpose as a <<filter-on-patterns, path pattern>> but is more powerful because it allows you to use `MATCH` and `WHERE` clauses internally.
           #Moreover, it can appear in any expression position, unlike path patterns.
           #A subquery has a scope, as indicated by the opening and closing braces, `{` and `}`.
           #Any variable that is defined in the outside scope can be referenced inside the subquery's own scope.

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
@@ -67,7 +67,7 @@ class SubqueryExpressionsTest extends DocumentingTest {
           #  MATCH [Pattern]
           #  WHERE [Expression]
           #}""".stripMargin('#'))
-      p("It is worth noting that the `MATCH` keyword can be omitted in subqueries and that the `WHERE` clause is optional.")
+      p("It is worth noting that the `MATCH` keyword can be omitted in such subqueries and that the `WHERE` clause is optional.")
 
       section("Simple EXISTS subquery", "existential-subquery-simple-case") {
         p(
@@ -145,14 +145,14 @@ class SubqueryExpressionsTest extends DocumentingTest {
       }
     }
 
-    section("COUNT subqueries", "count-subqueries") {
-      p("An count subquery can be used to find out how many times a specified pattern appears in the data.")
+    section("`COUNT` subqueries", "count-subqueries") {
+      p("A `COUNT` subquery expression can be used to to count the number of results of the subquery.")
       functionWithCypherStyleFormatting(
         """COUNT {
           #  [Pattern]
           #  WHERE [Expression]
           #}""".stripMargin('#'))
-      p("It is worth noting that the `MATCH` keyword can be omitted in subqueries and that the `WHERE` clause is optional.")
+      p("It is worth noting that the `MATCH` keyword can be omitted in such subqueries and that the `WHERE` clause is optional.")
 
       section("Simple count subquery", "count-subquery-simple-case") {
         p(
@@ -203,11 +203,11 @@ class SubqueryExpressionsTest extends DocumentingTest {
         section("Using count in SET", "count-subqueries-with-set") {
           query(
             """MATCH (person:Person) WHERE person.name ="Andy"
-              #SET person.howManyDogs = COUNT { (person)-[:HAS_DOG]->(:Dog) } + 1
+              #SET person.howManyDogs = COUNT { (person)-[:HAS_DOG]->(:Dog) }
               #RETURN person.howManyDogs as howManyDogs
       """.stripMargin('#'),
             ResultAssertions(r => {
-              r.toList should equal(List(Map("howManyDogs" -> 2)))
+              r.toList should equal(List(Map("howManyDogs" -> 1)))
             })) {
             resultTable()
           }

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
@@ -28,11 +28,9 @@ class SubqueryExpressionsTest extends DocumentingTest {
     doc("Subquery expressions", "cypher-subquery-expressions")
     initQueries(
       """CREATE
-        #(andy:Swedish:Person {name: 'Andy', age: 36, belt: 'white'}),
-        #(timothy:Person {name: 'Timothy', age: 25, address: 'Sweden/Malmo'}),
-        #(peter:Person {name: 'Peter', age: 35, email: 'peter_n@example.com'}),
-        #(andy)-[:KNOWS {since: 2012}]->(timothy),
-        #(andy)-[:KNOWS {since: 1999}]->(peter),
+        #(andy:Swedish:Person {name: 'Andy', age: 36}),
+        #(timothy:Person {name: 'Timothy', age: 25}),
+        #(peter:Person {name: 'Peter', age: 35}),
         #(andy)-[:HAS_DOG {since: 2016}]->(:Dog {name:'Andy'}),
         #(fido:Dog {name:'Fido'})<-[:HAS_DOG {since: 2010}]-(peter)-[:HAS_DOG {since: 2018}]->(:Dog {name:'Ozzy'}),
         #(fido)-[:HAS_TOY]->(:Toy{name:'Banana'})""".stripMargin('#'))
@@ -225,6 +223,23 @@ class SubqueryExpressionsTest extends DocumentingTest {
               """.stripMargin('#'),
             ResultAssertions(r => {
               r.toList should equal(List(Map("result" -> "Andy"), Map("result" -> "Timothy"), Map("result" -> "Doglover Peter")))
+            })) {
+            resultTable()
+          }
+        }
+        section("Using count as a grouping key", "count-subqueries-as-grouping-key") {
+          p(
+            """The following query groups all persons by how many dogs they own,
+              #and then calculates the average age for each group.
+              #""".stripMargin('#'))
+          query(
+            """MATCH (person:Person)
+              #RETURN COUNT { (person)-[:HAS_DOG]->(:Dog) } AS numDogs,
+              #       avg(person.age) AS averageAge
+              # ORDER BY numDogs
+              """.stripMargin('#'),
+            ResultAssertions(r => {
+              r.toList should equal(List(Map("numDogs" -> 0, "averageAge" -> 25), Map("numDogs" -> 1, "averageAge" -> 36), Map("numDogs" -> 2, "averageAge" -> 35)))
             })) {
             resultTable()
           }

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
@@ -41,7 +41,9 @@ class SubqueryExpressionsTest extends DocumentingTest {
       """* <<existential-subqueries,EXISTS subqueries>>
         # ** <<existential-subquery-simple-case, Simple EXISTS subquery>>
         # ** <<existential-subquery-with-where, EXISTS subquery with `WHERE` clause>>
-        # ** <<existential-subquery-nesting, Nesting EXISTS subqueries>>""".stripMargin('#'))
+        # ** <<existential-subquery-nesting, Nesting EXISTS subqueries>>
+        # ** <<existential-subquery-outside-where, EXISTS subquery outside of a WHERE cluase>>
+        # """.stripMargin('#'))
     p("""Subquery expressions can appear anywhere that an expression is valid.""".stripMargin('#'))
     p("The following graph is used for the examples below:")
     graphViz()

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
@@ -36,15 +36,15 @@ class SubqueryExpressionsTest extends DocumentingTest {
         #(fido)-[:HAS_TOY]->(:Toy{name:'Banana'})""".stripMargin('#'))
     synopsis("Cypher has expressions that evaluate a subquery and aggregate the result in different fashions.")
     p(
-      """* <<existential-subqueries,EXISTS subqueries>>
-        # ** <<existential-subquery-simple-case, Simple EXISTS subquery>>
-        # ** <<existential-subquery-with-where, EXISTS subquery with `WHERE` clause>>
-        # ** <<existential-subquery-nesting, Nesting EXISTS subqueries>>
-        # ** <<existential-subquery-outside-where, EXISTS subquery outside of a WHERE clause>>
-        #* <<count-subqueries, COUNT subqueries>>
-        # ** <<count-subquery-simple-case, Simple COUNT subquery>>
-        # ** <<count-subquery-with-where, COUNT subquery with `WHERE` clause>>
-        # ** <<count-subqueries-other-clauses, Using COUNT subqueries inside other clauses>>
+      """* <<existential-subqueries,`EXISTS` subqueries>>
+        # ** <<existential-subquery-simple-case, Simple `EXISTS` subquery>>
+        # ** <<existential-subquery-with-where, `EXISTS` subquery with `WHERE` clause>>
+        # ** <<existential-subquery-nesting, Nesting `EXISTS` subqueries>>
+        # ** <<existential-subquery-outside-where, `EXISTS` subquery outside of a WHERE clause>>
+        #* <<count-subqueries, `COUNT subqueries>>
+        # ** <<count-subquery-simple-case, Simple `COUNT` subquery>>
+        # ** <<count-subquery-with-where, `COUNT` subquery with `WHERE` clause>>
+        # ** <<count-subqueries-other-clauses, Using `COUNT` subqueries inside other clauses>>
         # """.stripMargin('#'))
     p(
       """Subquery expressions can appear anywhere that an expression is valid.
@@ -55,9 +55,9 @@ class SubqueryExpressionsTest extends DocumentingTest {
     p("The following graph is used for the examples below:")
     graphViz()
 
-    section("EXISTS subqueries", "existential-subqueries") {
+    section("`EXISTS` subqueries", "existential-subqueries") {
       p(
-        """An EXISTS subquery can be used to find out if a specified pattern exists at least once in the data.
+        """An `EXISTS` subquery can be used to find out if a specified pattern exists at least once in the data.
           #It serves the same purpose as a <<filter-on-patterns, path pattern>> but is more powerful because it allows you to use `MATCH` and `WHERE` clauses internally.
           #Moreover, it can appear in any expression position, unlike path patterns.
           #If the subquery evaluates to at least one row, the whole expression will become true.
@@ -69,7 +69,7 @@ class SubqueryExpressionsTest extends DocumentingTest {
           #}""".stripMargin('#'))
       p("It is worth noting that the `MATCH` keyword can be omitted in such subqueries and that the `WHERE` clause is optional.")
 
-      section("Simple EXISTS subquery", "existential-subquery-simple-case") {
+      section("Simple `EXISTS` subquery", "existential-subquery-simple-case") {
         p(
           """Variables introduced by the outside scope can be used in the `EXISTS` subquery without importing them
             #<<subquery-correlated-importing|as necessary with `CALL` subqueries>>.
@@ -86,7 +86,7 @@ class SubqueryExpressionsTest extends DocumentingTest {
           resultTable()
         }
       }
-      section("EXISTS subquery with `WHERE` clause", "existential-subquery-with-where") {
+      section("`EXISTS` subquery with `WHERE` clause", "existential-subquery-with-where") {
         p(
           """A `WHERE` clause can be used in conjunction to the `MATCH`.
             #Variables introduced by the `MATCH` clause and the outside scope can be used in this scope.""".stripMargin('#'))
@@ -103,9 +103,9 @@ class SubqueryExpressionsTest extends DocumentingTest {
           resultTable()
         }
       }
-      section("Nesting EXISTS subqueries", "existential-subquery-nesting") {
+      section("Nesting `EXISTS` subqueries", "existential-subquery-nesting") {
         p(
-          """EXISTS subqueries can be nested like the following example shows.
+          """`EXISTS` subqueries can be nested like the following example shows.
             #The nesting also affects the scopes.
             #That means that it is possible to access all variables from inside the subquery which are either from the outside scope or defined in the very same subquery.""".stripMargin('#'))
         query(
@@ -124,9 +124,9 @@ class SubqueryExpressionsTest extends DocumentingTest {
           resultTable()
         }
       }
-      section("EXISTS subquery outside of a WHERE clause", "existential-subquery-outside-where") {
+      section("`EXISTS` subquery outside of a WHERE clause", "existential-subquery-outside-where") {
         p(
-          """EXISTS subquery expressions can appear anywhere that an expression is valid.
+          """`EXISTS` subquery expressions can appear anywhere that an expression is valid.
             |Here the result if the subquery can find the given pattern is returned.""".stripMargin)
         query(
           """MATCH (person:Person)
@@ -154,7 +154,7 @@ class SubqueryExpressionsTest extends DocumentingTest {
           #}""".stripMargin('#'))
       p("It is worth noting that the `MATCH` keyword can be omitted in such subqueries and that the `WHERE` clause is optional.")
 
-      section("Simple count subquery", "count-subquery-simple-case") {
+      section("Simple `COUNT` subquery", "count-subquery-simple-case") {
         p(
           """Variables introduced by the outside scope can be used in the `COUNT` subquery without importing them
             #<<subquery-correlated-importing|as necessary with `CALL` subqueries>>.
@@ -170,7 +170,7 @@ class SubqueryExpressionsTest extends DocumentingTest {
           resultTable()
         }
       }
-      section("Count subquery with `WHERE` clause", "count-subquery-with-where") {
+      section("`COUNT` subquery with `WHERE` clause", "count-subquery-with-where") {
         p(
           """A `WHERE` clause can be used inside the `COUNT` pattern.
             #Variables introduced by the `MATCH` clause and the outside scope can be used in this scope.""".stripMargin('#'))
@@ -187,9 +187,9 @@ class SubqueryExpressionsTest extends DocumentingTest {
           resultTable()
         }
       }
-      section("Using count subqueries inside other clauses", "count-subqueries-other-clauses") {
-        p("COUNT can be used in any position in a query, with the exception of administration commands, where it is restricted. We provide a few examples below.")
-        section("Using count in RETURN", "count-subqueries-with-return") {
+      section("Using `COUNT` subqueries inside other clauses", "count-subqueries-other-clauses") {
+        p("`COUNT` can be used in any position in a query, with the exception of administration commands, where it is restricted. We provide a few examples below.")
+        section("Using `COUNT` in `RETURN`", "count-subqueries-with-return") {
           query(
             """MATCH (person:Person)
               #RETURN person.name, COUNT { (person)-[:HAS_DOG]->(:Dog) } as howManyDogs
@@ -200,7 +200,7 @@ class SubqueryExpressionsTest extends DocumentingTest {
             resultTable()
           }
         }
-        section("Using count in SET", "count-subqueries-with-set") {
+        section("Using `COUNT` in `SET`", "count-subqueries-with-set") {
           query(
             """MATCH (person:Person) WHERE person.name ="Andy"
               #SET person.howManyDogs = COUNT { (person)-[:HAS_DOG]->(:Dog) }
@@ -212,7 +212,7 @@ class SubqueryExpressionsTest extends DocumentingTest {
             resultTable()
           }
         }
-        section("Using count in CASE", "count-subqueries-with-case") {
+        section("Using `COUNT` in `CASE", "count-subqueries-with-case") {
           query(
             """MATCH (person:Person)
               #RETURN
@@ -227,7 +227,7 @@ class SubqueryExpressionsTest extends DocumentingTest {
             resultTable()
           }
         }
-        section("Using count as a grouping key", "count-subqueries-as-grouping-key") {
+        section("Using `COUNT` as a grouping key", "count-subqueries-as-grouping-key") {
           p(
             """The following query groups all persons by how many dogs they own,
               #and then calculates the average age for each group.

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.docgen
+
+import org.neo4j.cypher.docgen.tooling.{DocBuilder, DocumentingTest, ResultAssertions}
+
+class SubqueryExpressionsTest extends DocumentingTest {
+  override def outputPath = "target/docs/dev/ql/"
+
+  override def doc = new DocBuilder {
+    doc("Subquery expressions", "cypher-subquery-expressions")
+    initQueries(
+      """CREATE
+        #(andy:Swedish:Person {name: 'Andy', age: 36, belt: 'white'}),
+        #(timothy:Person {name: 'Timothy', age: 25, address: 'Sweden/Malmo'}),
+        #(peter:Person {name: 'Peter', age: 35, email: 'peter_n@example.com'}),
+        #(andy)-[:KNOWS {since: 2012}]->(timothy),
+        #(andy)-[:KNOWS {since: 1999}]->(peter),
+        #(andy)-[:HAS_DOG {since: 2016}]->(:Dog {name:'Andy'}),
+        #(fido:Dog {name:'Fido'})<-[:HAS_DOG {since: 2010}]-(peter)-[:HAS_DOG {since: 2018}]->(:Dog {name:'Ozzy'}),
+        #(fido)-[:HAS_TOY]->(:Toy{name:'Banana'})"""".stripMargin('#'))
+    synopsis("Cypher has expressions that evaluate a subquery and aggregate the result in different fashions.")
+    p(
+      """* <<existential-subqueries,EXISTS subqueries>>
+        # ** <<existential-subquery-simple-case, Simple EXISTS subquery>>
+        # ** <<existential-subquery-with-where, EXISTS subquery with `WHERE` clause>>
+        # ** <<existential-subquery-nesting, Nesting EXISTS subqueries>>""".stripMargin('#'))
+    p("""Subquery expressions can appear anywhere that an expression is valid.""".stripMargin('#'))
+    p("The following graph is used for the examples below:")
+    graphViz()
+
+    section("EXISTS subqueries", "existential-subqueries") {
+      p(
+        """An EXISTS subquery can be used to find out if a specified pattern exists at least once in the data.
+          #It can be used in the same way as a path pattern but it allows you to use `MATCH` and `WHERE` clauses internally.
+          #A subquery has a scope, as indicated by the opening and closing braces, `{` and `}`.
+          #Any variable that is defined in the outside scope can be referenced inside the subquery's own scope.
+          #Variables introduced inside the subquery are not part of the outside scope and therefore can't be accessed on the outside.
+          #If the subquery evaluates even once to anything that is not null, the whole expression will become true.
+          #This also means that the system only needs to calculate the first occurrence where the subquery evaluates to something that is not null and can skip the rest of the work.""".stripMargin('#'))
+      functionWithCypherStyleFormatting(
+        """EXISTS {
+          #  MATCH [Pattern]
+          #  WHERE [Expression]
+          #}""".stripMargin('#'))
+      p("It is worth noting that the `MATCH` keyword can be omitted in subqueries and that the `WHERE` clause is optional.")
+
+      section("Simple EXISTS subquery", "existential-subquery-simple-case") {
+        p("""Variables introduced by the outside scope can be used in the inner `MATCH` clause. The following example shows this:""")
+        query(
+          """MATCH (person:Person)
+            #WHERE EXISTS {
+            #  MATCH (person)-[:HAS_DOG]->(:Dog)
+            #}
+            #RETURN person.name AS name""".stripMargin('#'),
+          ResultAssertions(r => {
+            r.toList should equal(List(Map("name" -> "Andy"), Map("name" -> "Peter")))
+          })) {
+          resultTable()
+        }
+      }
+      section("Existential subquery with `WHERE` clause", "existential-subquery-with-where") {
+        p(
+          """A `WHERE` clause can be used in conjunction to the `MATCH`.
+            #Variables introduced by the `MATCH` clause and the outside scope can be used in this scope.""".stripMargin('#'))
+        query(
+          """MATCH (person:Person)
+            #WHERE EXISTS {
+            #  MATCH (person)-[:HAS_DOG]->(dog:Dog)
+            #  WHERE person.name = dog.name
+            #}
+            #RETURN person.name AS name""".stripMargin('#'),
+          ResultAssertions(r => {
+            r.toList should equal(List(Map("name" -> "Andy")))
+          })) {
+          resultTable()
+        }
+      }
+      section("Nesting EXISTS subqueries", "existential-subquery-nesting") {
+        p(
+          """Existential subqueries can be nested like the following example shows.
+            #The nesting also affects the scopes.
+            #That means that it is possible to access all variables from inside the subquery which are either on the outside scope or defined in the very same subquery.""".stripMargin('#'))
+        query(
+          """MATCH (person:Person)
+            #WHERE EXISTS {
+            #  MATCH (person)-[:HAS_DOG]->(dog:Dog)
+            #  WHERE EXISTS {
+            #    MATCH (dog)-[:HAS_TOY]->(toy:Toy)
+            #    WHERE toy.name = 'Banana'
+            #  }
+            #}
+            #RETURN person.name AS name""".stripMargin('#'),
+          ResultAssertions(r => {
+            r.toList should equal(List(Map("name" -> "Peter")))
+          })) {
+          resultTable()
+        }
+      }
+      section("EXISTS subquery outside of a WHERE cluase", "existential-subquery-outside-where") {
+        p("""EXISTS subquery expressions can appear anywhere that an expression is valid. Here the result if the subquery is returned""")
+        query(
+          """MATCH (person:Person)
+            #RETURN person.name AS name, EXISTS {
+            #  MATCH (person)-[:HAS_DOG]->(:Dog)
+            #} AS hasDog""".stripMargin('#'),
+          ResultAssertions(r => {
+            r.toList should equal(List(
+              Map("name" -> "Andy", "hasDog" -> true),
+              Map("name" -> "Timothy", "hasDog" -> false),
+              Map("name" -> "Peter", "hasDog" -> true)
+            ))
+          })) {
+          resultTable()
+        }
+      }
+    }
+  }.build()
+}

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
@@ -71,8 +71,8 @@ class SubqueryExpressionsTest extends DocumentingTest {
 
       section("Simple `EXISTS` subquery", "existential-subquery-simple-case") {
         p(
-          """Variables introduced by the outside scope can be used in the `EXISTS` subquery without importing them
-            #<<subquery-correlated-importing,as necessary with `CALL` subqueries>>.
+          """Variables introduced by the outside scope can be used in the `EXISTS` subquery without importing them,
+            #unlike the case for `CALL` subqueries, <<subquery-correlated-importing,as they require importing>>.
             #The following example shows this:""".stripMargin('#'))
         query(
           """MATCH (person:Person)
@@ -127,7 +127,7 @@ class SubqueryExpressionsTest extends DocumentingTest {
       section("`EXISTS` subquery outside of a `WHERE` clause", "existential-subquery-outside-where") {
         p(
           """`EXISTS` subquery expressions can appear anywhere that an expression is valid.
-            |Here the result if the subquery can find the given pattern is returned.""".stripMargin)
+            |Here the result is a boolean that shows whether the subquery can find the given pattern.""".stripMargin)
         query(
           """MATCH (person:Person)
             #RETURN person.name AS name, EXISTS {
@@ -146,7 +146,7 @@ class SubqueryExpressionsTest extends DocumentingTest {
     }
 
     section("`COUNT` subqueries", "count-subqueries") {
-      p("A `COUNT` subquery expression can be used to to count the number of results of the subquery.")
+      p("A `COUNT` subquery expression can be used to count the number of results of the subquery.")
       functionWithCypherStyleFormatting(
         """COUNT {
           #  MATCH [Pattern]
@@ -156,8 +156,8 @@ class SubqueryExpressionsTest extends DocumentingTest {
 
       section("Simple `COUNT` subquery", "count-subquery-simple-case") {
         p(
-          """Variables introduced by the outside scope can be used in the `COUNT` subquery without importing them
-            #<<subquery-correlated-importing,as necessary with `CALL` subqueries>>.
+          """Variables introduced by the outside scope can be used in the `COUNT` subquery without importing them,
+            #unlike the case for `CALL` subqueries, <<subquery-correlated-importing,as they require importing>>.
             #The following query exemplifies this and outputs the owners of more than one dog:
             #""".stripMargin('#'))
         query(
@@ -188,7 +188,9 @@ class SubqueryExpressionsTest extends DocumentingTest {
         }
       }
       section("Using `COUNT` subqueries inside other clauses", "count-subqueries-other-clauses") {
-        p("`COUNT` can be used in any position in a query, with the exception of administration commands, where it is restricted. We provide a few examples below.")
+        p(
+          """`COUNT` can be used in any position in a query, with the exception of administration commands, where it is restricted.
+            #See a few examples below:""".stripMargin('#'))
         section("Using `COUNT` in `RETURN`", "count-subqueries-with-return") {
           query(
             """MATCH (person:Person)

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
@@ -35,7 +35,7 @@ class SubqueryExpressionsTest extends DocumentingTest {
         #(andy)-[:KNOWS {since: 1999}]->(peter),
         #(andy)-[:HAS_DOG {since: 2016}]->(:Dog {name:'Andy'}),
         #(fido:Dog {name:'Fido'})<-[:HAS_DOG {since: 2010}]-(peter)-[:HAS_DOG {since: 2018}]->(:Dog {name:'Ozzy'}),
-        #(fido)-[:HAS_TOY]->(:Toy{name:'Banana'})"""".stripMargin('#'))
+        #(fido)-[:HAS_TOY]->(:Toy{name:'Banana'})""".stripMargin('#'))
     synopsis("Cypher has expressions that evaluate a subquery and aggregate the result in different fashions.")
     p(
       """* <<existential-subqueries,EXISTS subqueries>>
@@ -49,12 +49,13 @@ class SubqueryExpressionsTest extends DocumentingTest {
     section("EXISTS subqueries", "existential-subqueries") {
       p(
         """An EXISTS subquery can be used to find out if a specified pattern exists at least once in the data.
-          #It can be used in the same way as a path pattern but it allows you to use `MATCH` and `WHERE` clauses internally.
+          #It serves the same purpose as a path pattern but is more powerful because it allows you to use `MATCH` and `WHERE` clauses internally.
+          #Moreover, it can appear in any expression position, unlike path patterns.
           #A subquery has a scope, as indicated by the opening and closing braces, `{` and `}`.
           #Any variable that is defined in the outside scope can be referenced inside the subquery's own scope.
           #Variables introduced inside the subquery are not part of the outside scope and therefore can't be accessed on the outside.
-          #If the subquery evaluates even once to anything that is not null, the whole expression will become true.
-          #This also means that the system only needs to calculate the first occurrence where the subquery evaluates to something that is not null and can skip the rest of the work.""".stripMargin('#'))
+          #If the subquery evaluates to at least one row, the whole expression will become true.
+          #This also means that the system only needs to evaluate if there is at least one row and can skip the rest of the work.""".stripMargin('#'))
       functionWithCypherStyleFormatting(
         """EXISTS {
           #  MATCH [Pattern]
@@ -63,7 +64,10 @@ class SubqueryExpressionsTest extends DocumentingTest {
       p("It is worth noting that the `MATCH` keyword can be omitted in subqueries and that the `WHERE` clause is optional.")
 
       section("Simple EXISTS subquery", "existential-subquery-simple-case") {
-        p("""Variables introduced by the outside scope can be used in the inner `MATCH` clause. The following example shows this:""")
+        p(
+          """Variables introduced by the outside scope can be used in the `EXISTS` subquery without importing them
+            #<<subquery-correlated-importing|as necessary with `CALL` subqueries>>.
+            #The following example shows this:""".stripMargin('#'))
         query(
           """MATCH (person:Person)
             #WHERE EXISTS {
@@ -93,11 +97,11 @@ class SubqueryExpressionsTest extends DocumentingTest {
           resultTable()
         }
       }
-      section("Nesting EXISTS subqueries", "existential-subquery-nesting") {
+      section("Nesting Existential subqueries", "existential-subquery-nesting") {
         p(
           """Existential subqueries can be nested like the following example shows.
             #The nesting also affects the scopes.
-            #That means that it is possible to access all variables from inside the subquery which are either on the outside scope or defined in the very same subquery.""".stripMargin('#'))
+            #That means that it is possible to access all variables from inside the subquery which are either from the outside scope or defined in the very same subquery.""".stripMargin('#'))
         query(
           """MATCH (person:Person)
             #WHERE EXISTS {
@@ -115,7 +119,9 @@ class SubqueryExpressionsTest extends DocumentingTest {
         }
       }
       section("EXISTS subquery outside of a WHERE cluase", "existential-subquery-outside-where") {
-        p("""EXISTS subquery expressions can appear anywhere that an expression is valid. Here the result if the subquery is returned""")
+        p(
+          """EXISTS subquery expressions can appear anywhere that an expression is valid.
+            |Here the result if the subquery can find the given pattern is returned.""".stripMargin)
         query(
           """MATCH (person:Person)
             #RETURN person.name AS name, EXISTS {

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
@@ -149,7 +149,7 @@ class SubqueryExpressionsTest extends DocumentingTest {
       p("A `COUNT` subquery expression can be used to to count the number of results of the subquery.")
       functionWithCypherStyleFormatting(
         """COUNT {
-          #  [Pattern]
+          #  MATCH [Pattern]
           #  WHERE [Expression]
           #}""".stripMargin('#'))
       p("It is worth noting that the `MATCH` keyword can be omitted in such subqueries and that the `WHERE` clause is optional.")

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
@@ -82,7 +82,7 @@ class SubqueryExpressionsTest extends DocumentingTest {
           resultTable()
         }
       }
-      section("Existential subquery with `WHERE` clause", "existential-subquery-with-where") {
+      section("EXISTS subquery with `WHERE` clause", "existential-subquery-with-where") {
         p(
           """A `WHERE` clause can be used in conjunction to the `MATCH`.
             #Variables introduced by the `MATCH` clause and the outside scope can be used in this scope.""".stripMargin('#'))
@@ -99,9 +99,9 @@ class SubqueryExpressionsTest extends DocumentingTest {
           resultTable()
         }
       }
-      section("Nesting Existential subqueries", "existential-subquery-nesting") {
+      section("Nesting EXISTS subqueries", "existential-subquery-nesting") {
         p(
-          """Existential subqueries can be nested like the following example shows.
+          """EXISTS subqueries can be nested like the following example shows.
             #The nesting also affects the scopes.
             #That means that it is possible to access all variables from inside the subquery which are either from the outside scope or defined in the very same subquery.""".stripMargin('#'))
         query(

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
@@ -40,8 +40,8 @@ class SubqueryExpressionsTest extends DocumentingTest {
         # ** <<existential-subquery-simple-case, Simple `EXISTS` subquery>>
         # ** <<existential-subquery-with-where, `EXISTS` subquery with `WHERE` clause>>
         # ** <<existential-subquery-nesting, Nesting `EXISTS` subqueries>>
-        # ** <<existential-subquery-outside-where, `EXISTS` subquery outside of a WHERE clause>>
-        #* <<count-subqueries, `COUNT subqueries>>
+        # ** <<existential-subquery-outside-where, `EXISTS` subquery outside of a `WHERE` clause>>
+        #* <<count-subqueries, `COUNT` subqueries>>
         # ** <<count-subquery-simple-case, Simple `COUNT` subquery>>
         # ** <<count-subquery-with-where, `COUNT` subquery with `WHERE` clause>>
         # ** <<count-subqueries-other-clauses, Using `COUNT` subqueries inside other clauses>>
@@ -72,7 +72,7 @@ class SubqueryExpressionsTest extends DocumentingTest {
       section("Simple `EXISTS` subquery", "existential-subquery-simple-case") {
         p(
           """Variables introduced by the outside scope can be used in the `EXISTS` subquery without importing them
-            #<<subquery-correlated-importing|as necessary with `CALL` subqueries>>.
+            #<<subquery-correlated-importing,as necessary with `CALL` subqueries>>.
             #The following example shows this:""".stripMargin('#'))
         query(
           """MATCH (person:Person)
@@ -124,7 +124,7 @@ class SubqueryExpressionsTest extends DocumentingTest {
           resultTable()
         }
       }
-      section("`EXISTS` subquery outside of a WHERE clause", "existential-subquery-outside-where") {
+      section("`EXISTS` subquery outside of a `WHERE` clause", "existential-subquery-outside-where") {
         p(
           """`EXISTS` subquery expressions can appear anywhere that an expression is valid.
             |Here the result if the subquery can find the given pattern is returned.""".stripMargin)
@@ -157,7 +157,7 @@ class SubqueryExpressionsTest extends DocumentingTest {
       section("Simple `COUNT` subquery", "count-subquery-simple-case") {
         p(
           """Variables introduced by the outside scope can be used in the `COUNT` subquery without importing them
-            #<<subquery-correlated-importing|as necessary with `CALL` subqueries>>.
+            #<<subquery-correlated-importing,as necessary with `CALL` subqueries>>.
             #The following query exemplifies this and outputs the owners of more than one dog:
             #""".stripMargin('#'))
         query(
@@ -212,7 +212,7 @@ class SubqueryExpressionsTest extends DocumentingTest {
             resultTable()
           }
         }
-        section("Using `COUNT` in `CASE", "count-subqueries-with-case") {
+        section("Using `COUNT` in `CASE`", "count-subqueries-with-case") {
           query(
             """MATCH (person:Person)
               #RETURN

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SubqueryExpressionsTest.scala
@@ -42,7 +42,7 @@ class SubqueryExpressionsTest extends DocumentingTest {
         # ** <<existential-subquery-simple-case, Simple EXISTS subquery>>
         # ** <<existential-subquery-with-where, EXISTS subquery with `WHERE` clause>>
         # ** <<existential-subquery-nesting, Nesting EXISTS subqueries>>
-        # ** <<existential-subquery-outside-where, EXISTS subquery outside of a WHERE cluase>>
+        # ** <<existential-subquery-outside-where, EXISTS subquery outside of a WHERE clause>>
         # """.stripMargin('#'))
     p("""Subquery expressions can appear anywhere that an expression is valid.""".stripMargin('#'))
     p("The following graph is used for the examples below:")
@@ -120,7 +120,7 @@ class SubqueryExpressionsTest extends DocumentingTest {
           resultTable()
         }
       }
-      section("EXISTS subquery outside of a WHERE cluase", "existential-subquery-outside-where") {
+      section("EXISTS subquery outside of a WHERE clause", "existential-subquery-outside-where") {
         p(
           """EXISTS subquery expressions can appear anywhere that an expression is valid.
             |Here the result if the subquery can find the given pattern is returned.""".stripMargin)

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
@@ -61,10 +61,6 @@ class WhereTest extends DocumentingTest {
         | ** <<filter-on-patterns-using-not, Filter on patterns using `NOT`>>
         | ** <<filter-on-patterns-with-properties, Filter on patterns with properties>>
         | ** <<filter-on-relationship-type, Filter on relationship type>>
-        | * <<existential-subqueries, Using existential subqueries in `WHERE`>>
-        | ** <<existential-subquery-simple-case, Simple existential subquery>>
-        | ** <<existential-subquery-with-where, Existential subquery with `WHERE` clause>>
-        | ** <<existential-subquery-nesting, Nesting existential subqueries>>
         |* <<query-where-lists, Lists>>
         | ** <<where-in-operator, `IN` operator>>
         |* <<missing-properties-and-values, Missing properties and values>>
@@ -331,67 +327,6 @@ class WhereTest extends DocumentingTest {
           r.toSet should equal(Set(Map("type(r)" -> "KNOWS", "r.since" -> 1999), Map("type(r)" -> "KNOWS", "r.since" -> 2012)))
         })) {
           p("This returns all relationships having a type whose name starts with *'K'*.")
-          resultTable()
-        }
-      }
-    }
-    p("""An existential subquery can be used to find out if a specified pattern exists at least once in the data.
-        #It can be used in the same way as a path pattern but it allows you to use `MATCH` and `WHERE` clauses internally.
-        #A subquery has a scope, as indicated by the opening and closing braces, `{` and `}`.
-        #Any variable that is defined in the outside scope can be referenced inside the subquery's own scope.
-        #Variables introduced inside the subquery are not part of the outside scope and therefore can't be accessed on the outside.
-        #If the subquery evaluates even once to anything that is not null, the whole expression will become true.
-        #This also means that the system only needs to calculate the first occurrence where the subquery evaluates to something that is not null and can skip the rest of the work.""".stripMargin('#'))
-    functionWithCypherStyleFormatting("""EXISTS {
-                                        #  MATCH [Pattern]
-                                        #  WHERE [Expression]
-                                        #}""".stripMargin('#'))
-    p("It is worth noting that the `MATCH` keyword can be omitted in subqueries and that the `WHERE` clause is optional.")
-    section("Using existential subqueries in `WHERE`", "existential-subqueries") {
-      section("Simple existential subquery", "existential-subquery-simple-case") {
-        p("""Variables introduced by the outside scope can be used in the inner `MATCH` clause. The following example shows this:""")
-        query("""MATCH (person:Person)
-                            #WHERE EXISTS {
-                            #  MATCH (person)-[:HAS_DOG]->(:Dog)
-                            #}
-                            #RETURN person.name AS name""".stripMargin('#'),
-        ResultAssertions(r => {
-            r.toList should equal(List(Map("name" -> "Andy"), Map("name" -> "Peter")))
-          })) {
-          resultTable()
-        }
-      }
-      section("Existential subquery with `WHERE` clause", "existential-subquery-with-where") {
-        p("""A `WHERE` clause can be used in conjunction to the `MATCH`.
-            #Variables introduced by the `MATCH` clause and the outside scope can be used in this scope.""".stripMargin('#'))
-        query("""MATCH (person:Person)
-                            #WHERE EXISTS {
-                            #  MATCH (person)-[:HAS_DOG]->(dog:Dog)
-                            #  WHERE person.name = dog.name
-                            #}
-                            #RETURN person.name AS name""".stripMargin('#'),
-        ResultAssertions(r => {
-            r.toList should equal(List(Map("name" -> "Andy")))
-          })) {
-          resultTable()
-        }
-      }
-      section("Nesting existential subqueries", "existential-subquery-nesting") {
-        p("""Existential subqueries can be nested like the following example shows.
-            #The nesting also affects the scopes.
-            #That means that it is possible to access all variables from inside the subquery which are either on the outside scope or defined in the very same subquery.""".stripMargin('#'))
-        query("""MATCH (person:Person)
-                            #WHERE EXISTS {
-                            #  MATCH (person)-[:HAS_DOG]->(dog:Dog)
-                            #  WHERE EXISTS {
-                            #    MATCH (dog)-[:HAS_TOY]->(toy:Toy)
-                            #    WHERE toy.name = 'Banana'
-                            #  }
-                            #}
-                            #RETURN person.name AS name""".stripMargin('#'),
-        ResultAssertions(r => {
-            r.toList should equal(List(Map("name" -> "Peter")))
-          })) {
           resultTable()
         }
       }

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SubqueryExpressionsTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SubqueryExpressionsTest.scala
@@ -27,7 +27,7 @@ class SubqueryExpressionsTest extends RefcardTest with QueryStatisticsTestSuppor
   def graphDescription = List(
     "A KNOWS B")
   val title = "Subquery Expressions"
-  override val linkId = "syntax/Subquery expressions"
+  override val linkId = "syntax/expressions"
 
   override def assert(tx: Transaction, name: String, result: DocsExecutionResult): Unit = {
     name match {

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SubqueryExpressionsTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SubqueryExpressionsTest.scala
@@ -52,7 +52,7 @@ EXISTS {
 
 RETURN n###
 
-Use an `EXISTS` subquery to test for existence.
+Use an `EXISTS` subquery expression to test for the existence of a subquery.
 
 ###assertion=returns-one
 MATCH (n) WHERE

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SubqueryExpressionsTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SubqueryExpressionsTest.scala
@@ -53,5 +53,17 @@ EXISTS {
 RETURN n###
 
 Use an EXISTS subquery to test for existence.
+
+###assertion=returns-one
+MATCH (n) WHERE
+
+COUNT {
+  MATCH (n)-[:KNOWS]->(m) WHERE n.age = m.age
+}
+
+= 1
+RETURN n###
+
+Use a COUNT subquery to count the occurrences of the subquery.
 """
 }

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SubqueryExpressionsTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SubqueryExpressionsTest.scala
@@ -52,7 +52,7 @@ EXISTS {
 
 RETURN n###
 
-Use an EXISTS subquery to test for existence.
+Use an `EXISTS` subquery to test for existence.
 
 ###assertion=returns-one
 MATCH (n) WHERE

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SubqueryExpressionsTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SubqueryExpressionsTest.scala
@@ -64,6 +64,6 @@ COUNT {
 = 1
 RETURN n###
 
-Use a COUNT subquery to count the occurrences of the subquery.
+Use a `COUNT` subquery expression to count the number of results of a subquery.
 """
 }

--- a/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SubqueryExpressionsTest.scala
+++ b/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SubqueryExpressionsTest.scala
@@ -23,12 +23,13 @@ import org.neo4j.cypher.docgen.RefcardTest
 import org.neo4j.cypher.docgen.tooling.{DocsExecutionResult, QueryStatisticsTestSupport}
 import org.neo4j.graphdb.Transaction
 
-class WhereTest extends RefcardTest with QueryStatisticsTestSupport {
-  val graphDescription = List("ROOT FRIEND A", "A FRIEND B", "B FRIEND C", "C FRIEND ROOT")
-  val title = "WHERE"
-  override val linkId = "clauses/where"
+class SubqueryExpressionsTest extends RefcardTest with QueryStatisticsTestSupport {
+  def graphDescription = List(
+    "A KNOWS B")
+  val title = "Subquery Expressions"
+  override val linkId = "syntax/Subquery expressions"
 
-  override def assert(tx:Transaction, name: String, result: DocsExecutionResult): Unit = {
+  override def assert(tx: Transaction, name: String, result: DocsExecutionResult): Unit = {
     name match {
       case "returns-one" =>
         assertStats(result)
@@ -36,29 +37,21 @@ class WhereTest extends RefcardTest with QueryStatisticsTestSupport {
     }
   }
 
-  override def parameters(name: String): Map[String, Any] =
-    name match {
-      case "parameters=aname" =>
-        Map("value" -> "Bob")
-      case _ => Map.empty
-    }
-
   override val properties: Map[String, Map[String, Any]] = Map(
     "A" -> Map("property" -> "Andy", "age" -> 39),
-    "B" -> Map("property" -> "Timothy", "age" -> 39),
-    "C" -> Map("property" -> "Chris", "age" -> 22))
+    "B" -> Map("property" -> "Timothy", "age" -> 39)
+  )
 
   def text = """
-###assertion=returns-one parameters=aname
-MATCH (n)-->(m)
+###assertion=returns-one
+MATCH (n) WHERE
 
-WHERE n.property <> $value
+EXISTS {
+  MATCH (n)-->(m) WHERE n.age = m.age
+}
 
-AND id(n) = %A% AND id(m) = %B%
-RETURN n, m###
+RETURN n###
 
-Use a predicate to filter.
-Note that `WHERE` is always part of a  `MATCH`, `OPTIONAL MATCH` or `WITH` clause.
-Putting it after a different clause in a query will alter what it does.
+Use an EXISTS subquery to test for existence.
 """
 }


### PR DESCRIPTION
Replaces #1490

## TODO
~~- [ ] Differences between `COUNT` and `EXISTS`~~
~~- [ ] Optimizations made for `COUNT` internally?~~
- [x] `COUNT` as groupping key
- [x] Double check `size((a)-[r]->(b))` has completely been removed from the docs

The TODOs were copied from the previous PR.
* A am unsure if/how to document differences between `COUNT` and `EXISTS` - I guess that was when they supported different subqueries inside?
* For optimizations: 
  * We have no mention of `GetDegree` anywhere, so I am hesitant to document that optimization.
  * We could mention that `COUNT {} > 0` is handled as `EXISTS {}` internally. Should we?
