### PR TITLE
Alternative relationship types syntax deprecated in 3.2 (#1582)

### DIFF
--- a/cypher/cypher-docs/src/docs/graphgists/intro/compose-statements.adoc
+++ b/cypher/cypher-docs/src/docs/graphgists/intro/compose-statements.adoc
@@ -22,7 +22,7 @@ Expressing references between nodes as visual patterns makes them easy to unders
 
 If you want to combine the results of two statements that have the same result structure, you can use `UNION [ALL]`.
 
-For instance if you want to list both actors and directors without using the alternative relationship-type syntax `()-[:ACTED_IN|:DIRECTED]->()` you can do this:
+For instance if you want to list both actors and directors without using the alternative relationship-type syntax `()-[:ACTED_IN|DIRECTED]->()` you can do this:
 
 [source, cypher]
 ----

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MatchTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MatchTest.scala
@@ -170,7 +170,7 @@ class MatchTest extends DocumentingTest {
       }
       section("Match on multiple relationship types", "match-on-multiple-rel-types") {
         p("To match on one of multiple types, you can specify this by chaining them together with the pipe symbol `|`.")
-        query("""MATCH (wallstreet {title: 'Wall Street'})<-[:ACTED_IN|:DIRECTED]-(person)
+        query("""MATCH (wallstreet {title: 'Wall Street'})<-[:ACTED_IN|DIRECTED]-(person)
                 #RETURN person.name""".stripMargin('#'),
         assertEveryoneConnectedToWallStreetIsFound) {
           p("Returns nodes with an `ACTED_IN` or `DIRECTED` relationship to *'Wall Street'*.")


### PR DESCRIPTION
`MATCH (n)-[:A|:B|:C {foo: 'bar'}]-() RETURN n` - deprecated in 3.2, removed in 5.0

Replaced by `MATCH (n)-[:A|B|C {foo: 'bar'}]-() RETURN n`