### PR TITLE
Remove exists() from predicate functions in v5

### DIFF
--- a/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/glossary.asciidoc
@@ -173,7 +173,6 @@ This section comprises a glossary of all the keywords -- grouped by category and
 | <<functions-duration-inseconds, duration.inSeconds()>> | Temporal | Returns a _Duration_ equal to the difference in seconds and fractions of seconds, or minutes or hours, between two given instants.
 |<<functions-e, e()>>                           | Logarithmic       | Returns the base of the natural logarithm, `e`.
 |<<functions-endnode, endNode()>>                | Scalar            | Returns the end node of a relationship.
-|<<functions-exists, exists()>>                  | Predicate         | Returns true if a match for the pattern exists in the graph.
 |<<functions-exp, exp()>>                       | Logarithmic       | Returns `e^n`, where `e` is the base of the natural logarithm, and `n` is the value of the argument expression.
 |<<functions-floor, floor()>>                   | Numeric           | Returns the largest floating point number that is less than or equal to a number and equal to a mathematical integer.
 |<<functions-haversin, haversin()>>             | Trigonometric     | Returns half the versine of a number.

--- a/cypher/cypher-docs/src/docs/dev/ql/functions/index.asciidoc
+++ b/cypher/cypher-docs/src/docs/dev/ql/functions/index.asciidoc
@@ -49,7 +49,6 @@ These functions return either true or false for the given arguments.
 | Function | Signature | Description
 1.1+| <<functions-all,`all()`>>  | `all(variable :: VARIABLE IN list :: LIST OF ANY? WHERE predicate :: ANY?) :: (BOOLEAN?)` | Returns true if the predicate holds for all elements in the given list.
 1.1+| <<functions-any,`any()`>>  | `any(variable :: VARIABLE IN list :: LIST OF ANY? WHERE predicate :: ANY?) :: (BOOLEAN?)` | Returns true if the predicate holds for at least one element in the given list.
-1.1+| <<functions-exists,`exists()`>>  | `exists(input :: ANY?) :: (BOOLEAN?)` | Returns true if a match for the pattern exists in the graph.
 1.3+| <<functions-isempty,`isEmpty()`>>  | `isEmpty(input :: LIST? OF ANY?) :: (BOOLEAN?)` | Checks whether a list is empty.
 | `isEmpty(input :: MAP?) :: (BOOLEAN?)` | Checks whether a map is empty.
 | `isEmpty(input :: STRING?) :: (BOOLEAN?)` | Checks whether a string is empty.

--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/PredicateFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/PredicateFunctionsTest.scala
@@ -46,7 +46,6 @@ class PredicateFunctionsTest extends DocumentingTest {
         #
         #* <<functions-all,all()>>
         #* <<functions-any,any()>>
-        #* <<functions-exists,exists()>>
         #* <<functions-isempty,isEmpty()>>
         #* <<functions-none,none()>>
         #* <<functions-single,single()>>""".stripMargin('#'))
@@ -97,34 +96,6 @@ class PredicateFunctionsTest extends DocumentingTest {
         resultTable()
       }
     }
-    section("exists()", "functions-exists") {
-      p("""The function `exists()` returns `true` if a match for the given pattern exists in the graph.
-          #`null` is returned if the input argument is `null`.""".stripMargin('#'))
-      function("exists(pattern)",
-        "A Boolean.",
-        ("pattern", "A pattern"))
-      query("""MATCH (n)
-              #WHERE n.name IS NOT NULL
-              #RETURN
-              #  n.name AS name,
-              #  exists((n)-[:MARRIED]->()) AS is_married""".stripMargin('#'),
-      ResultAssertions(r => {
-          r.toList should equal(List(
-            Map("name" -> "Alice", "is_married" -> false),
-            Map("name" -> "Bob", "is_married" -> true),
-            Map("name" -> "Charlie", "is_married" -> false),
-            Map("name" -> "Daniel", "is_married" -> false),
-            Map("name" -> "Eskil", "is_married" -> false)))
-        })) {
-        p("The names of all nodes with the `name` property are returned, along with a boolean (`true` or `false`) indicating if they are married.")
-        resultTable()
-      }
-      note {
-        p(
-          """Note that the **function** `exists()` looks very similar to the **expression** `EXISTS {...}`, but they are not the same and should not be confused.
-            #See <<existential-subqueries, Using EXISTS subqueries>> for more information.""".stripMargin('#'))
-      }
-    }
     section("isEmpty()", "functions-isempty") {
       p("The function `isEmpty()` returns `true` if the given list or map contains no elements or if the given string contains no characters.")
       function("isEmpty(list)",
@@ -136,7 +107,7 @@ class PredicateFunctionsTest extends DocumentingTest {
       /*Result:
       ({name: "Eskil", eyes: "blue", age: 41, liked_colors: ["pink", "yellow", "black"]})
       ({alias: "Frank", eyes: "", age: 61, liked_colors: ["blue", "green"]})
-      */ 
+      */
       ResultAssertions(r => {
           r.toList.length should equal(2)
         })) {


### PR DESCRIPTION
The `exists()` function appears to be removed in v5, but the Predicate functions page still has it listed.

@sherfert I've tagged you as a reviewer here, as you added the 'EXISTS' content for v5 - please delegate if this needs to be confirmed by someone else.