### PR TITLE
Replace space char when generating ID from name

### DIFF
--- a/config-docs/src/main/java/org/neo4j/doc/ConfigDocsGenerator.java
+++ b/config-docs/src/main/java/org/neo4j/doc/ConfigDocsGenerator.java
@@ -83,7 +83,7 @@ public class ConfigDocsGenerator
 
     private String idFromName( String idPrefix, String name )
     {
-        return idPrefix + name.replace( '<', '-' ).replace( '>', '-' );
+        return idPrefix + name.replace( '<', '-' ).replace( '>', '-' ).replace( ' ', '-' );
     }
 
     private Optional<String> description( SettingImpl<Object> setting )


### PR DESCRIPTION
Names don't usually contain spaces, but we have entries for eg `fabric.graph.<graph ID>.database` that end up in the Configuration Settings page, where the space character mangles the ID for the asciidoc section, which in turn messes up the anchors as well as the content output. 