### PR TITLE
Add link to composite databases introduction section

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DatabasesTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DatabasesTest.scala
@@ -159,9 +159,9 @@ class DatabasesTest extends DocumentingTest with QueryStatisticsTestSupport {
         }
       }
       section("Creating composite databases", "administration-databases-create-composite-database", "enterprise-edition") {
-        // TODO: add a link to the place explaining what composite databases are
         p(
-          """Composite databases do not contain data, but they reference to other databases that can be queried together through their constituent aliases.""".stripMargin)
+          """Composite databases do not contain data, but they reference to other databases that can be queried together through their constituent aliases.
+            |For more information about composite databases, see <<operations-manual#composite-databases-introduction, Composite database introduction>>.""".stripMargin)
         p("Composite databases can be created using `CREATE COMPOSITE DATABASE`.")
         query("CREATE COMPOSITE DATABASE inventory", ResultAssertions(r => {
           assertStats(r, systemUpdates = 1)

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DatabasesTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DatabasesTest.scala
@@ -161,7 +161,7 @@ class DatabasesTest extends DocumentingTest with QueryStatisticsTestSupport {
       section("Creating composite databases", "administration-databases-create-composite-database", "enterprise-edition") {
         p(
           """Composite databases do not contain data, but they reference to other databases that can be queried together through their constituent aliases.
-            |For more information about composite databases, see <<operations-manual#composite-databases-introduction, Composite database introduction>>.""".stripMargin)
+            |For more information about composite databases, see <<operations-manual#composite-databases-introduction, Operations Manual -> Composite database introduction>>.""".stripMargin)
         p("Composite databases can be created using `CREATE COMPOSITE DATABASE`.")
         query("CREATE COMPOSITE DATABASE inventory", ResultAssertions(r => {
           assertStats(r, systemUpdates = 1)


### PR DESCRIPTION
Fix leftover part of https://github.com/neo4j/neo4j-documentation/pull/1609#discussion_r977507795, adding link introduced in https://github.com/neo-technology/neo4j-manual-modeling/pull/3029