### PR TITLE
fixing deprecated label formatting

### DIFF
--- a/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ScalarFunctionsTest.scala
+++ b/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ScalarFunctionsTest.scala
@@ -150,7 +150,7 @@ class ScalarFunctionsTest extends DocumentingTest {
         resultTable()
       }
     }
-    section("[deprecated]#id()", "functions-id") {
+    section("id() label:deprecated[]", "functions-id") {
       p("""The `id()` function will be removed in the next major release. It is recommended to use <<functions-element-id, `elementId()`>> instead.""")
       p("""The function `id()` returns a node or a relationship identifier, unique by an object type and a database.
             #Therefore, it is perfectly allowable for `id()` to return the same value for both nodes and relationships in the same database.


### PR DESCRIPTION
Same change is also reflected in docs-cypher: https://github.com/neo4j/docs-cypher/pull/176