### PR TITLE
TEXT index does not support range predicate

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/deprecations-additions-and-compatibility.asciidoc
@@ -754,7 +754,7 @@ label:updated[]
 [GRANT\|DENY] [IMMUTABLE] ...
 ----
 a|
-Privileges can be specified as `IMMUTABLE`, which means that they cannot be altered by users with Privilege Management. 
+Privileges can be specified as `IMMUTABLE`, which means that they cannot be altered by users with Privilege Management.
 They can only be administered with auth disabled.
 
 a|
@@ -855,6 +855,22 @@ returning an integer approximation for precision 0 and throwing an exception for
 
 !===
 To get an integer value use the `toInteger` function.
+
+a|
+label:functionality[]
+label:updated[]
+[source, cypher, role="noheader"]
+----
+CREATE TEXT INDEX ...
+----
+
+[source, cypher, role="noheader"]
+----
+MATCH ... WHERE n.prop < 42 ...
+----
+a|
+Text indexes no longer support finding entries using comparison operators like `<`, `+<=+`, `+>=+`, `>`.
+
 |===
 
 === New features

--- a/cypher/cypher-docs/src/docs/dev/query-tuning-indexes.adoc
+++ b/cypher/cypher-docs/src/docs/dev/query-tuning-indexes.adoc
@@ -90,7 +90,6 @@ However, other predicates are only used when it is known that the property is co
 
 * `n.prop = "string"`
 * `n.prop IN ["a", "b", "c"]`
-* `n.prop > "string"`
 
 This means that a `TEXT` index is not able to solve e.g. `a.prop = b.prop`.
 
@@ -101,7 +100,6 @@ In summary, `TEXT` indexes support the following predicates:
 |Predicate | Syntax
 |equality check| `n.prop = "string"`
 |list membership check | `n.prop IN ["a", "b", "c"]`
-|range search| `n.prop > "string"`
 |prefix search| `STARTS WITH`
 |suffix search| `ENDS WITH`
 |substring search| `CONTAINS`


### PR DESCRIPTION
Re-raising the changes on #1592, against the `5.0` branch.

cc @arnefischereit & @burqen 

Any impact on the Cypher Refcard can be ignored, as we do not intend on publishing the document beyond the 4.4 release. The Cypher Cheat Sheet will need to be manually updated to reflect these changes.